### PR TITLE
[Stride] Adds support for `ComputeColor` / `ComputeFloat4` + 'Color' attribute pins

### DIFF
--- a/VL.Stride.Runtime/src/Effects/ShaderFX/ComputeValue/ComputeFloat4.sdsl
+++ b/VL.Stride.Runtime/src/Effects/ShaderFX/ComputeValue/ComputeFloat4.sdsl
@@ -1,7 +1,3 @@
-﻿shader ComputeFloat4
+﻿shader ComputeFloat4 : ComputeColor
 {
-    float4 Compute()
-    {
-        return 0;
-    }
 };

--- a/VL.Stride.Runtime/src/Rendering/Effects/EffectPins.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/EffectPins.cs
@@ -37,7 +37,7 @@ namespace VL.Stride.Rendering
             }
         }
 
-        public abstract IVLPin CreatePin(GraphicsDevice graphicsDevice, ParameterCollection parameters);
+        public abstract IVLPin CreatePin(ShaderGeneratorContext context);
     }
 
     class PinDescription<T> : EffectPinDescription
@@ -53,7 +53,7 @@ namespace VL.Stride.Rendering
         public override object DefaultValueBoxed => DefaultValue;
         public T DefaultValue { get; }
 
-        public override IVLPin CreatePin(GraphicsDevice graphicsDevice, ParameterCollection parameters) => new Pin<T>(Name, DefaultValue);
+        public override IVLPin CreatePin(ShaderGeneratorContext context) => new Pin<T>(Name, DefaultValue);
     }
 
     /// <summary>
@@ -113,9 +113,9 @@ namespace VL.Stride.Rendering
 
         // The plain value read by the compiler, for example in case of IComputeValue<Vector4> this would be just the vector itself
         public override object DefaultValueBoxed { get; }
-        public override IVLPin CreatePin(GraphicsDevice graphicsDevice, ParameterCollection parameters)
+        public override IVLPin CreatePin(ShaderGeneratorContext context)
         {
-            return EffectPins.CreatePin(graphicsDevice, parameters, Key, Count, IsPermutationKey, RuntimeDefaultValue, Type);
+            return EffectPins.CreatePin(context, Key, Count, IsPermutationKey, RuntimeDefaultValue, Type);
         }
 
         public override string ToString()
@@ -126,17 +126,14 @@ namespace VL.Stride.Rendering
 
     static class EffectPins
     {
-        public static IVLPin CreatePin(GraphicsDevice graphicsDevice, ParameterCollection parameters, ParameterKey key, int count, bool isPermutationKey, object value, Type typeInPatch)
+        public static IVLPin CreatePin(ShaderGeneratorContext context, ParameterKey key, int count, bool isPermutationKey, object value, Type typeInPatch)
         {
-            if (key is ValueParameterKey<Color4> colorKey)
-                return new ColorParameterPin(parameters, colorKey, graphicsDevice.ColorSpace, (Color4)value);
-
             var argument = key.GetType().GetGenericArguments()[0];
 
             if (typeInPatch.IsEnum)
             {
                 var createPinMethod = typeof(EffectPins).GetMethod(nameof(CreateEnumPin), BindingFlags.Static | BindingFlags.Public);
-                return createPinMethod.MakeGenericMethod(argument, typeInPatch).Invoke(null, new object[] { parameters, key, value }) as IVLPin;
+                return createPinMethod.MakeGenericMethod(argument, typeInPatch).Invoke(null, new object[] { context, key, value }) as IVLPin;
             }
 
             if (argument == typeof(ShaderSource))
@@ -145,73 +142,73 @@ namespace VL.Stride.Rendering
                 {
                     var typeParam = typeInPatch.GetGenericArguments()[0];
                     var createPinMethod = typeof(EffectPins).GetMethod(nameof(CreateGPUValueSinkPin), BindingFlags.Static | BindingFlags.Public);
-                    return createPinMethod.MakeGenericMethod(typeParam).Invoke(null, new[] { parameters, key, value }) as IVLPin;
+                    return createPinMethod.MakeGenericMethod(typeParam).Invoke(null, new[] { context, key, value }) as IVLPin;
                 }
                 else
                 {
                     var createPinMethod = typeof(EffectPins).GetMethod(nameof(CreateShaderFXPin), BindingFlags.Static | BindingFlags.Public);
-                    return createPinMethod.MakeGenericMethod(typeof(IComputeNode)).Invoke(null, new object[] { parameters, key, value }) as IVLPin;
+                    return createPinMethod.MakeGenericMethod(typeof(IComputeNode)).Invoke(null, new object[] { context, key, value }) as IVLPin;
                 }
             }
 
             if (isPermutationKey)
             {
                 var createPinMethod = typeof(EffectPins).GetMethod(nameof(CreatePermutationPin), BindingFlags.Static | BindingFlags.Public);
-                return createPinMethod.MakeGenericMethod(argument).Invoke(null, new object[] { parameters, key, value }) as IVLPin;
+                return createPinMethod.MakeGenericMethod(argument).Invoke(null, new object[] { context, key, value }) as IVLPin;
             }
             else if (argument.IsValueType)
             {
                 if (count > 1)
                 {
                     var createPinMethod = typeof(EffectPins).GetMethod(nameof(CreateArrayPin), BindingFlags.Static | BindingFlags.Public);
-                    return createPinMethod.MakeGenericMethod(argument).Invoke(null, new object[] { parameters, key, value }) as IVLPin;
+                    return createPinMethod.MakeGenericMethod(argument).Invoke(null, new object[] { context, key, value }) as IVLPin;
                 }
                 else
                 {
                     var createPinMethod = typeof(EffectPins).GetMethod(nameof(CreateValuePin), BindingFlags.Static | BindingFlags.Public);
-                    return createPinMethod.MakeGenericMethod(argument).Invoke(null, new object[] { parameters, key, value }) as IVLPin;
+                    return createPinMethod.MakeGenericMethod(argument).Invoke(null, new object[] { context, key, value }) as IVLPin;
                 }
             }
             else
             {
                 var createPinMethod = typeof(EffectPins).GetMethod(nameof(CreateResourcePin), BindingFlags.Static | BindingFlags.Public);
-                return createPinMethod.MakeGenericMethod(argument).Invoke(null, new object[] { parameters, key }) as IVLPin;
+                return createPinMethod.MakeGenericMethod(argument).Invoke(null, new object[] { context, key }) as IVLPin;
             }
         }
 
-        public static IVLPin CreatePermutationPin<T>(ParameterCollection parameters, PermutationParameterKey<T> key, T value)
+        public static IVLPin CreatePermutationPin<T>(ShaderGeneratorContext context, PermutationParameterKey<T> key, T value)
         {
-            return new PermutationParameterPin<T>(parameters, key, value);
+            return new PermutationParameterPin<T>(context, key, value);
         }
 
-        public static IVLPin CreateEnumPin<T, TEnum>(ParameterCollection parameters, ValueParameterKey<T> key, TEnum value) where T : unmanaged where TEnum : unmanaged
+        public static IVLPin CreateEnumPin<T, TEnum>(ShaderGeneratorContext context, ValueParameterKey<T> key, TEnum value) where T : unmanaged where TEnum : unmanaged
         {
-            return new EnumParameterPin<T, TEnum>(parameters, key, value);
+            return new EnumParameterPin<T, TEnum>(context, key, value);
         }
 
-        public static IVLPin CreateShaderFXPin<T>(ParameterCollection parameters, PermutationParameterKey<ShaderSource> key, T value) where T : class, IComputeNode
+        public static IVLPin CreateShaderFXPin<T>(ShaderGeneratorContext context, PermutationParameterKey<ShaderSource> key, T value) where T : class, IComputeNode
         {
             return new ShaderFXPin<T>(key, value);
         }
 
-        public static IVLPin CreateGPUValueSinkPin<T>(ParameterCollection parameters, PermutationParameterKey<ShaderSource> key, SetVar<T> value)
+        public static IVLPin CreateGPUValueSinkPin<T>(ShaderGeneratorContext context, PermutationParameterKey<ShaderSource> key, SetVar<T> value)
         {
             return new GPUValueSinkPin<T>(key, value);
         }
 
-        public static IVLPin CreateValuePin<T>(ParameterCollection parameters, ValueParameterKey<T> key, T value) where T : struct
+        public static IVLPin CreateValuePin<T>(ShaderGeneratorContext context, ValueParameterKey<T> key, T value) where T : struct
         {
-            return new ValueParameterPin<T>(parameters, key, value);
+            return new ValueParameterPin<T>(context, key, value);
         }
 
-        public static IVLPin CreateArrayPin<T>(ParameterCollection parameters, ValueParameterKey<T> key, T[] value) where T : struct
+        public static IVLPin CreateArrayPin<T>(ShaderGeneratorContext context, ValueParameterKey<T> key, T[] value) where T : struct
         {
-            return new ArrayValueParameterPin<T>(parameters, key, value);
+            return new ArrayValueParameterPin<T>(context, key, value);
         }
 
-        public static IVLPin CreateResourcePin<T>(ParameterCollection parameters, ObjectParameterKey<T> key) where T : class
+        public static IVLPin CreateResourcePin<T>(ShaderGeneratorContext context, ObjectParameterKey<T> key) where T : class
         {
-            return new ResourceParameterPin<T>(parameters, key);
+            return new ResourceParameterPin<T>(context, key);
         }
     }
 
@@ -251,8 +248,8 @@ namespace VL.Stride.Rendering
 
     sealed class PermutationParameterPin<T> : ParameterPin<T, PermutationParameterKey<T>>
     {
-        public PermutationParameterPin(ParameterCollection parameters, PermutationParameterKey<T> key, T value)
-            : base(new PermutationParameterUpdater<T>(parameters, key), value)
+        public PermutationParameterPin(ShaderGeneratorContext context, PermutationParameterKey<T> key, T value)
+            : base(new PermutationParameterUpdater<T>(context, key), value)
         {
         }
     }
@@ -260,8 +257,8 @@ namespace VL.Stride.Rendering
     sealed class ValueParameterPin<T> : ParameterPin<T, ValueParameterKey<T>>
         where T : struct
     {
-        public ValueParameterPin(ParameterCollection parameters, ValueParameterKey<T> key, T value)
-            : base(new ValueParameterUpdater<T>(parameters, key), value)
+        public ValueParameterPin(ShaderGeneratorContext context, ValueParameterKey<T> key, T value)
+            : base(new ValueParameterUpdater<T>(context, key), value)
         {
         }
     }
@@ -272,9 +269,9 @@ namespace VL.Stride.Rendering
     {
         private readonly ValueParameterPin<T> pin;
 
-        public EnumParameterPin(ParameterCollection parameters, ValueParameterKey<T> key, TEnum value)
+        public EnumParameterPin(ShaderGeneratorContext context, ValueParameterKey<T> key, TEnum value)
         {
-            pin = new ValueParameterPin<T>(parameters, key, Unsafe.As<TEnum, T>(ref value));
+            pin = new ValueParameterPin<T>(context, key, Unsafe.As<TEnum, T>(ref value));
         }
 
         public TEnum Value
@@ -294,36 +291,11 @@ namespace VL.Stride.Rendering
         }
     }
 
-    sealed class ColorParameterPin : IVLPin<Color4>
-    {
-        private readonly ValueParameterPin<Color4> pin;
-
-        public readonly ColorSpace ColorSpace;
-
-        public ColorParameterPin(ParameterCollection parameters, ValueParameterKey<Color4> key, ColorSpace colorSpace, Color4 value)
-        {
-            pin = new ValueParameterPin<Color4>(parameters, key, value.ToColorSpace(colorSpace));
-            ColorSpace = colorSpace;
-        }
-
-        public Color4 Value
-        {
-            get => pin.Value;
-            set => pin.Value = value.ToColorSpace(ColorSpace);
-        }
-
-        object IVLPin.Value
-        {
-            get => Value;
-            set => Value = (Color4)value;
-        }
-    }
-
     sealed class ArrayValueParameterPin<T> : ParameterPin<T[], ValueParameterKey<T>>
         where T : struct
     {
-        public ArrayValueParameterPin(ParameterCollection parameters, ValueParameterKey<T> key, T[] value) 
-            : base(new ArrayParameterUpdater<T>(parameters, key), value)
+        public ArrayValueParameterPin(ShaderGeneratorContext context, ValueParameterKey<T> key, T[] value) 
+            : base(new ArrayParameterUpdater<T>(context, key), value)
         {
         }
     }
@@ -331,8 +303,8 @@ namespace VL.Stride.Rendering
     sealed class ResourceParameterPin<T> : ParameterPin<T, ObjectParameterKey<T>>
         where T : class
     {
-        public ResourceParameterPin(ParameterCollection parameters, ObjectParameterKey<T> key)
-            : base(new ObjectParameterUpdater<T>(parameters, key), default)
+        public ResourceParameterPin(ShaderGeneratorContext context, ObjectParameterKey<T> key)
+            : base(new ObjectParameterUpdater<T>(context, key), default)
         {
         }
     }

--- a/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.ComputeFX.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.ComputeFX.cs
@@ -67,8 +67,8 @@ namespace VL.Stride.Rendering
                         {
                             var gameHandle = AppHost.Current.Services.GetGameHandle();
                             var renderContext = RenderContext.GetShared(gameHandle.Resource.Services);
-                            var mixinParams = BuildBaseMixin(shaderName, shaderMetadata, graphicsDevice, out var shaderMixinSource);
-                            var effect = new VLComputeEffectShader(renderContext, shaderName, mixinParams);
+                            var context = BuildBaseMixin(shaderName, shaderMetadata, graphicsDevice, out var shaderMixinSource);
+                            var effect = new VLComputeEffectShader(renderContext, shaderName, context.Parameters);
                             var inputs = new List<IVLPin>();
                             var enabledInput = default(IVLPin);
                             foreach (var _input in _inputs)
@@ -81,7 +81,7 @@ namespace VL.Stride.Rendering
                                 else if (_input == _enabledInput)
                                     inputs.Add(enabledInput = nodeBuildContext.Input<bool>(v => effect.Enabled = v, effect.Enabled));
                                 else if (_input is ParameterPinDescription parameterPinDescription)
-                                    inputs.Add(parameterPinDescription.CreatePin(graphicsDevice, effect.Parameters));
+                                    inputs.Add(parameterPinDescription.CreatePin(context));
                             }
 
                             var compositionPins = inputs.OfType<ShaderFXPin>().ToList();

--- a/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.DrawFX.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.DrawFX.cs
@@ -2,6 +2,7 @@
 using Stride.Engine;
 using Stride.Graphics;
 using Stride.Rendering;
+using Stride.Rendering.Materials;
 using Stride.Shaders;
 using System;
 using System.Collections.Generic;
@@ -103,6 +104,7 @@ namespace VL.Stride.Rendering
                     (effectInstance, _, _) = 
                         CreateEffectInstance("DrawFXEffect", shaderName, shaderMetadata, serviceRegistry, graphicsDevice, effectBytecode: effectBytecode);
                     var effect = new CustomDrawEffect(effectInstance, graphicsDevice);
+                    var context = new ShaderGeneratorContext(graphicsDevice) { Parameters = effect.Parameters };
 
                     var inputs = new List<IVLPin>();
                     foreach (var _input in _inputs)
@@ -111,7 +113,7 @@ namespace VL.Stride.Rendering
                         if (_input == _parameterSetterInput)
                             inputs.Add(nodeBuildContext.Input<Action<ParameterCollection, RenderView, RenderDrawContext>>(v => effect.ParameterSetter = v));
                         else if (_input is ParameterPinDescription parameterPinDescription)
-                            inputs.Add(parameterPinDescription.CreatePin(game.GraphicsDevice, effect.Parameters));
+                            inputs.Add(parameterPinDescription.CreatePin(context));
                     }
 
                     var compositionPins = inputs.OfType<ShaderFXPin>().ToList();

--- a/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.ShaderFX.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.ShaderFX.cs
@@ -83,14 +83,14 @@ namespace VL.Stride.Rendering
                             var gameHandle = AppHost.Current.Services.GetGameHandle();
                             var game = gameHandle.Resource;
 
-                            var tempParameters = new ParameterCollection(); // only needed for pin construction - parameter updater will later take care of multiple sinks
+                            var context = new ShaderGeneratorContext(game.GraphicsDevice); // only needed for pin construction - parameter updater will later take care of multiple sinks
                             var nodeState = new ShaderFXNodeState(shaderName);
 
                             var inputs = new List<IVLPin>();
                             foreach (var _input in _inputs)
                             {
                                 if (_input is ParameterPinDescription parameterPinDescription)
-                                    inputs.Add(parameterPinDescription.CreatePin(game.GraphicsDevice, tempParameters));
+                                    inputs.Add(parameterPinDescription.CreatePin(context));
                             }
 
                             var outputMaker = typeof(EffectShaderNodes).GetMethod(nameof(BuildOutput), BindingFlags.Static | BindingFlags.NonPublic);

--- a/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.TextureFX.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.TextureFX.cs
@@ -138,7 +138,7 @@ namespace VL.Stride.Rendering
                             var gameHandle = AppHost.Current.Services.GetGameHandle();
                             var effect = new TextureFXEffect("TextureFXEffect") { Name = shaderName };
 
-                            BuildBaseMixin(shaderName, shaderMetadata, graphicsDevice, out var textureFXEffectMixin, effect.Parameters);
+                            var context = BuildBaseMixin(shaderName, shaderMetadata, graphicsDevice, out var textureFXEffectMixin, effect.Parameters);
 
                             //effect.Parameters.Set
                             var inputs = new List<IVLPin>();
@@ -158,7 +158,7 @@ namespace VL.Stride.Rendering
                                 else if (_input == _enabledInput)
                                     inputs.Add(enabledInput = nodeBuildContext.Input<bool>(v => effect.Enabled = v, effect.Enabled));
                                 else if (_input is ParameterPinDescription parameterPinDescription)
-                                    inputs.Add(parameterPinDescription.CreatePin(graphicsDevice, effect.Parameters));
+                                    inputs.Add(parameterPinDescription.CreatePin(context));
                                 else if (_input is ParameterKeyPinDescription<Texture> textureInput)
                                 {
                                     if (textureInput.Key.Name.StartsWith("Texturing.Texture"))

--- a/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.Utils.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.Utils.cs
@@ -62,8 +62,8 @@ namespace VL.Stride.Rendering
                     effect = new EffectInstance(new Effect(graphicsDevice, effectBytecode) { Name = effectName });
                 else
                 {
-                    var mixinParams = BuildBaseMixin(shaderName, shaderMetadata, graphicsDevice, out shaderMixinSource, parameterCollection);
-                    effect = new DynamicEffectInstance(effectName, mixinParams);
+                    var context = BuildBaseMixin(shaderName, shaderMetadata, graphicsDevice, out shaderMixinSource, parameterCollection);
+                    effect = new DynamicEffectInstance(effectName, context.Parameters);
                     (effect as DynamicEffectInstance).Initialize(serviceRegistry);
                 }
 
@@ -113,7 +113,7 @@ namespace VL.Stride.Rendering
             }
         }
 
-        private static ParameterCollection BuildBaseMixin(string shaderName, ShaderMetadata shaderMetadata, GraphicsDevice graphicsDevice, out ShaderMixinSource effectInstanceMixin, ParameterCollection parameters = null)
+        private static ShaderGeneratorContext BuildBaseMixin(string shaderName, ShaderMetadata shaderMetadata, GraphicsDevice graphicsDevice, out ShaderMixinSource effectInstanceMixin, ParameterCollection parameters = null)
         {
             effectInstanceMixin = new ShaderMixinSource();
             effectInstanceMixin.Mixins.Add(new ShaderClassSource(shaderName));
@@ -138,7 +138,7 @@ namespace VL.Stride.Rendering
                 } 
             }
 
-            return mixinParams;
+            return context;
         }
 
         //used for shader source generation

--- a/VL.Stride.Runtime/src/Rendering/Effects/ParsedShader.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/ParsedShader.cs
@@ -159,7 +159,7 @@ namespace VL.Stride.Rendering
         public readonly string TypeName;
         public readonly string Summary;
         public readonly string Remarks;
-        public bool IsOptional;
+        public readonly bool IsOptional;
         public readonly PermutationParameterKey<ShaderSource> Key;
 
         /// <summary>
@@ -174,6 +174,7 @@ namespace VL.Stride.Rendering
             Name = v.Name.Text;
 
             // parse attributes
+            var hasColorAttribute = false;
             foreach (var attr in v.Attributes.OfType<AttributeDeclaration>())
             {
                 switch (attr.Name)
@@ -187,12 +188,20 @@ namespace VL.Stride.Rendering
                     case ShaderMetadata.RemarksName:
                         Remarks = attr.ParseString();
                         break;
+                    case ShaderMetadata.ColorAttributeName:
+                        hasColorAttribute = true;
+                        break;
                     default:
                         break;
                 }
             }
 
             TypeName = v.Type.Name.Text;
+
+            // Treat ComputeFloat4 with Color attribute as ComputeColor
+            if (TypeName == "ComputeFloat4" && hasColorAttribute)
+                TypeName = "ComputeColor";
+
             Key = new PermutationParameterKey<ShaderSource>(Name);
             LocalIndex = localIndex;
             Variable = v;
@@ -271,6 +280,7 @@ namespace VL.Stride.Rendering
             { "ComputeFloat2", new CompDefaultValue<Vector2>() },
             { "ComputeFloat3", new CompDefaultValue<Vector3>() },
             { "ComputeFloat4", new CompDefaultValue<Vector4>() },
+            { "ComputeColor", new CompDefaultValue<Color4>() },
             { "ComputeMatrix", new CompDefaultValue<Matrix>() },
             { "ComputeBool", new CompDefaultValue<bool>() },
             { "ComputeInt", new CompDefaultValue<int>() },

--- a/VL.Stride.Runtime/src/Rendering/Effects/ParserExtensions.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/ParserExtensions.cs
@@ -122,6 +122,9 @@ namespace VL.Stride.Rendering
             if (type == typeof(Vector4))
                 return attr.ParseVector4();
 
+            if (type == typeof(Color4))
+                return new Color4(attr.ParseVector4());
+
             if (type == typeof(bool))
                 return attr.ParseBool();
 

--- a/VL.Stride.Runtime/src/Rendering/Effects/ShaderMetadata.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/ShaderMetadata.cs
@@ -291,6 +291,7 @@ namespace VL.Stride.Rendering
             { "ComputeFloat2", typeof(SetVar<Vector2>) },
             { "ComputeFloat3", typeof(SetVar<Vector3>) },
             { "ComputeFloat4", typeof(SetVar<Vector4>) },
+            { "ComputeColor", typeof(SetVar<Color4>) },
             { "ComputeMatrix", typeof(SetVar<Matrix>) },
             { "ComputeBool", typeof(SetVar<bool>) },
             { "ComputeInt", typeof(SetVar<int>) },
@@ -320,6 +321,7 @@ namespace VL.Stride.Rendering
         public const string WantsMipsName = "WantsMips";
         public const string DontConvertToLinearOnReadName = "DontConvertToLinearOnRead";
         public const string DontConvertToSRgbOnName = "DontConvertToSRgbOnWrite";
+        public const string ColorAttributeName = "Color";
 
         //pin
         public const string EnumTypeName = "EnumType";

--- a/VL.Stride.Runtime/src/Shaders/ShaderFX/DeclResource.cs
+++ b/VL.Stride.Runtime/src/Shaders/ShaderFX/DeclResource.cs
@@ -8,7 +8,7 @@ namespace VL.Stride.Shaders.ShaderFX
     public class DeclResource<T> : ComputeNode<T>, IComputeVoid
         where T : class
     {
-        readonly ObjectParameterUpdater<T> updater = new ObjectParameterUpdater<T>();
+        readonly ObjectParameterUpdater<T> updater = new ObjectParameterUpdater<T>(default(ShaderGeneratorContext));
         readonly string resourceGroupName;
 
         public DeclResource(string resourceGroupName = null)

--- a/VL.Stride.Runtime/src/Shaders/ShaderFX/GenericValueKeys.cs
+++ b/VL.Stride.Runtime/src/Shaders/ShaderFX/GenericValueKeys.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Stride.Core;
+using Stride.Core.Mathematics;
 using Stride.Rendering;
 using Stride.Rendering.Materials;
 using static VL.Stride.Shaders.ShaderFX.ShaderFXUtils;
@@ -11,7 +12,11 @@ namespace VL.Stride.Shaders.ShaderFX
     {
         static GenericValueKeys()
         {
-            GenericValueParameter = ParameterKeys.NewValue<T>(default, "ShaderFX.InputValue" + GetNameForType<T>());
+            var name = "ShaderFX.InputValue" + GetNameForType<T>();
+            if (typeof(T) == typeof(Color4))
+                name += "_Color";
+
+            GenericValueParameter = ParameterKeys.NewValue<T>(default, name);
             ParameterKeys.Merge(GenericValueParameter, typeof(GenericValueKeys<T>), GenericValueParameter.Name);
         }
 

--- a/VL.Stride.Runtime/src/Shaders/ShaderFX/Input/InputValue.cs
+++ b/VL.Stride.Runtime/src/Shaders/ShaderFX/Input/InputValue.cs
@@ -8,7 +8,7 @@ namespace VL.Stride.Shaders.ShaderFX
     public class InputValue<T> : ComputeValue<T>
         where T : struct
     {
-        private readonly ValueParameterUpdater<T> updater = new ValueParameterUpdater<T>();
+        private readonly ValueParameterUpdater<T> updater = new ValueParameterUpdater<T>(default(ShaderGeneratorContext));
 
         public InputValue(ValueParameterKey<T> key = null, string constantBufferName = null)
         {

--- a/VL.Stride.Runtime/src/Shaders/ShaderFX/RaymarcherMatcap1.cs
+++ b/VL.Stride.Runtime/src/Shaders/ShaderFX/RaymarcherMatcap1.cs
@@ -14,7 +14,7 @@ namespace VL.Stride.Shaders.ShaderFX
 {
     public class RaymarcherMatcap : Funk1In1Out<Vector2, Vector4>
     {
-        readonly ObjectParameterUpdater<Texture> updater = new ObjectParameterUpdater<Texture>();
+        readonly ObjectParameterUpdater<Texture> updater = new ObjectParameterUpdater<Texture>(default(ShaderGeneratorContext));
 
         public RaymarcherMatcap(string functionName, IEnumerable<KeyValuePair<string, IComputeNode>> inputs)
             : base(functionName, inputs)

--- a/VL.Stride.Runtime/src/Shaders/ShaderFX/ShaderFXUtils.cs
+++ b/VL.Stride.Runtime/src/Shaders/ShaderFX/ShaderFXUtils.cs
@@ -127,6 +127,7 @@ namespace VL.Stride.Shaders.ShaderFX
             KnownTypes.Add(typeof(Vector2), "Float2");
             KnownTypes.Add(typeof(Vector3), "Float3");
             KnownTypes.Add(typeof(Vector4), "Float4");
+            KnownTypes.Add(typeof(Color4), "Float4");
             KnownTypes.Add(typeof(Matrix), "Matrix");
             KnownTypes.Add(typeof(int), "Int");
             KnownTypes.Add(typeof(Int2), "Int2");


### PR DESCRIPTION
# PR Details

<!--- A general summary of your changes -->

## Description

One can now either add the `[Color]` attribute to an existing `ComputeFloat4` pin, or use Stride's original `ComputeColor` type. Both ways lead to the same result, the pin on vvvv side is of type `GPU<RGBA>`.

The `[Default]` attribute is also supported. For example to set red as the default color, one would write `[Default(1, 0, 0, 1)]`.

## Related Issue

https://discourse.vvvv.org/t/add-feature-to-annotate-computefloat4-as-color/21591/4

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation
