### PR TITLE
[Core] add support for Lists and Arrays to ValueByPath methods

### DIFF
--- a/VL.Core/tests/ValueByPathTests.cs
+++ b/VL.Core/tests/ValueByPathTests.cs
@@ -1,4 +1,6 @@
 ﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace VL.Core.Tests
 {
@@ -16,5 +18,85 @@ namespace VL.Core.Tests
         }
 
         record Foo(int X);
+
+        [Test]
+        public void SetArrayItem()
+        {
+            var array = new[] { 1, 2, 3 };
+            bool pathExists;
+            var mutated = array.WithValueByPath("[1]", 4, out _);
+            Assert.AreEqual(4, mutated[1]);
+            Assert.AreEqual(array, mutated); 
+            Assert.AreNotEqual(2, array[1]);
+        }
+
+        [Test]
+        public void SetImmutableListItem()
+        {
+            var list = ImmutableList.Create(1, 2, 3);
+            var changed = list.WithValueByPath("[1]", 4, out _);
+            Assert.AreEqual(4, changed[1]);
+            Assert.AreNotEqual(list, changed);
+            Assert.AreEqual(2, list[1]);
+        }
+
+        [Test]
+        public void ListSetIndexBoundsChecked()
+        {
+            var list = new List<int>() { 1, 2, 3 };
+            bool pathExists;
+            Assert.DoesNotThrow(() => { 
+                var indexOverflow = list.WithValueByPath("[3]", 4, out pathExists);
+                Assert.AreEqual(list, indexOverflow);
+                Assert.IsFalse(pathExists);
+
+            });
+            Assert.DoesNotThrow(() => { 
+                var indexUnderflow = list.WithValueByPath("[-3]", 4, out pathExists);
+                Assert.AreEqual(list, indexUnderflow);
+                Assert.IsFalse(pathExists);
+            });
+        }
+
+        [Test]
+        public void IListGetItem()
+        {
+            var list = new List<int>() { 1, 2, 3 };
+            int listValue;
+
+            Assert.IsTrue(
+                list.TryGetValueByPath("[1]", 0, out listValue, out _)
+            );
+            Assert.AreEqual(2, listValue);
+
+            var array = new[] { 1, 2, 3 };
+            int arrayValue;
+            Assert.IsTrue(
+                array.TryGetValueByPath("[1]", 0, out arrayValue, out _)
+            );
+            Assert.AreEqual(2, arrayValue);
+        }
+
+        [Test]
+        public void ListGetIndexBoundsChecked()
+        {
+            var list = new List<int>() { 1, 2, 3 };
+            int value = -1;
+            int defaultValue = 0;
+            bool pathExists;
+            Assert.DoesNotThrow(() => {
+                var lookupSucceeded = list.TryGetValueByPath("[3]", defaultValue, out value, out pathExists);
+                Assert.IsFalse(lookupSucceeded);
+                Assert.AreEqual(defaultValue, value);
+                Assert.IsFalse(pathExists);
+
+            });
+            Assert.DoesNotThrow(() => {
+                var lookupSucceeded = list.TryGetValueByPath("[-3]", defaultValue, out value, out pathExists);
+                Assert.IsFalse(lookupSucceeded);
+                Assert.AreEqual(defaultValue, value);
+                Assert.IsFalse(pathExists);
+            });
+        }
     }
 }


### PR DESCRIPTION
# PR Details

add support for Lists and Arrays to [X]ValueByPath methods

## Description

extends existing lookup via index notation of spreads to list and arrays on VLObject TryGetValueByPath and WithValueByPath extension methods.

## Motivation and Context

with this change Select (ByPath) index notation on (Mutable)List and (Mutable)Arrays analog to the lookup of slices of  spreads

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation
