### PR TITLE
adds VL.Core.Commands.csproj to VL.StandardLibs.sln

### DIFF
--- a/VL.StandardLibs.sln
+++ b/VL.StandardLibs.sln
@@ -93,6 +93,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "VL.Serialization.FSPickler.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VL.TPL.Dataflow", "VL.TPL.Dataflow\src\VL.TPL.Dataflow.csproj", "{54E94A1E-2AB5-4AC2-A96D-E919E330E96F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VL.Core.Commands", "VL.Core.Commands\src\VL.Core.Commands.csproj", "{DEEA2582-1136-4A67-8949-B8443DF558FE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -211,6 +213,10 @@ Global
 		{54E94A1E-2AB5-4AC2-A96D-E919E330E96F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54E94A1E-2AB5-4AC2-A96D-E919E330E96F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54E94A1E-2AB5-4AC2-A96D-E919E330E96F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEEA2582-1136-4A67-8949-B8443DF558FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEEA2582-1136-4A67-8949-B8443DF558FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEEA2582-1136-4A67-8949-B8443DF558FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEEA2582-1136-4A67-8949-B8443DF558FE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -243,6 +249,7 @@ Global
 		{797E2432-C36D-497E-A44C-A328200D32A3} = {631EEE8D-C0CB-437C-B7F1-F97C9BC28BCF}
 		{2C5B9824-1606-4C3D-A315-CA1FF4274B73} = {631EEE8D-C0CB-437C-B7F1-F97C9BC28BCF}
 		{54E94A1E-2AB5-4AC2-A96D-E919E330E96F} = {F964B103-A85D-4894-89E8-E3835D02ACAD}
+		{DEEA2582-1136-4A67-8949-B8443DF558FE} = {5E301EB3-5AD0-4857-A05F-79284145D34D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B63A603C-4858-49FB-AAEA-C11100FB980B}


### PR DESCRIPTION
# PR Details

<!--- A general summary of your changes -->

Adds  VL.Core.Commands.csproj to VL.StandardLibs.sln

<!--- Your changes in detail -->


<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Currently it's not possible to build the StandardLibs with the solution file that resides in the public repo since some of the projects rely on VL.Core.Commands which isn't part of that solution. 

<img width="1508" alt="2024-02-16 11_10_35-VL StandardLibs - Microsoft Visual Studio" src="https://github.com/vvvv/VL.StandardLibs/assets/1632591/9d6387cc-237f-4d51-807d-77318598e0ae">

This pr adds VL.Core.Commands.csproj to the solution to fix that.

![image](https://github.com/vvvv/VL.StandardLibs/assets/1632591/1d59a0c4-473d-4805-abcb-05b6bf89e6bb)



<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation
