### PR TITLE
Adds TextureSliceView node and improves texture tooltip

### DIFF
--- a/VL.Stride.HDE/VL.Stride.HDE.vl
+++ b/VL.Stride.HDE/VL.Stride.HDE.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="VDq9TVGGhYiNegoTop6Mqh" LanguageVersion="2024.6.0-0277-g64b6f5fb9a" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="VDq9TVGGhYiNegoTop6Mqh" LanguageVersion="2024.6.7-0007-g276e09bed3" Version="0.128">
   <NugetDependency Id="S1C3z3GKjeENrXFbYsqDAm" Location="VL.CoreLib" Version="2021.4.6-0825-gfd5be72bbc" />
   <Patch Id="S9Y5tQRruhZQQEPhzndqij">
     <Canvas Id="S9Lazm76rLSPFTgbYk3zkc" DefaultCategory="Stride.HDE" CanvasType="FullCategory">
@@ -244,43 +244,23 @@
         </p:Interfaces>
         <Patch Id="CPxNqG5kcRFPpggxqTwbvF">
           <Canvas Id="ASjjgEkMuLMNYBrlbnrNzf" CanvasType="Group">
-            <ControlPoint Id="LVs2cugZbSLMat4ypuyTbP" Bounds="792,197" />
-            <ControlPoint Id="KfjvKirTAm4LLYW4MMJ2hK" Bounds="1017,1995" />
-            <Pad Id="SYeH0p4hgtFLR8rENoWbjT" Bounds="792,229" />
-            <Node Bounds="791,313,205,19" Id="RDf8iVprSchM738aVxDRoP">
-              <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.Runtime.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="TextureInfo" />
-                <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
-                  <p:OuterCategoryReference Kind="Category" Name="Textures" NeedsToBeDirectParent="true" />
-                </CategoryReference>
-              </p:NodeReference>
-              <Pin Id="NnB4eX27vq0PryS1iVGuWa" Name="Input" Kind="InputPin" />
-              <Pin Id="IXC5Anvx6y1Pe619Scp8M1" Name="Output" Kind="OutputPin" />
-              <Pin Id="L5bm7Ayn1oULcPq8eHHiWH" Name="Size" Kind="OutputPin" />
-              <Pin Id="Lh4tZadbsEqOvGo6tF8cy3" Name="Width" Kind="OutputPin" />
-              <Pin Id="Jw1tXvUPasSOJwSqnKsgpg" Name="Height" Kind="OutputPin" />
-              <Pin Id="U5EWaN9Tc85OTkaSbEIa8g" Name="Depth" Kind="OutputPin" />
-              <Pin Id="C2K5TghC4lwLnpIJVpV85r" Name="Format" Kind="OutputPin" />
-              <Pin Id="QwujQvelj3RPmEFG7T7xX9" Name="Mip Levels" Kind="OutputPin" />
-              <Pin Id="DV1moj0zFQKPKCwcmVEi2V" Name="Array Size" Kind="OutputPin" />
-              <Pin Id="KlZTQIrfPoqOa1lqwRjMFb" Name="Shared Handle" Kind="OutputPin" />
-              <Pin Id="MjoT6FfmkO7OqUzkv4vQ9V" Name="Loaded" Kind="OutputPin" />
-            </Node>
+            <ControlPoint Id="LVs2cugZbSLMat4ypuyTbP" Bounds="772,168" />
+            <ControlPoint Id="KfjvKirTAm4LLYW4MMJ2hK" Bounds="1038,2375" />
+            <Pad Id="SYeH0p4hgtFLR8rENoWbjT" Bounds="772,200" />
             <ControlPoint Id="Mf1031tox1FLlsbIpXKuyK" Bounds="393,349" />
-            <Node Bounds="210,413,1230,1493" Id="ReIHo7Pn6GSLw5tpIQ9ZNh">
+            <Node Bounds="263,380,1318,1937" Id="ReIHo7Pn6GSLw5tpIQ9ZNh">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <CategoryReference Kind="Category" Name="Primitive" />
               </p:NodeReference>
               <Pin Id="KjoeVo8WdOaOqTCeztOx5S" Name="Condition" Kind="InputPin" />
-              <ControlPoint Id="PwahkxiAOndMUhxo0QYCvf" Bounds="1023,1900" Alignment="Bottom" />
-              <ControlPoint Id="JnmK1HyRW9wMi1ltong0pU" Bounds="1023,419" Alignment="Top" />
+              <ControlPoint Id="PwahkxiAOndMUhxo0QYCvf" Bounds="1038,2311" Alignment="Bottom" />
+              <ControlPoint Id="JnmK1HyRW9wMi1ltong0pU" Bounds="1023,386" Alignment="Top" />
               <Patch Id="LeC6KOhgzsGQI58sm0voEV" ManuallySortedPins="true">
                 <Patch Id="TRMwVIoZEd9NnuvwDGKpuw" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="SKiATj3eEBSQGZZKtuTr9R" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="1021,1867,145,19" Id="Qs6goAiilK7PpCY7XZO975">
+                <Node Bounds="1035,2254,145,19" Id="Qs6goAiilK7PpCY7XZO975">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="PanelWidget" />
@@ -296,12 +276,12 @@
                   <Pin Id="Uy90nzTPNpGQOxOQSoyLtp" Name="Clip Enabled" Kind="InputPin" />
                   <Pin Id="URI3uJw6F2WOrb8SDGgit3" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="FhS0c0HZe4cPWpuR5QEuFU" Comment="Padding" Bounds="1115,1789,35,28" ShowValueBox="true" isIOBox="true" Value="0, 0.02">
+                <Pad Id="FhS0c0HZe4cPWpuR5QEuFU" Comment="Padding" Bounds="1129,2176,35,28" ShowValueBox="true" isIOBox="true" Value="0, 0.02">
                   <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Vector2" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1119,1833,56,19" Id="NkJ1eacSbQFO8FmRVmrtCl">
+                <Node Bounds="1133,2220,56,19" Id="NkJ1eacSbQFO8FmRVmrtCl">
                   <p:NodeReference LastCategoryFullName="Graphics.Skia.Paint" LastDependency="VL.Skia.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="SetAlpha" />
@@ -314,7 +294,7 @@
                   <Pin Id="JqjGm0yC1m0QO8H4Alue7Y" Name="Value" Kind="InputPin" />
                   <Pin Id="HLwEgBYRIqlMQ2pVevMi3f" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1021,1783,52,19" Id="SINXvWmHRBdLXlMEu81zHt">
+                <Node Bounds="1071,2103,52,19" Id="SINXvWmHRBdLXlMEu81zHt">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Column" />
@@ -328,7 +308,7 @@
                   </Pin>
                   <Pin Id="LRqJ0tdI9DoMUAl43RBmtd" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="432,1213,209,19" Id="D5pQFCXdELAOScPP50ixQ0">
+                <Node Bounds="311,1471,209,19" Id="D5pQFCXdELAOScPP50ixQ0">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Cons" />
@@ -339,7 +319,7 @@
                   <Pin Id="QgWi4ih67FjMZ5A6N80tqz" Name="Input 3" Kind="InputPin" />
                   <Pin Id="EZ8ZXV2iK2VOsL9XsNbghm" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="634,1184,68,19" Id="FcSzGwJflx9OrkgYHEeWFL">
+                <Node Bounds="514,1429,68,19" Id="FcSzGwJflx9OrkgYHEeWFL">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
@@ -350,37 +330,7 @@
                   <Pin Id="UPPqwlJZeK3Lod4hpSALAc" Name="Paint" Kind="InputPin" />
                   <Pin Id="ORZfbr0rz8nPpymZwm8V7e" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="805,546,65,19" Id="TEYgz8nZ0jYO6ot77PLzis">
-                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="+" />
-                  </p:NodeReference>
-                  <Pin Id="O7lLEypVEhXPPJxz7O9bBJ" Name="Input" Kind="InputPin" />
-                  <Pin Id="Sc12Sa9P2w5NAhZkRNaC1z" Name="Input 2" Kind="InputPin" DefaultValue="x">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="TypeFlag" Name="String" />
-                    </p:TypeAnnotation>
-                  </Pin>
-                  <Pin Id="A5bhvgZzbKyLeD6PK3Rdxa" Name="Input 3" Kind="InputPin" />
-                  <Pin Id="G5hOq5mcdxULqQMRgcJIOx" Name="Output" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="805,513,55,19" Id="JEkMa1u5HqEM6dmcah0Eq5">
-                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="ToString" />
-                  </p:NodeReference>
-                  <Pin Id="Airztoh1wFiMLgt6558w56" Name="Input" Kind="InputPin" />
-                  <Pin Id="TFavbRFGPDRP38HMJwLdRY" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="868,514,55,19" Id="VaYxr6WIaLUL6MdfqiVHrc">
-                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="ToString" />
-                  </p:NodeReference>
-                  <Pin Id="J3EgfgIBgKkPgq9Xzqc9qG" Name="Input" Kind="InputPin" />
-                  <Pin Id="Q3RbT2CjbePPnjw5xh7AgT" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="534,1184,76,19" Id="VtXBmzXswP1LWljVMNqta1">
+                <Node Bounds="414,1439,76,19" Id="VtXBmzXswP1LWljVMNqta1">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="EmptyWidget" />
@@ -393,7 +343,7 @@
                   </Pin>
                   <Pin Id="LhE2FK8dCrCO8k2XT0VFqB" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="764,992,165,19" Id="GRg43PHGxJ5MZW0rWOPBUe">
+                <Node Bounds="696,1348,165,19" Id="GRg43PHGxJ5MZW0rWOPBUe">
                   <p:NodeReference LastCategoryFullName="HDE.Viewers" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TooltipPaint" />
@@ -409,7 +359,7 @@
                   <Pin Id="CWonPw8977BQblmAeSwLDB" Name="Font2" Kind="OutputPin" />
                   <Pin Id="N1NJVgbQ3SkNkce2olWcpd" Name="Font3" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="684,1342,55,19" Id="SvJZEK8hXDyOhp2eGUlrPL">
+                <Node Bounds="698,1729,55,19" Id="SvJZEK8hXDyOhp2eGUlrPL">
                   <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -417,17 +367,17 @@
                   <Pin Id="BBgOEFIEdlaNc4itlEbtaV" Name="Input" Kind="InputPin" />
                   <Pin Id="LhMhFt7dSEmPxFVa2Jnavh" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="806,436,46,26" Id="LEun9Z6fJsuNOEzCUQGSql">
+                <Node Bounds="710,536,46,19" Id="LEun9Z6fJsuNOEzCUQGSql">
                   <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="Int2" />
-                    <Choice Kind="OperationCallFlag" Name="Split" />
+                    <Choice Kind="OperationCallFlag" Name="Int2 (Split)" />
                   </p:NodeReference>
                   <Pin Id="QjV9kvfvEAdNM1py9rEzo1" Name="Input" Kind="StateInputPin" />
                   <Pin Id="U6bQX1ePfVnMGd8ZeiWR5j" Name="X" Kind="OutputPin" />
                   <Pin Id="AzOMZKlZIjnQHrLWgfsoW2" Name="Y" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="684,1385,68,19" Id="DUsOI35EuUjLMjY89Vwih8">
+                <Node Bounds="698,1772,68,19" Id="DUsOI35EuUjLMjY89Vwih8">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
@@ -438,56 +388,7 @@
                   <Pin Id="OtKuqPCHHbUQJqrKeAHoTa" Name="Paint" Kind="InputPin" />
                   <Pin Id="Q4OjSSrnxeMO4Fy5HCm8U1" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="929,680,121,108" Id="PJgqeIWMS72LdNkZCI0a9m">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
-                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
-                    <Choice Kind="ApplicationStatefulRegion" Name="If" />
-                    <CategoryReference Kind="Category" Name="Primitive" />
-                  </p:NodeReference>
-                  <Pin Id="IaYPQetKuuqLXeLuPJ9K0h" Name="Condition" Kind="InputPin" />
-                  <ControlPoint Id="QaYjW2VscTHLUaHQnGdYOD" Bounds="943,686" Alignment="Top" />
-                  <ControlPoint Id="MkVStfIj3sBPprBsMV7D1c" Bounds="943,782" Alignment="Bottom" />
-                  <Patch Id="VqaSqPDMwxyPHqYFC3I7PH" ManuallySortedPins="true">
-                    <Patch Id="QoOcRsFw7PkN8CZp2eP6px" Name="Create" ManuallySortedPins="true" />
-                    <Patch Id="O4AOyemk2BxQcshKGVGP4F" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="941,734,45,19" Id="GT4n4LeamfDNz21REboWov">
-                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="+" />
-                      </p:NodeReference>
-                      <Pin Id="AZuIrAe36nGMzqhlWHrutQ" Name="Input" Kind="InputPin" />
-                      <Pin Id="BHGczfB8S9nLdzomEDEVZh" Name="Input 2" Kind="InputPin" DefaultValue="x">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                          <Choice Kind="TypeFlag" Name="String" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <Pin Id="SLDQa6fMpw4QKtW9Jocxho" Name="Input 3" Kind="InputPin" />
-                      <Pin Id="GegCA48S7uNP3QhBNKvmmO" Name="Output" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="983,703,55,19" Id="VDogJ1wWTpXLTOL9gxWNFh">
-                      <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="ToString" />
-                      </p:NodeReference>
-                      <Pin Id="Fs4o8QHv9mvQWvZhtR3UGi" Name="Input" Kind="InputPin" />
-                      <Pin Id="Iif3yugzz9JOsmw0sRQ6DB" Name="Result" Kind="OutputPin" />
-                    </Node>
-                  </Patch>
-                </Node>
-                <Node Bounds="882,584,25,19" Id="MteZzjZjXfLOSTUcSi5gYy">
-                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="&gt;" />
-                  </p:NodeReference>
-                  <Pin Id="OeW7glew66TPhiNJ2wfMrc" Name="Input" Kind="InputPin" />
-                  <Pin Id="Mq453DhkixXPfJTvsRU4OY" Name="Input 2" Kind="InputPin" DefaultValue="1">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                      <Choice Kind="TypeFlag" Name="Integer32" />
-                    </p:TypeAnnotation>
-                  </Pin>
-                  <Pin Id="NFNwTwBslygNr94FkmrGZZ" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="871,1107,68,19" Id="RMSy7sudiGRLBabjPbNMZf">
+                <Node Bounds="886,1448,68,19" Id="RMSy7sudiGRLBabjPbNMZf">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
@@ -498,7 +399,7 @@
                   <Pin Id="CzKjoj91BQbMm1aLfSn7fE" Name="Paint" Kind="InputPin" />
                   <Pin Id="QUiBbd5K6OaMIPRxI0AufB" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="940,872,55,19" Id="JsRC4YvETNMLuTmDYLf8Pc">
+                <Node Bounds="938,766,55,19" Id="JsRC4YvETNMLuTmDYLf8Pc">
                   <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -506,19 +407,19 @@
                   <Pin Id="Po3uvUB9DPsOSgD3SZC8lS" Name="Input" Kind="InputPin" />
                   <Pin Id="FLf54hdjFAXNKCgHoNzznw" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1110,707,99,113" Id="NVxAgoVkawSLxst4R9zr23">
+                <Node Bounds="1110,696,99,118" Id="NVxAgoVkawSLxst4R9zr23">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:NodeReference>
                   <Pin Id="TnLEXx9GSLPMnRh23nHYNk" Name="Condition" Kind="InputPin" />
-                  <ControlPoint Id="VkeTkPb01PnP40oYqTlK1U" Bounds="1124,713" Alignment="Top" />
-                  <ControlPoint Id="UAKEkfl8E0KNhSZxldWoED" Bounds="1124,814" Alignment="Bottom" />
+                  <ControlPoint Id="VkeTkPb01PnP40oYqTlK1U" Bounds="1184,702" Alignment="Top" />
+                  <ControlPoint Id="UAKEkfl8E0KNhSZxldWoED" Bounds="1124,808" Alignment="Bottom" />
                   <Patch Id="TRMrLqqkfNqOq6X6aFa1iG" ManuallySortedPins="true">
                     <Patch Id="VzSGbgWmz8DNF3gyJPw5aq" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="JGEAteGCTqBM2BOGKPU9HJ" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="1122,767,65,19" Id="LRL1YmlQpZMPUI7AdXf5Rt">
+                    <Node Bounds="1122,761,65,19" Id="LRL1YmlQpZMPUI7AdXf5Rt">
                       <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="+" />
@@ -537,7 +438,7 @@
                       <Pin Id="G7GqNUhQiahMvFa7GK3LnP" Name="Input 4" Kind="InputPin" />
                       <Pin Id="GX9Nk3Yhre6NT97qyRZN1O" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="1142,730,55,19" Id="KkNuLcUQH6cMc4isnfgM0n">
+                    <Node Bounds="1142,725,55,19" Id="KkNuLcUQH6cMc4isnfgM0n">
                       <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -547,7 +448,7 @@
                     </Node>
                   </Patch>
                 </Node>
-                <Node Bounds="1110,611,25,19" Id="B4Vj4wq9JYUOUjSVBnFpjR">
+                <Node Bounds="1112,594,25,19" Id="B4Vj4wq9JYUOUjSVBnFpjR">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="&gt;" />
@@ -560,7 +461,7 @@
                   </Pin>
                   <Pin Id="FQaRT8u6KR1PHygdUlSQeo" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="951,975,25,19" Id="MIsXFMSTCi4OiL9t3Tx0uU">
+                <Node Bounds="917,803,25,19" Id="MIsXFMSTCi4OiL9t3Tx0uU">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="+" />
@@ -593,64 +494,23 @@
                   <Pin Id="Fq7IQlFlQGONF9I5TUpqc2" Name="Input 2" Kind="InputPin" />
                   <Pin Id="EcPFCe02sLXO2lxsTL152h" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Pad Id="Fj9ejYTIsQMOVllUUqbohc" Comment="" Bounds="432,461,128,15" ShowValueBox="true" isIOBox="true" Value="ShaderResource">
+                <Pad Id="Fj9ejYTIsQMOVllUUqbohc" Comment="" Bounds="436,450,128,15" ShowValueBox="true" isIOBox="true" Value="ShaderResource">
                   <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="TypeFlag" Name="TextureFlags" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="291,600,556,579" Id="DQ52OlBYRHjNhoP6liU2g4">
+                <Node Bounds="286,601,559,520" Id="DQ52OlBYRHjNhoP6liU2g4">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <FullNameCategoryReference ID="Primitive" />
                   </p:NodeReference>
                   <Pin Id="IiGoomhp1vKOoo1OpDDmEw" Name="Condition" Kind="InputPin" />
-                  <ControlPoint Id="C0qc3AC6PUhNcV8qx7PYAv" Bounds="419,1173" Alignment="Bottom" />
-                  <ControlPoint Id="SJ0mEwoaoxcLA5Bqt87eDo" Bounds="468,606" Alignment="Top" />
+                  <ControlPoint Id="C0qc3AC6PUhNcV8qx7PYAv" Bounds="346,1115" Alignment="Bottom" />
+                  <ControlPoint Id="SJ0mEwoaoxcLA5Bqt87eDo" Bounds="466,607" Alignment="Top" />
                   <Patch Id="VtWmPb09VA9MTx5eqh958Z" ManuallySortedPins="true">
                     <Patch Id="F1bYL2EibG1Oa1Shhhx5xn" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="IQmzZueODLmLGDIiAJNzde" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="603,877,55,19" Id="O4ixpxTD5jwMvLNqKDGqCB">
-                      <p:NodeReference LastCategoryFullName="HDE" LastDependency="VL.HDE.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="ToString (Invariant)" />
-                        <PinReference Kind="InputPin" Name="Input">
-                          <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
-                            <Choice Kind="TypeFlag" Name="Float64" />
-                          </p:DataTypeReference>
-                        </PinReference>
-                      </p:NodeReference>
-                      <Pin Id="OITh7SB3lN0QVUEDmDWKHF" Name="Input" Kind="InputPin" />
-                      <Pin Id="EA8XKoyXBL2O5IPh4yX4kT" Name="Format" Kind="InputPin" DefaultValue="0.0">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                          <Choice Kind="TypeFlag" Name="String" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <Pin Id="M3cBOJalYnbMxXhGskOm2H" Name="Result" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="551,920,45,19" Id="FHGB2ZJaS7VMjISK4ACMGD">
-                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="+" />
-                      </p:NodeReference>
-                      <Pin Id="GzRkjPAHiMzP4ThzzL7FHO" Name="Input" Kind="InputPin" />
-                      <Pin Id="JHwOUtJChDuLJnBT4XqgUs" Name="Input 2" Kind="InputPin" DefaultValue=" ">
-                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                          <Choice Kind="TypeFlag" Name="String" />
-                        </p:TypeAnnotation>
-                      </Pin>
-                      <Pin Id="GcUdmcMNcYxOChAkPUNqkp" Name="Input 3" Kind="InputPin" />
-                      <Pin Id="GOa3KjkSV0QL8KooovSfbF" Name="Output" Kind="OutputPin" />
-                    </Node>
-                    <Node Bounds="539,877,55,19" Id="V4UXQ9wUbXRM6exXEgEvxb">
-                      <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
-                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                        <Choice Kind="OperationCallFlag" Name="ToString" />
-                        <CategoryReference Kind="ClassType" Name="Object" NeedsToBeDirectParent="true" />
-                      </p:NodeReference>
-                      <Pin Id="SydfRXN8Y2AOYDHGQeEryC" Name="Input" Kind="InputPin" />
-                      <Pin Id="LUV0T3yuzL8MVpZ2uYtQV1" Name="Result" Kind="OutputPin" />
-                    </Node>
                     <Node Bounds="437,821,172,19" Id="VcNJ44EYz75PDa9UeCgRx7">
                       <p:NodeReference LastCategoryFullName="Stride.Textures" LastDependency="VL.Stride.Runtime.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -658,7 +518,7 @@
                       </p:NodeReference>
                       <Pin Id="Fbwn5TSHxFML82tgvE3Rji" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="Dbe4fVRTDChLEshtLHmquL" Name="Input" Kind="InputPin" />
-                      <Pin Id="TpWmKQDe4bbMYilfHzBxT2" Name="Frame Delay" Kind="InputPin" />
+                      <Pin Id="TpWmKQDe4bbMYilfHzBxT2" Name="Frame Delay" Kind="InputPin" DefaultValue="7" />
                       <Pin Id="Om3ab9QcBUoLEJ93hHXtsp" Name="Size" Kind="InputPin" />
                       <Pin Id="JZZ8bH7GbvfP95moEwPv8t" Name="New Format" Kind="InputPin" />
                       <Pin Id="GBfmZDrujCbORdXQaosx3o" Name="Output" Kind="OutputPin" />
@@ -666,8 +526,7 @@
                       <Pin Id="IJlEpqxWYvsLFW78nc3CpK" Name="Readback Time" Kind="OutputPin" />
                       <Pin Id="K40cScfRWWsPOYDWQLq99E" Name="Result Available" Kind="OutputPin" />
                     </Node>
-                    <Pad Id="EpfDpBipjBILBlqcHKIo3P" Comment="" Bounds="553,961,35,15" ShowValueBox="true" isIOBox="true" />
-                    <Pad Id="Ofwrg36Hl8oLckmtPrnGYq" Comment="Width" Bounds="752,663,35,15" ShowValueBox="true" isIOBox="true" Value="256">
+                    <Pad Id="Ofwrg36Hl8oLckmtPrnGYq" Comment="Width" Bounds="750,661,35,15" ShowValueBox="true" isIOBox="true" Value="256">
                       <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="TypeFlag" Name="Integer32" />
                       </p:TypeAnnotation>
@@ -722,19 +581,19 @@
                       <Pin Id="ExkZKEUqSjdOJE1IeZ04B8" Name="Input" Kind="InputPin" />
                       <Pin Id="Dh4gs35YB3APKcCwUnQWIO" Name="Output" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="314,886,200,270" Id="HfywuH70cEoNLstd6GIZCE">
+                    <Node Bounds="309,886,209,212" Id="HfywuH70cEoNLstd6GIZCE">
                       <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                         <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                         <Choice Kind="ApplicationStatefulRegion" Name="If" />
                         <CategoryReference Kind="Category" Name="Primitive" />
                       </p:NodeReference>
                       <Pin Id="MgzLOj2daLcPKw4g64BB0F" Name="Condition" Kind="InputPin" />
-                      <ControlPoint Id="HTuKh8iaqCZLqOdzbQTMow" Bounds="419,1150" Alignment="Bottom" />
+                      <ControlPoint Id="HTuKh8iaqCZLqOdzbQTMow" Bounds="346,1092" Alignment="Bottom" />
                       <ControlPoint Id="SPo0MjmWzuCMjFcnE5E4Wd" Bounds="426,892" Alignment="Top" />
                       <Patch Id="IYyzrlOCevDOnEWAIXTVhW" ManuallySortedPins="true">
                         <Patch Id="DsEzud5G7O1OYgpTWd3MRG" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="D8GMhmFVUT9OVeRyNGt8pO" Name="Then" ManuallySortedPins="true" />
-                        <Node Bounds="326,919,82,26" Id="M65h8L7pH8iM23kNAQkyXB">
+                        <Node Bounds="332,915,82,26" Id="M65h8L7pH8iM23kNAQkyXB">
                           <p:NodeReference LastCategoryFullName="Graphics.Skia.Imaging" LastDependency="VL.Skia.vl">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="Category" Name="Imaging" NeedsToBeDirectParent="true" />
@@ -745,19 +604,19 @@
                           <Pin Id="Ki425DAxB5jPiSriwvlqOD" Name="Result" Kind="OutputPin" />
                           <Pin Id="P8rqXE5nkI3NLqTkrRLNiT" Name="Image" Kind="OutputPin" />
                         </Node>
-                        <Node Bounds="392,964,110,170" Id="MzNJFhMpMEFMDd3r70sTs6">
+                        <Node Bounds="332,964,174,112" Id="MzNJFhMpMEFMDd3r70sTs6">
                           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                             <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                             <Choice Kind="ApplicationStatefulRegion" Name="If" />
                             <CategoryReference Kind="Category" Name="Primitive" />
                           </p:NodeReference>
                           <Pin Id="Dh0trXfvRJCNkGk3KEkD7a" Name="Condition" Kind="InputPin" />
-                          <ControlPoint Id="EeJ2xK7CPvJQRyBxGWuKfb" Bounds="419,1128" Alignment="Bottom" />
+                          <ControlPoint Id="EeJ2xK7CPvJQRyBxGWuKfb" Bounds="346,1070" Alignment="Bottom" />
                           <ControlPoint Id="LgWpOS28T4vPHCBSXpHl4n" Bounds="426,970" Alignment="Top" />
                           <Patch Id="G0Ck1sk1W8QMbCuUzLSmC1" ManuallySortedPins="true">
                             <Patch Id="RDirzWUVO5xOY2Fc3cc9Qu" Name="Create" ManuallySortedPins="true" />
                             <Patch Id="Mwrx6ddSv5aOJCsCN3EG4h" Name="Then" ManuallySortedPins="true" />
-                            <Node Bounds="404,1007,86,19" Id="NocSGJOtpLoLWE1nDlGsrP">
+                            <Node Bounds="408,1001,86,19" Id="NocSGJOtpLoLWE1nDlGsrP">
                               <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                                 <Choice Kind="ProcessNode" Name="SKImageWidget" />
@@ -773,7 +632,7 @@
                         </Node>
                       </Patch>
                     </Node>
-                    <Node Bounds="313,811,76,19" Id="CbG2OAyVMVML1eJdCX97dT">
+                    <Node Bounds="342,821,76,19" Id="CbG2OAyVMVML1eJdCX97dT">
                       <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="EmptyWidget" />
@@ -799,7 +658,7 @@
                   <Pin Id="AA7hFz8vHrULOGDpn6QsVa" Name="Paint" Kind="InputPin" />
                   <Pin Id="MCgp6aCfpwZOgMK5vtsxcz" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="410,535,25,19" Id="IynIKRLv3P5N5a2gvGiTM5">
+                <Node Bounds="410,528,25,19" Id="IynIKRLv3P5N5a2gvGiTM5">
                   <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureFlags" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="=" />
@@ -814,7 +673,7 @@
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="949,1110,68,19" Id="BqeKKbm0SAjO7VvtKaTBjo">
+                <Node Bounds="1055,1451,68,19" Id="BqeKKbm0SAjO7VvtKaTBjo">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
@@ -834,7 +693,7 @@
                   <Pin Id="FnaB2kb0rIUP1EmXV1Zfca" Name="Input" Kind="InputPin" />
                   <Pin Id="MCK4NjNzT9WQFv1SEBNZQ1" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1068,839,44,26" Id="IClppLJkSEzO1p8LxdxQE2">
+                <Node Bounds="1059,964,44,26" Id="IClppLJkSEzO1p8LxdxQE2">
                   <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Texture" />
@@ -844,7 +703,7 @@
                   <Pin Id="B4ljsTIG2YvNVJAR1miAyF" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="Pl2hHeqdKguL9WlwzxctXK" Name="Usage" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1071,890,55,19" Id="GvXdXNMwyS8NaWOmbB76gY">
+                <Node Bounds="1062,1015,55,19" Id="GvXdXNMwyS8NaWOmbB76gY">
                   <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -853,7 +712,7 @@
                   <Pin Id="SC7sTB6NmcTOlrV9tK92yP" Name="Input" Kind="InputPin" />
                   <Pin Id="SHCdZswEIUqLJFy9Y4Lbu8" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1050,936,25,19" Id="CP0XsR7hl4aP2DhN2NCFZB">
+                <Node Bounds="1041,1061,25,19" Id="CP0XsR7hl4aP2DhN2NCFZB">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="+" />
@@ -866,7 +725,7 @@
                   <Pin Id="PYnyk9AJQ5pMRJNAhh27EC" Name="Input 2" Kind="InputPin" />
                   <Pin Id="OZyTBuzUkJAOH2npAhVfyK" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1041,1111,68,19" Id="GKVzSwxUrNGLQJ2ledH8NG">
+                <Node Bounds="1135,1446,68,19" Id="GKVzSwxUrNGLQJ2ledH8NG">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
@@ -877,7 +736,7 @@
                   <Pin Id="OtqAomJkCvsOiLswY9IbrU" Name="Paint" Kind="InputPin" />
                   <Pin Id="JOZL2BXXCwNMXrPozxEf3r" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1149,842,52,26" Id="J1156fG1vHFLCtLu5VfYGi">
+                <Node Bounds="1140,967,52,26" Id="J1156fG1vHFLCtLu5VfYGi">
                   <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Texture" />
@@ -887,7 +746,7 @@
                   <Pin Id="DhZxXyUHCqRL97uvOL3Qx8" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="N2GJTRLn9bxLxDMppyANPa" Name="Options" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1142,1112,68,19" Id="SEUUjiTDWu7NSOpaRFBlAc">
+                <Node Bounds="1236,1447,68,19" Id="SEUUjiTDWu7NSOpaRFBlAc">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
@@ -898,7 +757,7 @@
                   <Pin Id="KuNucnE6RvSMIy0KMF1eJe" Name="Paint" Kind="InputPin" />
                   <Pin Id="BWpAOzoUJZYL4t4ipiBY1m" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1208,982,55,19" Id="Beh5vuNq8N4L3AbXTAFnwp">
+                <Node Bounds="1199,1107,55,19" Id="Beh5vuNq8N4L3AbXTAFnwp">
                   <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -907,7 +766,7 @@
                   <Pin Id="VzbWJBbwo7GN9xrU7te5JG" Name="Input" Kind="InputPin" />
                   <Pin Id="BM0mTzV8JR0OwUJfCubu5L" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1190,1036,25,19" Id="QARmJYefMQJLj9okl8yV5v">
+                <Node Bounds="1181,1161,25,19" Id="QARmJYefMQJLj9okl8yV5v">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="+" />
@@ -920,7 +779,7 @@
                   <Pin Id="U3mQdfRtue8OQ9TdkqiENO" Name="Input 2" Kind="InputPin" />
                   <Pin Id="Uo8SJtla3mdPcMRTGnM0yd" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="997,1723,45,26" Id="RzllAh1XDJOLQcH8c5cFdc">
+                <Node Bounds="1106,1952,45,26" Id="RzllAh1XDJOLQcH8c5cFdc">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Add" />
@@ -931,8 +790,8 @@
                   <Pin Id="MmZoZ4xuE3DQcUzJbTnPww" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="OwlADhgGXrTMhO0adNYsg6" Name="Apply" Kind="InputPin" />
                 </Node>
-                <ControlPoint Id="LKoCEIYR3KNLovZD5KSGDM" Bounds="1102,1361" />
-                <Node Bounds="1270,909,27,19" Id="CtFKhKhnMViOb1WJ0lzDjr">
+                <ControlPoint Id="LKoCEIYR3KNLovZD5KSGDM" Bounds="1116,1748" />
+                <Node Bounds="1261,1034,27,19" Id="CtFKhKhnMViOb1WJ0lzDjr">
                   <p:NodeReference LastCategoryFullName="Stride.Graphics.TextureOptions" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="!=" />
@@ -942,14 +801,12 @@
                   <Pin Id="GvmDJV7YPpMP5iMaACFjDP" Name="Input 2" Kind="InputPin" />
                   <Pin Id="S8x5IKz905pMJRMPdfKlHY" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="CIj2MVl4PVLPRdCUnkVaJY" Comment="" Bounds="1293,884,116,15" ShowValueBox="true" isIOBox="true" Value="None">
+                <Pad Id="CIj2MVl4PVLPRdCUnkVaJY" Comment="" Bounds="1284,1009,116,15" ShowValueBox="true" isIOBox="true" Value="None">
                   <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="TypeFlag" Name="TextureOptions" />
                   </p:TypeAnnotation>
                 </Pad>
-                <ControlPoint Id="NRsPsbSq1OnM6ZNuUknUNZ" Bounds="1265,1132" />
-                <ControlPoint Id="CmPvZ8jiUGgObgD34wzv9K" Bounds="1197,1639" />
-                <Node Bounds="1113,949,27,19" Id="IVJ4LOXBGLeMsoBP4mrevm">
+                <Node Bounds="1104,1074,27,19" Id="IVJ4LOXBGLeMsoBP4mrevm">
                   <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsResourceUsage" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="!=" />
@@ -959,12 +816,12 @@
                   <Pin Id="Au68Lg22ylaPMx6xcwZWMG" Name="Input 2" Kind="InputPin" />
                   <Pin Id="KntgAk0RMDiQM8HU6PAaVq" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="FWycYjvbWh8OyPyg75Ro2O" Comment="" Bounds="1134,913,77,15" ShowValueBox="true" isIOBox="true" Value="Default">
+                <Pad Id="FWycYjvbWh8OyPyg75Ro2O" Comment="" Bounds="1125,1038,77,15" ShowValueBox="true" isIOBox="true" Value="Default">
                   <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="TypeFlag" Name="GraphicsResourceUsage" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="955,1668,45,26" Id="B6Ab4DmDwt0L0PGNYppvSO">
+                <Node Bounds="1048,1951,45,26" Id="B6Ab4DmDwt0L0PGNYppvSO">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Add" />
@@ -975,8 +832,8 @@
                   <Pin Id="QxoGdpQLwsVMCdCxlj8321" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="OOYmfe1RTVfMbqq7GyzAkB" Name="Apply" Kind="InputPin" />
                 </Node>
-                <ControlPoint Id="HBqsu6F9GGRMgM1oNp6bTe" Bounds="1113,1142" />
-                <Node Bounds="900,1608,45,26" Id="B3KSPDEoQTIN7tihFrfb4F">
+                <ControlPoint Id="HBqsu6F9GGRMgM1oNp6bTe" Bounds="1207,1477" />
+                <Node Bounds="983,1953,45,26" Id="B3KSPDEoQTIN7tihFrfb4F">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Add" />
@@ -987,7 +844,7 @@
                   <Pin Id="IXp4OOqkb4GM1dAnraEdwn" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="IhJSrghsu6NLKQ9JpIIzDP" Name="Apply" Kind="InputPin" />
                 </Node>
-                <Node Bounds="997,977,25,19" Id="PyI7SMqjpGoNSf9WpoRfNE">
+                <Node Bounds="988,1102,25,19" Id="PyI7SMqjpGoNSf9WpoRfNE">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="&gt;" />
@@ -1000,12 +857,12 @@
                   </Pin>
                   <Pin Id="VaA9ZYchUnSPnLkyQ0X99J" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="Dt0asx8J6MfNYbUbJVlYNs" Comment="" Bounds="1020,937,20,15" ShowValueBox="true" isIOBox="true" Value="1">
+                <Pad Id="Dt0asx8J6MfNYbUbJVlYNs" Comment="" Bounds="1011,1062,20,15" ShowValueBox="true" isIOBox="true" Value="1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Integer32" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="787,1440,68,19" Id="Pr1UrrRWXdnL7BbXwDBL4H">
+                <Node Bounds="801,1827,68,19" Id="Pr1UrrRWXdnL7BbXwDBL4H">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
@@ -1016,7 +873,7 @@
                   <Pin Id="UcmCdhcYMg2MVpFwT8WLu3" Name="Paint" Kind="InputPin" />
                   <Pin Id="BYzkbxOr5duNp5pwXxeUIJ" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="761,1229,70,26" Id="C4eF6HuCHA7LcJEXceslbC">
+                <Node Bounds="768,1541,70,26" Id="C4eF6HuCHA7LcJEXceslbC">
                   <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ViewFormat" />
@@ -1026,7 +883,7 @@
                   <Pin Id="BYG2tlwRuKJN2rzF2fdGsx" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="NuSJ6dDT13rNSFjoTRMANe" Name="View Format" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="780,1362,55,19" Id="MT5B0HHNvQBOjGclk20gV9">
+                <Node Bounds="821,1753,55,19" Id="MT5B0HHNvQBOjGclk20gV9">
                   <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -1034,7 +891,7 @@
                   <Pin Id="N7V8KbBGeLgMakON7sW71G" Name="Input" Kind="InputPin" />
                   <Pin Id="KYEJinaFgJEMeMYvEoZmqP" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="766,1504,45,26" Id="Ev9kXS9z9TCPOOo44XAcQ8">
+                <Node Bounds="780,1891,45,26" Id="Ev9kXS9z9TCPOOo44XAcQ8">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Add" />
@@ -1045,7 +902,7 @@
                   <Pin Id="JPT6i6j214rMoR14Drz9m8" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="AMn5b4k64sVOz9tRsnIDU0" Name="Apply" Kind="InputPin" />
                 </Node>
-                <Node Bounds="768,1401,25,19" Id="OPDJFpuO7uoPPO5IbC3KSF">
+                <Node Bounds="801,1793,25,19" Id="OPDJFpuO7uoPPO5IbC3KSF">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="+" />
@@ -1058,7 +915,7 @@
                   <Pin Id="Q8Ja57ojRoROsHhYmaLENz" Name="Input 2" Kind="InputPin" />
                   <Pin Id="QMiFqLcFHckNrzRG8v3CIY" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="806,1476,27,19" Id="ELozGXZuZ4bQJctnZPmZDq">
+                <Node Bounds="820,1863,27,19" Id="ELozGXZuZ4bQJctnZPmZDq">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="!=" />
@@ -1067,7 +924,7 @@
                   <Pin Id="KoqP58lJBlMNwKsA5OxMyf" Name="Input 2" Kind="InputPin" />
                   <Pin Id="KEoEVmNN18BL5Rc924FS2H" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="847,1560,41,26" Id="AgOP6E37ym3Mw7WUfDa8hv">
+                <Node Bounds="865,1954,41,26" Id="AgOP6E37ym3Mw7WUfDa8hv">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Add" />
@@ -1077,7 +934,7 @@
                   <Pin Id="UvBO2rpeg15M4s0vMzrh5V" Name="Item" Kind="InputPin" />
                   <Pin Id="BCzBrrYM7NuQLjkkjLb3zV" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="644,1421,45,26" Id="SxAJH8G6NoTLIjRSy0FdLe">
+                <Node Bounds="658,1808,45,26" Id="SxAJH8G6NoTLIjRSy0FdLe">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Add" />
@@ -1087,7 +944,7 @@
                   <Pin Id="OfGtoDmgHXgMeaplNJ9DIr" Name="Item" Kind="InputPin" />
                   <Pin Id="MxSakTVGXEsPPx7TrPYPI3" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="756,1323,48,26" Id="QouctuW7lj0NpjT2yNa9Oq">
+                <Node Bounds="770,1710,48,26" Id="QouctuW7lj0NpjT2yNa9Oq">
                   <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Texture" />
@@ -1097,7 +954,7 @@
                   <Pin Id="IQEdzM0jmoQPfNo9lRSoQO" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="HIhBllM7Ch4LMOToVHbHxp" Name="Format" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="466,1337,68,19" Id="SgtfjusFAAvQXk1OJDw0tv">
+                <Node Bounds="479,1725,68,19" Id="SgtfjusFAAvQXk1OJDw0tv">
                   <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
@@ -1108,7 +965,7 @@
                   <Pin Id="Bqw1XVcjfGTPL1oZqVQZvw" Name="Paint" Kind="InputPin" />
                   <Pin Id="AqllSr8fVCOOSDad9Shopl" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="445,1401,45,26" Id="CI902WzD1XOMn5tAynQErm">
+                <Node Bounds="459,1788,45,26" Id="CI902WzD1XOMn5tAynQErm">
                   <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Add" />
@@ -1119,7 +976,7 @@
                   <Pin Id="VqUpeYjNyC5M2oVQUiopNs" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="ENdoVJwBCZUN7Z8f0RppW6" Name="Apply" Kind="InputPin" />
                 </Node>
-                <Node Bounds="559,1345,27,19" Id="NWrbIiQfPkIN5ujLRCGv1z">
+                <Node Bounds="572,1733,27,19" Id="NWrbIiQfPkIN5ujLRCGv1z">
                   <p:NodeReference LastCategoryFullName="Stride.API.Graphics.TextureDimension" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="!=" />
@@ -1129,17 +986,17 @@
                   <Pin Id="AJeoFRTH667PppsFKShW2B" Name="Input 2" Kind="InputPin" />
                   <Pin Id="RcaAddtoaLCMsHJ0y9DcE2" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="556,1269,65,26" Id="BZ41OT7vokSPKy4LIfjO6V">
+                <Node Bounds="496,1644,86,26" Id="BZ41OT7vokSPKy4LIfjO6V">
                   <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <Choice Kind="OperationCallFlag" Name="Dimension" />
                     <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="ViewDimension" />
                   </p:NodeReference>
                   <Pin Id="ITF8CJcjZT7OtNSGP5b3Pn" Name="Input" Kind="StateInputPin" />
                   <Pin Id="A4yYAQ8BLOGQKnXZ2a67av" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="AHcTupvoFTIL1wPDykatLP" Name="Dimension" Kind="OutputPin" />
+                  <Pin Id="AHcTupvoFTIL1wPDykatLP" Name="View Dimension" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="466,1306,55,19" Id="TSm5Uc1a4kzOhPcDS7SXcQ">
+                <Node Bounds="479,1694,55,19" Id="TSm5Uc1a4kzOhPcDS7SXcQ">
                   <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ToString" />
@@ -1147,70 +1004,553 @@
                   <Pin Id="Ow4My9JDlSHLIAo24nyLm7" Name="Input" Kind="InputPin" />
                   <Pin Id="Qs2lYSDreXhLa7ueNJaStT" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="Qv56kj5ntr4MvQAsDuImuS" Comment="" Bounds="579,1329,87,15" ShowValueBox="true" isIOBox="true" Value="Texture2D">
+                <Pad Id="Qv56kj5ntr4MvQAsDuImuS" Comment="" Bounds="596,1713,87,15" ShowValueBox="true" isIOBox="true" Value="Texture2D">
                   <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="TextureDimension" />
                   </p:TypeAnnotation>
                 </Pad>
+                <Node Bounds="1040,411,65,26" Id="RQgnM3Vp6PXOhYlaWUz1pK">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="ViewDepth" />
+                  </p:NodeReference>
+                  <Pin Id="DYMdzindXzOMo5ZT4WwpJj" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="USwiQlnNuVOPuqalatni1X" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="SI14xshRxFBOIalyZIFuzw" Name="View Depth" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="966,451,61,26" Id="Jilkf2R0C9LOx1vTxszPl5">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" Name="Graphics" NeedsToBeDirectParent="true">
+                        <p:OuterCategoryReference Kind="Category" Name="API" NeedsToBeDirectParent="true" />
+                      </p:OuterCategoryReference>
+                    </CategoryReference>
+                    <Choice Kind="OperationCallFlag" Name="MipLevels" />
+                  </p:NodeReference>
+                  <Pin Id="TeVkFhi2iI6LUmVQcYSQ2n" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="U4zk5YmSJpnMNt9sPOIhAx" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="Lq4A8GoY2ezOqgb4MI3hq4" Name="Mip Levels" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1129,412,59,26" Id="SV9PRjSmW0LQIwZwDlsoxH">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" Name="Graphics" NeedsToBeDirectParent="true">
+                        <p:OuterCategoryReference Kind="Category" Name="API" NeedsToBeDirectParent="true" />
+                      </p:OuterCategoryReference>
+                    </CategoryReference>
+                    <Choice Kind="OperationCallFlag" Name="ArraySize" />
+                  </p:NodeReference>
+                  <Pin Id="SGQCF30qwduOskxKlsBaqc" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="BVRln2UbMZiMZtG7Bxog3o" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="H5fSGlopzejPXyRlAERdZW" Name="Array Size" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1128,460,86,26" Id="C2K5HrfaJVPOPVuTkbDR7A">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" Name="Graphics" NeedsToBeDirectParent="true">
+                        <p:OuterCategoryReference Kind="Category" Name="API" NeedsToBeDirectParent="true" />
+                      </p:OuterCategoryReference>
+                    </CategoryReference>
+                    <Choice Kind="OperationCallFlag" Name="ViewDimension" />
+                  </p:NodeReference>
+                  <Pin Id="NbT1k3yENaiOIsHm1InZIr" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="BTW7uGPhZ0gQGZbepr7CNL" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="Vi9Uwbr0X2gLSqNnnJ5CZX" Name="View Dimension" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1386,717,150,224" Id="NdBuLVceI6pPI3dsKTvjUD">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                    <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                  </p:NodeReference>
+                  <Pin Id="MOULA5y8N7nLOzr3VlhOra" Name="Condition" Kind="InputPin" />
+                  <Patch Id="U9OYSIPd3o3QSDiYltazLH" ManuallySortedPins="true">
+                    <Patch Id="HtnPb2htakBMvnbOde417B" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="MfJE2mqYFCULInV8lwt44N" Name="Then" ManuallySortedPins="true" />
+                    <Node Bounds="1398,891,68,19" Id="BRMTdXJWetoMJTH7KBiSBQ">
+                      <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
+                      </p:NodeReference>
+                      <Pin Id="EU3AtOG6qfJLQIHExNR1rh" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="B9NmPnTibLxLYyQlDI0H2o" Name="Value" Kind="InputPin" />
+                      <Pin Id="D9x58q23XxtLVwBvzVTYdD" Name="Center Ellipsis" Kind="InputPin" />
+                      <Pin Id="RNhUASeeBbJNNhmfGyoH61" Name="Paint" Kind="InputPin" />
+                      <Pin Id="Der9suTzHPyOBTW2lOaz9S" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                    <Node Bounds="1427,814,97,19" Id="QCVxTLDO4DIMK6a8wPLFnm">
+                      <p:NodeReference LastCategoryFullName="Stride.HDE.TextureViewer" LastDependency="VL.Stride.HDE.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="TextureSizeString" />
+                      </p:NodeReference>
+                      <Pin Id="GSZntLxQX9wQb8rSELHTus" Name="Size" Kind="InputPin" />
+                      <Pin Id="Hn39AYmpz1PLx1KUBmeyWY" Name="Depth" Kind="InputPin" />
+                      <Pin Id="VDixHuYjBBlNxUm9XjD2zL" Name="Dimension" Kind="InputPin" />
+                      <Pin Id="TRcTC1mHfd4No5sDQpP0lP" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="1438,767,86,26" Id="KjFqqnaR8TDPGjTz9Dpe4m">
+                      <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
+                          <p:OuterCategoryReference Kind="Category" Name="Graphics" NeedsToBeDirectParent="true">
+                            <p:OuterCategoryReference Kind="Category" Name="API" NeedsToBeDirectParent="true" />
+                          </p:OuterCategoryReference>
+                        </CategoryReference>
+                        <Choice Kind="OperationCallFlag" Name="Dimension" />
+                      </p:NodeReference>
+                      <Pin Id="MN3X75DaqZMMzBSwhslh87" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="Acdfrnkovl4PCetnXh2wXt" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="JsDHL1gwFxyODKM2ch3K4M" Name="Dimension" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="1398,853,25,19" Id="UWosrBratIgNnOumpOLrtn">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <FullNameCategoryReference ID="Math" />
+                        <Choice Kind="OperationCallFlag" Name="+" />
+                      </p:NodeReference>
+                      <Pin Id="M8xQIk1NZexLDvOf7wM6EX" Name="Input" Kind="InputPin" DefaultValue="Base: " />
+                      <Pin Id="F99nZamPvEvLc4PwCNtG47" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="FyvmuAH4DphNy35TQVY44X" Name="Output" Kind="OutputPin" />
+                    </Node>
+                  </Patch>
+                  <ControlPoint Id="QeS81hZzaDQO999GGSe15m" Bounds="1400,935" Alignment="Bottom" />
+                  <ControlPoint Id="OlmVaDrLt8XMwZt6In5xD7" Bounds="1403,723" Alignment="Top" />
+                </Node>
+                <Node Bounds="1381,521,27,19" Id="S67MSJJcWorLEYpkqEaDmN">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="!=" />
+                  </p:NodeReference>
+                  <Pin Id="VLKa1cMHwuWMzpiGKDmRwk" Name="Input" Kind="InputPin" />
+                  <Pin Id="IHV72MpPulBOvPngWJpJZT" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="BmJaLaK6UfmNhQ1CDwr4yY" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="454,1563,45,26" Id="KiIp26HjWknOuoxX1QhBbH">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Add" />
+                    <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="FVYj6487CWKNu4OFANAu1V" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="GSIhSEJfCVVPRvFjotCgB0" Name="Item" Kind="InputPin" />
+                  <Pin Id="SHr00MMdZ31NoSFdfLBzCM" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="QsWKox5TEu1NjyZVP0Y6cn" Name="Apply" Kind="InputPin" />
+                </Node>
+                <Node Bounds="874,559,97,19" Id="HUAhnqtJmp9PTl9eKJWZ7e">
+                  <p:NodeReference LastCategoryFullName="Stride.HDE.TextureViewer" LastDependency="VL.Stride.HDE.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="TextureSizeString" />
+                  </p:NodeReference>
+                  <Pin Id="TE6CTCKmhHbOgVt0xY1zzA" Name="Size" Kind="InputPin" />
+                  <Pin Id="AN4yb8CjA1pN9ywm5xXqSw" Name="Depth" Kind="InputPin" />
+                  <Pin Id="HuHi5xA3XCMLS5W6eF7JWs" Name="Dimension" Kind="InputPin" />
+                  <Pin Id="TszW9Th2cCaQclAcoC5sgZ" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1389,561,30,19" Id="MFKnCEOdEoTPxp6OGjD9ok">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="Primitive.Boolean" />
+                    <Choice Kind="OperationCallFlag" Name="OR" />
+                  </p:NodeReference>
+                  <Pin Id="Thdm57zDtbQMTvdZqRvBOu" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="UAkrEFKoAc5MLPua8jHW4x" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="FtE0kqB0b0ROJ0KMZbgEuv" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="1422,520,27,19" Id="KwsxC2EcnlUL3HYayZt6IU">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="!=" />
+                  </p:NodeReference>
+                  <Pin Id="EtUjM0P987HMlryd4R10nx" Name="Input" Kind="InputPin" />
+                  <Pin Id="J0bWd9bT1oPOLfcLgVCriP" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Ez7jMmm09kcMDBoSHMjGkX" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1438,457,44,26" Id="AjFB6dLgXgWPY1AsAZm14v">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="ClassType" Name="Texture" />
+                    <Choice Kind="OperationCallFlag" Name="Depth" />
+                  </p:NodeReference>
+                  <Pin Id="K6QJQMoHf7zL5C0VcsXvB8" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="VuNmYgKyUH8NiLFQRsy2TJ" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="DLTyQogKiATMA8BEkdcfc0" Name="Depth" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1039,490,56,26" Id="OpMnBSkmuIQPbGoCsC2TVq">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" Name="Graphics" NeedsToBeDirectParent="true">
+                        <p:OuterCategoryReference Kind="Category" Name="API" NeedsToBeDirectParent="true" />
+                      </p:OuterCategoryReference>
+                    </CategoryReference>
+                    <Choice Kind="OperationCallFlag" Name="MipLevel" />
+                  </p:NodeReference>
+                  <Pin Id="KkCXn80eqndOIyqNYPWOKZ" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="RHbRwqm5VZSM4hW2qVfzNQ" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="RTlWThOTMZlPqVntxfBjnV" Name="Mip Level" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="939,732,45,19" Id="SKvxz4G9QNkNdZ5R47tuiH">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
+                  </p:NodeReference>
+                  <Pin Id="LlW2skjtu2sNgySIpZP7jb" Name="Condition" Kind="InputPin" />
+                  <Pin Id="BUo2dGkVn8INArRD5GeLq8" Name="Input" Kind="InputPin" />
+                  <Pin Id="SGBFp910kL5Nntjn1Pfd1z" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Tyd5cj86yvIPA83HJZY8I6" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="877,734,45,19" Id="NJBYIZN4eozNSweCCe0ayY">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
+                  </p:NodeReference>
+                  <Pin Id="FgrBZNabQM2LCydnRypmte" Name="Condition" Kind="InputPin" />
+                  <Pin Id="HzxQhfiv6zDPyOd2TyNpwm" Name="Input" Kind="InputPin" DefaultValue="Mips: " />
+                  <Pin Id="DPrQxM8lHw1OZRI8nWMNLP" Name="Input 2" Kind="InputPin" DefaultValue="Mip Level: " />
+                  <Pin Id="K1Q2phJ4CVzMlRRMFCIxVa" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="990,1158,30,19" Id="VJA4LQKIdG6N0YfQIPWIDq">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="Primitive.Boolean" />
+                    <Choice Kind="OperationCallFlag" Name="OR" />
+                  </p:NodeReference>
+                  <Pin Id="TX0cGYbyWyvOjSEf1c3QTz" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="JeaAZKlysotN3gwlJYWztB" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="GwxJW4fTS0QPCKAaaVI7XT" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="1227,464,90,26" Id="AfPjtYkPOCJMvPMlrhXMVC">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="ViewDescription" />
+                  </p:NodeReference>
+                  <Pin Id="BoU6If5FB80P41ly7NYwqL" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="DzhNJaCU97NMywoMG73S7m" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="O6DLxTeTGvfMpBEQgKrrLT" Name="View Description" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1215,507,101,26" Id="HZxbdLvLLEuPJJgSMt98sn">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Graphics.TextureViewDescription" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="ClassType" Name="TextureViewDescription" />
+                    <Choice Kind="OperationCallFlag" Name="Type" />
+                  </p:NodeReference>
+                  <Pin Id="KR4fr0UOaeGME1ttcSz2hU" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="KFU3hu53uXkOloyC3ntIHc" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="ECFxqsYjl40N0WUBhRhCJ2" Name="Type" Kind="OutputPin" />
+                </Node>
+                <Pad Id="NikIv2vQ5g3PKxnRSGhgkR" Comment="Type" Bounds="1214,563,70,15" ShowValueBox="true" isIOBox="true" Value="Single">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
+                    <Choice Kind="TypeFlag" Name="ViewType" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1173,602,25,19" Id="Mki1JcCjyJEN93PuAP95BR">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="=" />
+                  </p:NodeReference>
+                  <Pin Id="MDwxKyQLV37MQqTQLC0r3a" Name="Input" Kind="InputPin" />
+                  <Pin Id="DczPntKe36IMlahRhe5UdL" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="EtpqsXupk1oLoQhCKDBnBK" Name="Result" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="I3c0KiqqPGCNpI5BIQwqxF" Bounds="1284,1474" />
+                <Pad Id="UGfsEPR1jRdNopWJvdr5u7" Comment="Type" Bounds="1345,410,70,15" ShowValueBox="true" isIOBox="true" Value="Single">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
+                    <Choice Kind="TypeFlag" Name="ViewType" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="923,1951,45,26" Id="D7YWJ1DuFw3NNgKJhthIU3">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Add" />
+                    <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="STMRYmBzuR2NTVczATmCVH" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="J04SY0tOLiAM5dLTrPVOA9" Name="Item" Kind="InputPin" />
+                  <Pin Id="LHxvi2QWd2qPb5mGOGyKdA" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="RYE1fZo2bksLLT9QQWquZW" Name="Apply" Kind="InputPin" />
+                </Node>
+                <Node Bounds="1449,1106,120,251" Id="DfzMC0pX8GQNCdWXETewBU">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                    <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                  </p:NodeReference>
+                  <Pin Id="A8oh86LUjnBNwxfBClnmyT" Name="Condition" Kind="InputPin" />
+                  <Patch Id="N5rqegQl85vOaYVOHe3fEI" ManuallySortedPins="true">
+                    <Patch Id="EToJu0Lag3SQKJJmjnt2FK" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="IDfUvesFjVUOZ5GdYUwzdB" Name="Then" ManuallySortedPins="true" />
+                    <Node Bounds="1463,1288,68,19" Id="TTNC76SXaICOk1U4VXIy2o">
+                      <p:NodeReference LastCategoryFullName="HDE.TooltipWidgets" LastDependency="VL.HDE.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="ProcessAppFlag" Name="TextWidget (SingleLine)" />
+                      </p:NodeReference>
+                      <Pin Id="CUDg3srZfbhPdCZIJcrkKu" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="OZSybwFe7mMLEBWoI1qLhA" Name="Value" Kind="InputPin" />
+                      <Pin Id="MEpVyCa4TWCLtPaxIMKxOH" Name="Center Ellipsis" Kind="InputPin" />
+                      <Pin Id="R2vxapJhMPLPMQNSbK2pyo" Name="Paint" Kind="InputPin" />
+                      <Pin Id="RhWrBH2yHvgNuGIKMkyLW7" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                    <Node Bounds="1464,1243,25,19" Id="LQfjx3xLvYpNk8QQSNWCSD">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="+" />
+                      </p:NodeReference>
+                      <Pin Id="Q5NHmUdIyvKNunVgEHfbq2" Name="Input" Kind="InputPin" DefaultValue="Array Slice: ">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="TypeFlag" Name="String" />
+                        </p:TypeAnnotation>
+                      </Pin>
+                      <Pin Id="SP5Hqqfk5DfQdr0LOGSA8n" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="IBgJkQZWneBPNijwYzJT62" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="1496,1144,61,26" Id="GwAbIpL80udPVoW0XH2xcY">
+                      <p:NodeReference LastCategoryFullName="Stride.API.Graphics.Texture" LastDependency="VL.Stride.Runtime.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="ClassType" Name="Texture" NeedsToBeDirectParent="true">
+                          <p:OuterCategoryReference Kind="Category" Name="Graphics" NeedsToBeDirectParent="true">
+                            <p:OuterCategoryReference Kind="Category" Name="API" NeedsToBeDirectParent="true" />
+                          </p:OuterCategoryReference>
+                        </CategoryReference>
+                        <Choice Kind="OperationCallFlag" Name="ArraySlice" />
+                      </p:NodeReference>
+                      <Pin Id="C1rzSA8IjNaMzqYT580pMj" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="ODO8g82dh0tL9bx9vJCho6" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="TNaLhuuqvUpLNZcAXf16f8" Name="Array Slice" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="1502,1205,55,19" Id="MvV4zgSGqgzPoE8aOMKpjz">
+                      <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="ToString" />
+                      </p:NodeReference>
+                      <Pin Id="QdXdxMHTdsYLwnECR61iOH" Name="Input" Kind="InputPin" />
+                      <Pin Id="QFQnUBougy0QZEDjy6AVYA" Name="Result" Kind="OutputPin" />
+                    </Node>
+                  </Patch>
+                  <ControlPoint Id="NWh1Xds6eycNZJOJ3gaSzT" Bounds="1463,1351" Alignment="Bottom" />
+                  <ControlPoint Id="C2O0suZlyDfLEtT7fx3DtB" Bounds="1464,1112" Alignment="Top" />
+                </Node>
+                <Node Bounds="1111,662,57,19" Id="FwBv0J0A3TwP7ppYhAabn0">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="Primitive.Boolean" />
+                    <Choice Kind="OperationCallFlag" Name="ANDNOT" />
+                  </p:NodeReference>
+                  <Pin Id="KdxcDWSMMeXOwLn9oCLllj" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="VuYorkuN7r4MPH38SyYjmz" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Q24OXpFIvHmNhlooebrlSa" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="1198,655,37,19" Id="NBBUwDK2r1wNNmwmCe0pww">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="AND" />
+                  </p:NodeReference>
+                  <Pin Id="JjmQqwEsDQDPYXZWz0vGPO" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="QVxXCWlUYpHQRN4SJnAM3a" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="LjtTNULWrzFPxSMPbd4pUh" Name="Output" Kind="StateOutputPin" />
+                </Node>
+              </Patch>
+            </Node>
+            <Node Bounds="770,249,223,19" Id="BnDbdy5MltiQbZe6owlZyh">
+              <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.Runtime.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="Category" Name="Textures" NeedsToBeDirectParent="true" />
+                </CategoryReference>
+                <Choice Kind="OperationCallFlag" Name="Info" />
+              </p:NodeReference>
+              <Pin Id="BsErVNw6pJjLdsux4Vrq0H" Name="Input" Kind="InputPin" />
+              <Pin Id="Hh55H9tXzLeMrXkty3zwDv" Name="Output" Kind="OutputPin" />
+              <Pin Id="CNbsVJLB8CQMhbWqR2pBHt" Name="View Size" Kind="OutputPin" />
+              <Pin Id="QqQjS6Cvv6dPb09X1Vj6Pt" Name="View Format" Kind="OutputPin" />
+              <Pin Id="HQONtxfsawTPbO9u8uyDwC" Name="Resource Size" Kind="OutputPin" />
+              <Pin Id="SmRdvBkKSk1O2lo7u0WM2S" Name="Resource Format" Kind="OutputPin" />
+              <Pin Id="QcUsp84UmZFMBFATS5U6cm" Name="Exists" Kind="OutputPin" />
+            </Node>
+            <!--
+
+    ************************ TextureSizeString (Internal) ************************
+
+-->
+            <Node Name="TextureSizeString (Internal)" Bounds="1727,389,365,446" Id="AEXLXdjvt2tPVIhm7TJDlp">
+              <p:NodeReference>
+                <Choice Kind="OperationDefinition" />
+              </p:NodeReference>
+              <Patch Id="PO2mdGpL2HLL5QU11DV9Sc">
+                <Node Bounds="1739,553,65,19" Id="LCCJHXtAyiMMXrY2ns97rf">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="Ld35UAxd6f4Oaa7kotfedE" Name="Input" Kind="InputPin" />
+                  <Pin Id="MMYoEiQZf5GOSJrUYOXdja" Name="Input 2" Kind="InputPin" DefaultValue="x">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="String" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="RB7GHsBpq4KLKTJj6teODN" Name="Input 3" Kind="InputPin" />
+                  <Pin Id="R8zoFl6xj96NkKrviQ1XXe" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1739,520,55,19" Id="TY98NMNmwEwMehWuDo5zHy">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="ToString" />
+                  </p:NodeReference>
+                  <Pin Id="JUVT1SjxXDFNTreXMCTRjr" Name="Input" Kind="InputPin" />
+                  <Pin Id="KK0u3ODgT9GLc0HQb5hlyG" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1802,521,55,19" Id="NcSvDsyaXP0NemnPWdVdyo">
+                  <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="ToString" />
+                  </p:NodeReference>
+                  <Pin Id="M3Z1UvIWLXZMJkmhB3WdLo" Name="Input" Kind="InputPin" />
+                  <Pin Id="JQj1MIKbZO0LutA9KQzOPg" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1890,655,120,110" Id="MLh7yzQf5oKOzMQon3M6kh">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                    <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:NodeReference>
+                  <Pin Id="PfBuBJ5TrOnM4Uy6uCE3qh" Name="Condition" Kind="InputPin" />
+                  <ControlPoint Id="CjT4ysKnWOhPDbhhsJZ28y" Bounds="1904,661" Alignment="Top" />
+                  <ControlPoint Id="FsfLT7EhVs5NDn54okZZaO" Bounds="1904,759" Alignment="Bottom" />
+                  <Patch Id="McFcYwsfpLvNn1CZB9usuD" ManuallySortedPins="true">
+                    <Patch Id="EqE62tScsKJLkpsAXiV77z" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="I87wEJaislrPO9lLRqn8IO" Name="Then" ManuallySortedPins="true" />
+                    <Node Bounds="1902,711,45,19" Id="KprL0bIrXfeOg0gJNHIyHy">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="+" />
+                      </p:NodeReference>
+                      <Pin Id="EQ3OxiUUaygLGkZgg9SUzg" Name="Input" Kind="InputPin" />
+                      <Pin Id="VZkXKHVkPPaNr6F3GVGK0N" Name="Input 2" Kind="InputPin" DefaultValue="x">
+                        <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                          <Choice Kind="TypeFlag" Name="String" />
+                        </p:TypeAnnotation>
+                      </Pin>
+                      <Pin Id="AsQYAjMqjoBM58K7bVR5Jz" Name="Input 3" Kind="InputPin" />
+                      <Pin Id="KlLXEEhPjuBPDxRx4OlXgQ" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="1943,678,55,19" Id="Ij58CfCqcefOYV2iz1AlPd">
+                      <p:NodeReference LastCategoryFullName="System.Conversion" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="ToString" />
+                      </p:NodeReference>
+                      <Pin Id="PCiSRIY10q5M2v6HKNOW9l" Name="Input" Kind="InputPin" />
+                      <Pin Id="LfxXMgqsbREQPMbbxVxYaa" Name="Result" Kind="OutputPin" />
+                    </Node>
+                  </Patch>
+                </Node>
+                <Node Bounds="1865,574,25,19" Id="DWTepmcLREkOOWadg87NvC">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="&gt;" />
+                  </p:NodeReference>
+                  <Pin Id="AhlZcaknsJjOg6ZryaoM2Y" Name="Input" Kind="InputPin" />
+                  <Pin Id="I2vfCmLKlANPxOX2oJRtWU" Name="Input 2" Kind="InputPin" DefaultValue="1">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="Integer32" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="O7zztqskOQXLJMo8wvtoTn" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1865,606,30,19" Id="Bb77cat1X8AMvIFO7oDJAt">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="Primitive.Boolean" />
+                    <Choice Kind="OperationCallFlag" Name="OR" />
+                  </p:NodeReference>
+                  <Pin Id="JXZaY8q2gR3NX2smEjgAGE" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="EIudoPVRmRkM88TDU6ehPD" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Kx9W2dw7bHnOL1gU2m6Vkg" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="1920,567,25,19" Id="StAywCrcNWzOwLqXKRJgs7">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="=" />
+                  </p:NodeReference>
+                  <Pin Id="LpbYJSPJCfQQVrQ4ovGOeh" Name="Input" Kind="InputPin" />
+                  <Pin Id="D8WXjlB6tTdQNdhmCTNTEo" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="BYL9TbXnir9NYSfqL3jfUo" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Link Id="D9s0tWIEssNNfmXGRpqTKs" Ids="KK0u3ODgT9GLc0HQb5hlyG,Ld35UAxd6f4Oaa7kotfedE" />
+                <Link Id="JsiCLVcmt5XQDPl5s7aWSA" Ids="JQj1MIKbZO0LutA9KQzOPg,RB7GHsBpq4KLKTJj6teODN" />
+                <Link Id="N48MatioGivLqA82rqWCXt" Ids="O7zztqskOQXLJMo8wvtoTn,JXZaY8q2gR3NX2smEjgAGE" />
+                <Link Id="Fp3VvrQutVNQWzRMDFibLQ" Ids="CjT4ysKnWOhPDbhhsJZ28y,FsfLT7EhVs5NDn54okZZaO" IsFeedback="true" />
+                <Link Id="CRdnzApb1SZMr00jspN9fS" Ids="R8zoFl6xj96NkKrviQ1XXe,CjT4ysKnWOhPDbhhsJZ28y" />
+                <Link Id="MN5asUUcl5HQQh3jOdvga3" Ids="CjT4ysKnWOhPDbhhsJZ28y,EQ3OxiUUaygLGkZgg9SUzg" />
+                <Link Id="CRqn7RWormgMTYJB3f8vyp" Ids="KlLXEEhPjuBPDxRx4OlXgQ,FsfLT7EhVs5NDn54okZZaO" />
+                <Link Id="EM8uMvlnB1yMqGO439RMb3" Ids="LfxXMgqsbREQPMbbxVxYaa,AsQYAjMqjoBM58K7bVR5Jz" />
+                <Link Id="HqG50xZfOU5NHiyncXPpx3" Ids="Kx9W2dw7bHnOL1gU2m6Vkg,PfBuBJ5TrOnM4Uy6uCE3qh" />
+                <Link Id="M3fA7vjIhYcOFGCh4PvSzw" Ids="BYL9TbXnir9NYSfqL3jfUo,EIudoPVRmRkM88TDU6ehPD" />
+                <Node Bounds="1743,458,34,19" Id="Ih7UiI6ClCsMUHUV8ztZDF">
+                  <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Int2 (Split)" />
+                  </p:NodeReference>
+                  <Pin Id="NhOvxZDBLV2Mlecr6Q4VDO" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="VT4qIBSD1KdOACYbPhPUaO" Name="X" Kind="OutputPin" />
+                  <Pin Id="ASEpIruvgmPM3IEBGo5RTl" Name="Y" Kind="OutputPin" />
+                </Node>
+                <Link Id="RJVXNu7AukrLC4Mfmq5cWF" Ids="VT4qIBSD1KdOACYbPhPUaO,JUVT1SjxXDFNTreXMCTRjr" />
+                <Link Id="D9AcDgd8ZdxMU55jQr0SCz" Ids="ASEpIruvgmPM3IEBGo5RTl,M3Z1UvIWLXZMJkmhB3WdLo" />
+                <ControlPoint Id="DVSev8cvwIUPI0gX5VCTwp" Bounds="1872,407" />
+                <Link Id="T9oO88WfTU9OZRMidupm2g" Ids="DVSev8cvwIUPI0gX5VCTwp,AhlZcaknsJjOg6ZryaoM2Y" />
+                <Pin Id="GGHFrKhfn8OORzWXLCSiJc" Name="Size" Kind="InputPin" />
+                <Link Id="NKai4zpCUgYM6rkecNDEPL" Ids="GGHFrKhfn8OORzWXLCSiJc,BStNeW6iDvML2w7KOnujsi" IsHidden="true" />
+                <Pin Id="QasL4pNQWqMPppUxSPJzo0" Name="Depth" Kind="InputPin" />
+                <Link Id="QIwzszKOyAsMgIJo0MtXhk" Ids="QasL4pNQWqMPppUxSPJzo0,DVSev8cvwIUPI0gX5VCTwp" IsHidden="true" />
+                <ControlPoint Id="BStNeW6iDvML2w7KOnujsi" Bounds="1746,413" />
+                <Link Id="IXeFn9k2p3dLRnzit2kP8A" Ids="BStNeW6iDvML2w7KOnujsi,NhOvxZDBLV2Mlecr6Q4VDO" />
+                <Pad Id="QtuqQ6yw1x4M6z1PujTd61" Comment="" Bounds="1979,465,82,15" ShowValueBox="true" isIOBox="true" Value="Texture3D">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="TextureDimension" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Link Id="PZll1f0DWQPNxsdTnLpQzj" Ids="QtuqQ6yw1x4M6z1PujTd61,D8WXjlB6tTdQNdhmCTNTEo" />
+                <ControlPoint Id="Tebky9lwQeVLYmBIMWOcEF" Bounds="1930,409" />
+                <Link Id="OSWzEBwdmZwOrvtETzn1YM" Ids="Tebky9lwQeVLYmBIMWOcEF,LpbYJSPJCfQQVrQ4ovGOeh" />
+                <Pin Id="NYEpr9M52HeLNpRVS8eBUk" Name="Dimension" Kind="InputPin" />
+                <Link Id="TFoKgoGSoYBLpJPuKE7gjt" Ids="NYEpr9M52HeLNpRVS8eBUk,Tebky9lwQeVLYmBIMWOcEF" IsHidden="true" />
+                <Link Id="Ai1Grv8Oz3APubey8bYy2K" Ids="DVSev8cvwIUPI0gX5VCTwp,PCiSRIY10q5M2v6HKNOW9l" />
+                <Link Id="Oh3KDUzOrnxPgA3NGwqbRJ" Ids="FsfLT7EhVs5NDn54okZZaO,AEM5b5PMUJeLcqY8qz8f8D" />
+                <ControlPoint Id="AEM5b5PMUJeLcqY8qz8f8D" Bounds="1903,818" />
+                <Pin Id="U2Z89x11zThNBCUc378dPJ" Name="Output" Kind="OutputPin" />
+                <Link Id="SDoqOpZk4jkNuslaol3VE8" Ids="AEM5b5PMUJeLcqY8qz8f8D,U2Z89x11zThNBCUc378dPJ" IsHidden="true" />
               </Patch>
             </Node>
           </Canvas>
           <ProcessDefinition Id="U6ElWysHWfjMwQ5jsuKe9p" HasStateOut="true">
             <Fragment Id="StdqCpmiNikNukmRr12idl" Patch="VRfAJ9fy7WBM0ZIBuHouvW" Enabled="true" />
             <Fragment Id="Gy30es5geJSOiITTqOGgtt" Patch="FcQj9AAdwC6Mx115D0isEp" Enabled="true" />
+            <Fragment Id="GBMj3XYHrtMPNqNcqlruPN" Patch="AEXLXdjvt2tPVIhm7TJDlp" />
           </ProcessDefinition>
           <Link Id="Uu4fVCxEcm6OFDDSxko6UG" Ids="JPM43pMvyOuNEk4vIgKb6n,LVs2cugZbSLMat4ypuyTbP" IsHidden="true" />
           <Link Id="HCQ4wqq9pl0LaE7C1fBXJP" Ids="KfjvKirTAm4LLYW4MMJ2hK,FuEjuh9aGBTMNoEmvblFCc" IsHidden="true" />
           <Link Id="MBKwtUW1EXqQNHhMnYTMgw" Ids="LVs2cugZbSLMat4ypuyTbP,SYeH0p4hgtFLR8rENoWbjT" />
-          <Link Id="JadE2jFRiknNnxsDQeHVsf" Ids="SYeH0p4hgtFLR8rENoWbjT,NnB4eX27vq0PryS1iVGuWa" />
-          <Link Id="PykT0MWyw4nLJbUoPm2P5S" Ids="L5bm7Ayn1oULcPq8eHHiWH,QjV9kvfvEAdNM1py9rEzo1" />
-          <Link Id="OP3gYvT84UlMFoC0eXxsX2" Ids="U5EWaN9Tc85OTkaSbEIa8g,OeW7glew66TPhiNJ2wfMrc" />
-          <Link Id="Bkix9eIymHIQLyT17f5OZw" Ids="U5EWaN9Tc85OTkaSbEIa8g,Fs4o8QHv9mvQWvZhtR3UGi" />
-          <Link Id="ImCpL9EAz0AMTl70lAgSXa" Ids="QwujQvelj3RPmEFG7T7xX9,Po3uvUB9DPsOSgD3SZC8lS" />
-          <Link Id="IVjWnEH5j06MgJN33m5Xbm" Ids="DV1moj0zFQKPKCwcmVEi2V,Hd4OCca7ZhcOQhDNu4E607" />
-          <Link Id="C7Bdaz6CuSDMRvfxkE59qO" Ids="DV1moj0zFQKPKCwcmVEi2V,IvO6B61ivV7Oy7EGsbPmRt" />
           <Link Id="UQxJlWtubGGQdbArbtfIaE" Ids="KNKAu4p7IMKOYgSQqNQG1j,Mf1031tox1FLlsbIpXKuyK" IsHidden="true" />
-          <Link Id="RqIWYNLStY8QaOw4L7v6Ne" Ids="IXC5Anvx6y1Pe619Scp8M1,D6TAc2hfDgoL4IXLM71jId" />
-          <Link Id="JK1rzHbiD6sOa2ntjcpy1O" Ids="IXC5Anvx6y1Pe619Scp8M1,FOBupfnPr69NXaRVRQYfnE" />
-          <Link Id="UlxPAxgbgNfL3ETJUCBu4M" Ids="IXC5Anvx6y1Pe619Scp8M1,UIbPkBh2h5wP69AfCD5f6w" />
-          <Link Id="BEcwuB1SC6YLNnT3GmhOC1" Ids="QwujQvelj3RPmEFG7T7xX9,M4eoXa6THCoOBMOtNEN4OX" />
-          <Link Id="RHfEmA7vwwrPrwwhKnQbbx" Ids="IXC5Anvx6y1Pe619Scp8M1,N9bA7gGfvmzMzmiIKZXDZX" />
-          <Link Id="KvwIyHM1eVFOim1HoNw8SZ" Ids="L5bm7Ayn1oULcPq8eHHiWH,EtNbt8kcJreMhIljW5r9Dx" />
-          <Link Id="ALO6FQsDs0YOglIBNbayU9" Ids="MjoT6FfmkO7OqUzkv4vQ9V,KjoeVo8WdOaOqTCeztOx5S" />
           <Link Id="A9O6muEfMQwOgHuQQ72HZz" Ids="FhS0c0HZe4cPWpuR5QEuFU,SBGaL0171PVL3iRB87PlCZ" />
           <Link Id="TCozzqxpAnIPnbIR7ZKznB" Ids="HLwEgBYRIqlMQ2pVevMi3f,BT3tcVULVVOL7SmqBWakEb" />
-          <Link Id="IDC9fep5M9HLvFkVGlCZx2" Ids="TFavbRFGPDRP38HMJwLdRY,O7lLEypVEhXPPJxz7O9bBJ" />
-          <Link Id="O5SsUzu7Av4Ocuug8fyZPG" Ids="Q3RbT2CjbePPnjw5xh7AgT,A5bhvgZzbKyLeD6PK3Rdxa" />
           <Link Id="R4gxOQRna6AOdylh44piVN" Ids="LRqJ0tdI9DoMUAl43RBmtd,JPvgYCtP7mSO9GU5RtoddL" />
           <Link Id="DtPWFaxakjBQcfNrAxvKc0" Ids="ORZfbr0rz8nPpymZwm8V7e,QgWi4ih67FjMZ5A6N80tqz" />
           <Link Id="UhUK46wgat1QOqtuBhwemM" Ids="CWonPw8977BQblmAeSwLDB,UPPqwlJZeK3Lod4hpSALAc" />
-          <Link Id="DVK7TJPy21hLmdgGe7TOpy" Ids="U6bQX1ePfVnMGd8ZeiWR5j,Airztoh1wFiMLgt6558w56" />
-          <Link Id="K3egknQpY1zMwBCpOVUJDu" Ids="AzOMZKlZIjnQHrLWgfsoW2,J3EgfgIBgKkPgq9Xzqc9qG" />
           <Link Id="MaNXBDvnl0DLHDKS868LhJ" Ids="LhE2FK8dCrCO8k2XT0VFqB,HhfSPfLXxwLLNsWwvxEVEr" />
           <Link Id="FEiVbgfqP2YMkWbt0XzvdC" Ids="CWonPw8977BQblmAeSwLDB,OtKuqPCHHbUQJqrKeAHoTa" />
           <Link Id="ScL356IDBJrQGgzU64KU66" Ids="LhMhFt7dSEmPxFVa2Jnavh,ONUVfLriimRLNQRZMHK5Fd" />
-          <Link Id="ATIdNo5I2FsMtjW6cU9crU" Ids="NFNwTwBslygNr94FkmrGZZ,IaYPQetKuuqLXeLuPJ9K0h" />
-          <Link Id="Ob5KP339uApNrAaEUcwySF" Ids="QaYjW2VscTHLUaHQnGdYOD,MkVStfIj3sBPprBsMV7D1c" IsFeedback="true" />
-          <Link Id="J1nwNKQWGgcLStg7plcYw0" Ids="G5hOq5mcdxULqQMRgcJIOx,QaYjW2VscTHLUaHQnGdYOD" />
-          <Link Id="LYZJBWOD4CgPpqwHUJ1a14" Ids="QaYjW2VscTHLUaHQnGdYOD,AZuIrAe36nGMzqhlWHrutQ" />
-          <Link Id="TBvH0JJZS1FN01cRQZjlS8" Ids="GegCA48S7uNP3QhBNKvmmO,MkVStfIj3sBPprBsMV7D1c" />
-          <Link Id="CnaiSEKHjy9QCw6D7w5BuQ" Ids="Iif3yugzz9JOsmw0sRQ6DB,SLDQa6fMpw4QKtW9Jocxho" />
           <Link Id="Je1fGS14WbOLhd5CEIoO6E" Ids="CWonPw8977BQblmAeSwLDB,CzKjoj91BQbMm1aLfSn7fE" />
-          <Link Id="JYJpxYRyAdELQAcYSKy55s" Ids="FQaRT8u6KR1PHygdUlSQeo,TnLEXx9GSLPMnRh23nHYNk" />
+          <Link Id="JYJpxYRyAdELQAcYSKy55s" Ids="FQaRT8u6KR1PHygdUlSQeo,KdxcDWSMMeXOwLn9oCLllj" />
           <Link Id="NnBJPBTeYGOMWmxMYnK5tq" Ids="VkeTkPb01PnP40oYqTlK1U,UAKEkfl8E0KNhSZxldWoED" IsFeedback="true" />
           <Link Id="KOqWaYYjAJsMFlGX8O3OxB" Ids="GX9Nk3Yhre6NT97qyRZN1O,UAKEkfl8E0KNhSZxldWoED" />
-          <Link Id="UNad8dks3POPgKI0RMZf6o" Ids="MkVStfIj3sBPprBsMV7D1c,VkeTkPb01PnP40oYqTlK1U" />
           <Link Id="K378NLJF3uCOZOy5W6K0J2" Ids="Nf2NMxhZstDPNZaV2f5OcZ,PT614Wudh14NQYjDijY4F5" />
           <Link Id="BKMnc5co3W6PuKWg7vfLrv" Ids="VkeTkPb01PnP40oYqTlK1U,G7GqNUhQiahMvFa7GK3LnP" />
           <Link Id="HYrBZpWLamIOboMBflorey" Ids="UAKEkfl8E0KNhSZxldWoED,NfiNADeJ6sCLxz6Jz82wPJ" />
           <Link Id="Bq60INo7aLxNjezOjWom4F" Ids="FLf54hdjFAXNKCgHoNzznw,ESzwQgc6z36Mwfv8pcXcoy" />
           <Link Id="P7MwiI2O49xO8BDhcLV8do" Ids="DEGHleZ5TuSQO1xlGv2mfl,UmyM58hxnecO69iWuPKV7y" />
           <Link Id="ABIeiAnqtg6M1qqsYw9TPs" Ids="Fj9ejYTIsQMOVllUUqbohc,Fq7IQlFlQGONF9I5TUpqc2" />
-          <Link Id="LlGyrBU8loKNyes2HgILW5" Ids="MFXXr6kONyiQYecZPx7bvs,SydfRXN8Y2AOYDHGQeEryC" />
-          <Link Id="DK21j1krtIjN91fLgxhmsx" Ids="IJlEpqxWYvsLFW78nc3CpK,OITh7SB3lN0QVUEDmDWKHF" />
-          <Link Id="HkcbJHr3zPBOh45ApIWwp2" Ids="LUV0T3yuzL8MVpZ2uYtQV1,GzRkjPAHiMzP4ThzzL7FHO" />
-          <Link Id="FbvTiAzl8mVQJ3oeztQ5AX" Ids="M3cBOJalYnbMxXhGskOm2H,GcUdmcMNcYxOChAkPUNqkp" />
-          <Link Id="FkUqmsoYwPhMWFjhSjIg9j" Ids="GOa3KjkSV0QL8KooovSfbF,EpfDpBipjBILBlqcHKIo3P" />
           <Link Id="LcBw6Rcl5SPPLULy9xlw6L" Ids="SJ0mEwoaoxcLA5Bqt87eDo,C0qc3AC6PUhNcV8qx7PYAv" IsFeedback="true" />
           <Link Id="Q8xKjctUN8hPTz5FzQiYdR" Ids="MCgp6aCfpwZOgMK5vtsxcz,SJ0mEwoaoxcLA5Bqt87eDo" />
           <Link Id="RhdIvWVGOYiLVqhcJ7LBc2" Ids="C0qc3AC6PUhNcV8qx7PYAv,PD6RomoLHqUPye65GeePDJ" />
@@ -1235,16 +1575,15 @@
           <Link Id="QDsJMilgNzoN4GxVgC8cnB" Ids="BWpAOzoUJZYL4t4ipiBY1m,LKoCEIYR3KNLovZD5KSGDM,HKX5X5Q5musLgL9iZd0i5J" />
           <Link Id="IvMoufnmwLDOPN2wEgJp5H" Ids="N2GJTRLn9bxLxDMppyANPa,HcQOC0eDQeCPPYQ7kConUj" />
           <Link Id="T8FHsTZIIXkMFspjrl7FSE" Ids="CIj2MVl4PVLPRdCUnkVaJY,GvmDJV7YPpMP5iMaACFjDP" />
-          <Link Id="SJnrHjEtPqrL8ZeKiUtvXV" Ids="S8x5IKz905pMJRMPdfKlHY,NRsPsbSq1OnM6ZNuUknUNZ,CmPvZ8jiUGgObgD34wzv9K,OwlADhgGXrTMhO0adNYsg6" />
+          <Link Id="SJnrHjEtPqrL8ZeKiUtvXV" Ids="S8x5IKz905pMJRMPdfKlHY,I3c0KiqqPGCNpI5BIQwqxF,OwlADhgGXrTMhO0adNYsg6" />
           <Link Id="FDoUfhCpoNLL4LDFWzp0yP" Ids="Pl2hHeqdKguL9WlwzxctXK,GTvTqPaXx3iLBCKJp34JnM" />
           <Link Id="KZtNt8hcPKzOgq8sQ4VmW8" Ids="FWycYjvbWh8OyPyg75Ro2O,Au68Lg22ylaPMx6xcwZWMG" />
           <Link Id="H7Xvm7fXpPsLqFDpLbMWoX" Ids="QxoGdpQLwsVMCdCxlj8321,T6lf0HhEQzZLVHComZDIFa" />
           <Link Id="NkmWccwZS2wNAHjjM128D2" Ids="JOZL2BXXCwNMXrPozxEf3r,NHxPGKqpsvgPNsQsHrqgyS" />
           <Link Id="CIn4vFcStNYQHUxK2c9Sk7" Ids="KntgAk0RMDiQM8HU6PAaVq,HBqsu6F9GGRMgM1oNp6bTe,OOYmfe1RTVfMbqq7GyzAkB" />
-          <Link Id="IgcxVNw6PsQLlOlGjsZ23w" Ids="IXp4OOqkb4GM1dAnraEdwn,AEyMywbkOtfPt0hqAOWvE9" />
           <Link Id="Uh7iWFnPZIhPn21OSxp8i0" Ids="TMQVLjhNcFVPt2JHfDmn2q,IJOD6BkWvhgOn7Jaa3uwho" />
           <Link Id="UkLoXEdCckZPHjqaboOGQF" Ids="Dt0asx8J6MfNYbUbJVlYNs,FaqdTlYjg0lMnZucS2jn1J" />
-          <Link Id="C9MRdxjJsdKMh9GZHRphsM" Ids="VaA9ZYchUnSPnLkyQ0X99J,IhJSrghsu6NLKQ9JpIIzDP" />
+          <Link Id="C9MRdxjJsdKMh9GZHRphsM" Ids="VaA9ZYchUnSPnLkyQ0X99J,TX0cGYbyWyvOjSEf1c3QTz" />
           <Link Id="AWXa5ltMkK7Pl5tNo5ff0j" Ids="VgknqGbV7IcN0LrfDAkw1q,Dbe4fVRTDChLEshtLHmquL" />
           <Link Id="MGIuFmn9oGyNoqQWDVa2KN" Ids="CWonPw8977BQblmAeSwLDB,UcmCdhcYMg2MVpFwT8WLu3" />
           <Link Id="USPcYrnB77QMx6VQd4kdgy" Ids="BYzkbxOr5duNp5pwXxeUIJ,LM1bcZbaYTJPgzYGBVEwSP" />
@@ -1253,7 +1592,6 @@
           <Link Id="RbIVov9ZplBL25fGT9OWC2" Ids="KEoEVmNN18BL5Rc924FS2H,AMn5b4k64sVOz9tRsnIDU0" />
           <Link Id="Pr9UZBKTXHRMdJAHwIVKsT" Ids="QUiBbd5K6OaMIPRxI0AufB,UvBO2rpeg15M4s0vMzrh5V" />
           <Link Id="VnZAjNflepAM4LSRiK9D5i" Ids="JPT6i6j214rMoR14Drz9m8,USgTFEReXGQLrDfVV9mSnp" />
-          <Link Id="VXJxuDfOLxXNMq1toHwfna" Ids="BCzBrrYM7NuQLjkkjLb3zV,KGVD4TO0juwQGKj6tv4OHU" />
           <Link Id="ETWRFCE8mocPvV3CbHUoGp" Ids="QMiFqLcFHckNrzRG8v3CIY,M3W9dAyjPNYODl9tjVvJuZ" />
           <Link Id="D5tBxzd1En3LuzAz96HVQj" Ids="MxSakTVGXEsPPx7TrPYPI3,EV05zDeJO8LQGxsJfj3RW6" />
           <Link Id="FRHUokKwwQON7xkb6bGabf" Ids="Q4OjSSrnxeMO4Fy5HCm8U1,OfGtoDmgHXgMeaplNJ9DIr" />
@@ -1263,7 +1601,6 @@
           <Link Id="BTIepDKd3DWObW5WXdMoD7" Ids="HIhBllM7Ch4LMOToVHbHxp,N7V8KbBGeLgMakON7sW71G" />
           <Link Id="IOmEfo5dBs3NXSzPr96o6q" Ids="AqllSr8fVCOOSDad9Shopl,KugWXr6mwbzMnB0FNRvzS1" />
           <Link Id="UnFkJjlzcmSQaPZ6g9WjRO" Ids="RcaAddtoaLCMsHJ0y9DcE2,ENdoVJwBCZUN7Z8f0RppW6" />
-          <Link Id="LNfGrnXYUm0NrnWhPuoddG" Ids="EZ8ZXV2iK2VOsL9XsNbghm,BwrKtatAIiUNdUmQu8Fqm1" />
           <Link Id="OOnAlU1qPNsPkRY5el10Xp" Ids="VqUpeYjNyC5M2oVQUiopNs,EoGHWi1HBq7LXBuHUNlLEL" />
           <Link Id="SdXPGmYZBR1LugrGUotndU" Ids="AHcTupvoFTIL1wPDykatLP,Ow4My9JDlSHLIAo24nyLm7" />
           <Link Id="OPhdAAWtNfhQAb3XGACopw" Ids="Qs2lYSDreXhLa7ueNJaStT,Bhj2v64Qo6ZLTzVwtUkn5E" />
@@ -1306,6 +1643,75 @@
             <Pin Id="Qr6cgagBsQBMPIxekL8FI4" Name="Context" Kind="InputPin" />
             <Pin Id="FuEjuh9aGBTMNoEmvblFCc" Name="Widget" Kind="OutputPin" />
           </Patch>
+          <Link Id="OMFH6G2HEogLci8s5DpA2o" Ids="SYeH0p4hgtFLR8rENoWbjT,BsErVNw6pJjLdsux4Vrq0H" />
+          <Link Id="Vlq02Bz9Cv5O3R3kVt1dWG" Ids="CNbsVJLB8CQMhbWqR2pBHt,QjV9kvfvEAdNM1py9rEzo1" />
+          <Link Id="M3ObghW8kotLCGc0iCcAaY" Ids="CNbsVJLB8CQMhbWqR2pBHt,EtNbt8kcJreMhIljW5r9Dx" />
+          <Link Id="GHbqhrVVguXPwz2yz7ttTC" Ids="Hh55H9tXzLeMrXkty3zwDv,DYMdzindXzOMo5ZT4WwpJj" />
+          <Link Id="UCQtCXbXzrBPn3UMdkFO07" Ids="USwiQlnNuVOPuqalatni1X,TeVkFhi2iI6LUmVQcYSQ2n" />
+          <Link Id="Mur3sIHAagxO28d3lyYdha" Ids="Lq4A8GoY2ezOqgb4MI3hq4,M4eoXa6THCoOBMOtNEN4OX" />
+          <Link Id="An3s9Vtl3NANNPGdVSiaml" Ids="Hh55H9tXzLeMrXkty3zwDv,SGQCF30qwduOskxKlsBaqc" />
+          <Link Id="Bt6l87XklJUQKy38Ya5xrZ" Ids="H5fSGlopzejPXyRlAERdZW,Hd4OCca7ZhcOQhDNu4E607" />
+          <Link Id="R2BK1cIpE2kO44QW9Ozs4P" Ids="H5fSGlopzejPXyRlAERdZW,IvO6B61ivV7Oy7EGsbPmRt" />
+          <Link Id="L9blgMpFhJpNw4ek4nYf62" Ids="QcUsp84UmZFMBFATS5U6cm,KjoeVo8WdOaOqTCeztOx5S" />
+          <Link Id="IaRTibxSDyFNLRPIE5qvTr" Ids="Hh55H9tXzLeMrXkty3zwDv,UIbPkBh2h5wP69AfCD5f6w" />
+          <Link Id="ISwz8mtXJJgPP1pLe5crvR" Ids="Hh55H9tXzLeMrXkty3zwDv,FOBupfnPr69NXaRVRQYfnE" />
+          <Link Id="EYBZFn8SLQnPk8P1V0RNAe" Ids="Hh55H9tXzLeMrXkty3zwDv,N9bA7gGfvmzMzmiIKZXDZX" />
+          <Link Id="PWuk4VlIALnNtsB0Rymn4x" Ids="Hh55H9tXzLeMrXkty3zwDv,D6TAc2hfDgoL4IXLM71jId" />
+          <Link Id="V4LSUxzvkAbQahHFx6paks" Ids="BVRln2UbMZiMZtG7Bxog3o,NbT1k3yENaiOIsHm1InZIr" />
+          <Link Id="VbqQ8T11A53LO5QwhPMIg6" Ids="EZ8ZXV2iK2VOsL9XsNbghm,FVYj6487CWKNu4OFANAu1V" />
+          <Link Id="F6nmr4hbDNiMJtyVCnqi1d" Ids="SHr00MMdZ31NoSFdfLBzCM,BwrKtatAIiUNdUmQu8Fqm1" />
+          <Link Id="QVfloEn33f0OmJFWy8vNpO" Ids="CNbsVJLB8CQMhbWqR2pBHt,VLKa1cMHwuWMzpiGKDmRwk" />
+          <Link Id="M9U6mRo2ZHALoF8tot3Ac7" Ids="HQONtxfsawTPbO9u8uyDwC,IHV72MpPulBOvPngWJpJZT" />
+          <Link Id="QTjO0p5cZqqLx7Xm3Du6Te" Ids="BmJaLaK6UfmNhQ1CDwr4yY,Thdm57zDtbQMTvdZqRvBOu" />
+          <Link Id="NfLROnqBmlFPtyb6f2361h" Ids="OlmVaDrLt8XMwZt6In5xD7,QeS81hZzaDQO999GGSe15m" IsFeedback="true" />
+          <Link Id="PnlL4hjWpHXLucNzDcKAwg" Ids="Der9suTzHPyOBTW2lOaz9S,QeS81hZzaDQO999GGSe15m" />
+          <Link Id="PVqoDAaOz38PBdMspX4TaQ" Ids="QeS81hZzaDQO999GGSe15m,GSIhSEJfCVVPRvFjotCgB0" />
+          <Link Id="PNrag4S0vIcNs2P6WTQCtP" Ids="CNbsVJLB8CQMhbWqR2pBHt,TE6CTCKmhHbOgVt0xY1zzA" />
+          <Link Id="L9F76epbrCoPTF1KODmCzt" Ids="SI14xshRxFBOIalyZIFuzw,AN4yb8CjA1pN9ywm5xXqSw" />
+          <Link Id="HH1uT4EDlLkNApcUXXGGca" Ids="Vi9Uwbr0X2gLSqNnnJ5CZX,HuHi5xA3XCMLS5W6eF7JWs" />
+          <Link Id="BWiMipoAikgP2dHMEQXW1w" Ids="TszW9Th2cCaQclAcoC5sgZ,VkeTkPb01PnP40oYqTlK1U" />
+          <Link Id="JFRnmxquSpHPcnt9gSjr1k" Ids="HQONtxfsawTPbO9u8uyDwC,GSZntLxQX9wQb8rSELHTus" />
+          <Link Id="DfimzhD5AyhOsHKhoQLYKU" Ids="JsDHL1gwFxyODKM2ch3K4M,VDixHuYjBBlNxUm9XjD2zL" />
+          <Link Id="U5anQPKBfz1NAPukL3PZdW" Ids="DLTyQogKiATMA8BEkdcfc0,Hn39AYmpz1PLx1KUBmeyWY" />
+          <Link Id="IKhPb2L3KTVPv6klgMtrLm" Ids="CWonPw8977BQblmAeSwLDB,RNhUASeeBbJNNhmfGyoH61" />
+          <Link Id="Bv6s9ETlqYPLP23yjBrz2d" Ids="FyvmuAH4DphNy35TQVY44X,B9NmPnTibLxLYyQlDI0H2o" />
+          <Link Id="NfVurgaCTTYOjTx8OYROC4" Ids="TRcTC1mHfd4No5sDQpP0lP,F99nZamPvEvLc4PwCNtG47" />
+          <Link Id="D37J0EgcVT6MKLF2DmPCKg" Ids="FtE0kqB0b0ROJ0KMZbgEuv,MOULA5y8N7nLOzr3VlhOra" />
+          <Link Id="N1IV1mmzatsK9sNL4tHCDf" Ids="FtE0kqB0b0ROJ0KMZbgEuv,QsWKox5TEu1NjyZVP0Y6cn" />
+          <Link Id="KGph1G7bAeyLjhUnyUsnlr" Ids="Hh55H9tXzLeMrXkty3zwDv,K6QJQMoHf7zL5C0VcsXvB8" />
+          <Link Id="S0H8GUuMtMlPR9vkQ07HeH" Ids="DLTyQogKiATMA8BEkdcfc0,J0bWd9bT1oPOLfcLgVCriP" />
+          <Link Id="LDcpK8PIrzLLiWRW2DUBCj" Ids="SI14xshRxFBOIalyZIFuzw,EtUjM0P987HMlryd4R10nx" />
+          <Link Id="Rkn0c1M9I1hOrurNO0t4kH" Ids="Ez7jMmm09kcMDBoSHMjGkX,UAkrEFKoAc5MLPua8jHW4x" />
+          <Link Id="LwNm6fQQn33Njsmql50F5Y" Ids="U4zk5YmSJpnMNt9sPOIhAx,KkCXn80eqndOIyqNYPWOKZ" />
+          <Link Id="OzgyfmqNIk5Mj3iFfYuILb" Ids="Lq4A8GoY2ezOqgb4MI3hq4,BUo2dGkVn8INArRD5GeLq8" />
+          <Link Id="SJu4MRgO6QMNaRLKFURoqX" Ids="RTlWThOTMZlPqVntxfBjnV,SGBFp910kL5Nntjn1Pfd1z" />
+          <Link Id="Tz6ZY5BD4MmOmVctd6aknY" Ids="Tyd5cj86yvIPA83HJZY8I6,Po3uvUB9DPsOSgD3SZC8lS" />
+          <Link Id="SFaWymioDO8P7KF65tP0ex" Ids="K1Q2phJ4CVzMlRRMFCIxVa,C5FB4z3ZqgRNGTnTgtZd2a" />
+          <Link Id="ILe2zCNgOf2L5zjbmUvBdM" Ids="GwxJW4fTS0QPCKAaaVI7XT,IhJSrghsu6NLKQ9JpIIzDP" />
+          <Link Id="EFe9ctnRh9xN1m2rCFbAYl" Ids="FtE0kqB0b0ROJ0KMZbgEuv,JeaAZKlysotN3gwlJYWztB" />
+          <Link Id="BnZAJ1AVO2FOz1y3G5fwx0" Ids="O6DLxTeTGvfMpBEQgKrrLT,KR4fr0UOaeGME1ttcSz2hU" />
+          <Link Id="MrfsFjq6qQJOd3idYhOaxY" Ids="BTW7uGPhZ0gQGZbepr7CNL,BoU6If5FB80P41ly7NYwqL" />
+          <Link Id="INVx6M4LsMCNKhPKfq0d6b" Ids="ECFxqsYjl40N0WUBhRhCJ2,MDwxKyQLV37MQqTQLC0r3a" />
+          <Link Id="Rt4Buu9ExrmNddfFJe8JnK" Ids="NikIv2vQ5g3PKxnRSGhgkR,DczPntKe36IMlahRhe5UdL" />
+          <Link Id="PAbs1vSmCgqP8zX2Ghj6KQ" Ids="VuNmYgKyUH8NiLFQRsy2TJ,MN3X75DaqZMMzBSwhslh87" />
+          <Link Id="NFcUJCdLSKiMTTBRfJ5uME" Ids="VuNmYgKyUH8NiLFQRsy2TJ,C1rzSA8IjNaMzqYT580pMj" />
+          <Link Id="UL82LWdbtCfLKZlziE56Yj" Ids="BCzBrrYM7NuQLjkkjLb3zV,STMRYmBzuR2NTVczATmCVH" />
+          <Link Id="SWqkYuiPFeAPBV3zTcw0Rt" Ids="IXp4OOqkb4GM1dAnraEdwn,AEyMywbkOtfPt0hqAOWvE9" />
+          <Link Id="RPiSIpn82pULgaOiKxNTM4" Ids="LHxvi2QWd2qPb5mGOGyKdA,KGVD4TO0juwQGKj6tv4OHU" />
+          <Link Id="O0nTsM2TwgFNMCPfs3RK8L" Ids="C2O0suZlyDfLEtT7fx3DtB,NWh1Xds6eycNZJOJ3gaSzT" IsFeedback="true" />
+          <Link Id="KTeG4weFYdoOCs9orH6rys" Ids="RhWrBH2yHvgNuGIKMkyLW7,NWh1Xds6eycNZJOJ3gaSzT" />
+          <Link Id="RecIgaGyu1oP6z8d5aan2V" Ids="NWh1Xds6eycNZJOJ3gaSzT,J04SY0tOLiAM5dLTrPVOA9" />
+          <Link Id="CjxFngzOAeDLO6hbXv5T43" Ids="IBgJkQZWneBPNijwYzJT62,OZSybwFe7mMLEBWoI1qLhA" />
+          <Link Id="I9Jh26i1BhLNn3PNHxEk62" Ids="Q24OXpFIvHmNhlooebrlSa,TnLEXx9GSLPMnRh23nHYNk" />
+          <Link Id="MSMp3Zgw6TsOv5SuTlK1kU" Ids="EtpqsXupk1oLoQhCKDBnBK,LlW2skjtu2sNgySIpZP7jb" />
+          <Link Id="PshRaxvjk1nNMDiZj45dWf" Ids="EtpqsXupk1oLoQhCKDBnBK,FgrBZNabQM2LCydnRypmte" />
+          <Link Id="Rue6NZVhR4EPh4nUk3jbLf" Ids="EtpqsXupk1oLoQhCKDBnBK,VuYorkuN7r4MPH38SyYjmz" />
+          <Link Id="E1nX5cdff0bQY0IOpzozgq" Ids="TNaLhuuqvUpLNZcAXf16f8,QdXdxMHTdsYLwnECR61iOH" />
+          <Link Id="GyLOlkKxj9YLPDiVMQSPeK" Ids="QFQnUBougy0QZEDjy6AVYA,SP5Hqqfk5DfQdr0LOGSA8n" />
+          <Link Id="U2kbSjixML0MokHMgez0iF" Ids="FQaRT8u6KR1PHygdUlSQeo,JjmQqwEsDQDPYXZWz0vGPO" />
+          <Link Id="CvT7swdaqItOuIYEFkLUtb" Ids="EtpqsXupk1oLoQhCKDBnBK,QVxXCWlUYpHQRN4SJnAM3a" />
+          <Link Id="BmLjO5eHYFrOwJCdxWgOSz" Ids="LjtTNULWrzFPxSMPbd4pUh,A8oh86LUjnBNwxfBClnmyT" />
+          <Link Id="Vz9nl4Nd9PGPm6vQAe6LKD" Ids="LjtTNULWrzFPxSMPbd4pUh,RYE1fZo2bksLLT9QQWquZW" />
         </Patch>
       </Node>
       <!--
@@ -4095,7 +4501,7 @@
     </Node>
   </Patch>
   <NugetDependency Id="Txbrzp6oF4kOTUi8RagaJX" Location="VL.Skia" Version="2021.4.6-0825-gfd5be72bbc" />
-  <NugetDependency Id="Ud5bnJoeFCEOqyyW4atsiO" Location="VL.HDE" Version="2021.4.7-0856-g96a2ae2475" />
+  <NugetDependency Id="Ud5bnJoeFCEOqyyW4atsiO" Location="VL.HDE" Version="2024.6.7-0007-g276e09bed3" />
   <NugetDependency Id="OJ4QRCpczcAN2pIoJC7bM7" Location="VL.Stride.Runtime" Version="2021.4.7-0856-g96a2ae2475" />
   <PlatformDependency Id="JHz0mP9UFWSO7pgataHtVZ" Location="Stride.Rendering.dll" />
   <PlatformDependency Id="SP5lqToLPJUOKXbOeRfG34" Location="Stride.Graphics.dll" />

--- a/VL.Stride.Runtime/VL.Stride.Graphics.vl
+++ b/VL.Stride.Runtime/VL.Stride.Graphics.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="Dky5PMnuvcKN4CxmfNs7Uv" LanguageVersion="2023.5.3-0246-g06cc3f05c3" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="Dky5PMnuvcKN4CxmfNs7Uv" LanguageVersion="2024.6.7-0007-g276e09bed3" Version="0.128">
   <NugetDependency Id="EKAeSpl0TUSO67sl9VuE19" Location="VL.CoreLib" Version="2021.4.11-1152-g29d61bbe61" />
   <Patch Id="M3fVx2jjvOSLPGL4EJGFf9">
     <Canvas Id="JugVUmEZoitO7m1cCzT7W3" DefaultCategory="Stride" CanvasType="FullCategory">
@@ -1095,7 +1095,7 @@
           </p:NodeReference>
           <Patch Id="IEnIXYZTbdkPdQ1hFKgCSu">
             <Canvas Id="F8DupD1zyDwMw0Y6Ov9PmO" CanvasType="Group">
-              <Node Bounds="418,500,241,217" Id="GIEzvLtYa1WOn9VRUj9xNG">
+              <Node Bounds="418,500,241,218" Id="GIEzvLtYa1WOn9VRUj9xNG">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -1105,7 +1105,7 @@
                 <Pin Id="LFdNjAPAXXlPzEvQp6m6cp" Name="Dispose Cached Outputs" Kind="InputPin" />
                 <Pin Id="L60RZRk4QDrOEHetnt95bj" Name="Has Changed" Kind="OutputPin" />
                 <ControlPoint Id="BamL1flIQAQPbM1GqLZArk" Bounds="432,712" Alignment="Bottom" />
-                <ControlPoint Id="UrNkgK7PDqVPRBUC7Laeql" Bounds="432,507" Alignment="Top" />
+                <ControlPoint Id="UrNkgK7PDqVPRBUC7Laeql" Bounds="432,506" Alignment="Top" />
                 <Patch Id="AS4uWZI8yzhN9tsbMinsWy" ManuallySortedPins="true">
                   <Patch Id="UFjMgUY9nO1NcxyNJUHXv5" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="LQwnWfTmyBnPaNDbRnbir2" Name="Then" ManuallySortedPins="true" />
@@ -4194,7 +4194,7 @@
                 <Link Id="JHMLBoIWKGjNSsCP1GWF6H" Ids="CrBfGcamhwzPl86mCPaDd0,HX3nIogo5ZUOL7GAb405bk" IsHidden="true" />
                 <Link Id="MNS6f9Kt3U8OmtTaiqvbQj" Ids="DaTyAKbkjzYNlc2ecH86qY,Po9EKi2heJQO3VlCNjqEEG" />
                 <Link Id="NhLqdZ4jwUiOhGVAYvTlrb" Ids="Po9EKi2heJQO3VlCNjqEEG,HEEmzroUfa9MMiJdtsCtYq" IsHidden="true" />
-                <Node Bounds="1406,356,-11,26" Id="Kcx6yqi8lJHM2JrOvdQ9Gr">
+                <Node Bounds="1406,356,40,26" Id="Kcx6yqi8lJHM2JrOvdQ9Gr">
                   <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Object" />
@@ -4280,7 +4280,7 @@
                 <Pin Id="R5bTUw5Cq4UMCRj2FTUXwh" Name="Source" Kind="InputPin" Bounds="1146,308" />
                 <Pin Id="TMbCwaEzvuBQZVVXY9zZxD" Name="Destination" Kind="InputPin" Bounds="1322,305" />
                 <Pin Id="QjNKSia5dTdPlwmyU1moiK" Name="Success" Kind="OutputPin" Bounds="1075,578" />
-                <Node Bounds="1214,638,42,19" Id="PLKehgnVwfEP6ndLpiMDQg">
+                <Node Bounds="1214,638,68,19" Id="PLKehgnVwfEP6ndLpiMDQg">
                   <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.Graphics.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="CanCopyTo" />
@@ -4296,6 +4296,62 @@
                 <Link Id="STcRK3734qpPeZsuwXzrhC" Ids="J7du31Bom80LwtuEXR6Iu5,P6MpodCLltlL4grvmGZ8fH" />
                 <Link Id="CAZoCbgp4vxMT16IYhNCL7" Ids="HHAJ2IInafRMXi9uStn9li,KgN1yMVfaxtLZFjNLTmAvJ" />
                 <Link Id="P3ADpvxiFaDNUmzssFq9Xb" Ids="J7du31Bom80LwtuEXR6Iu5,R8TLWgQBByxL7gruDuL2AU" />
+              </Patch>
+            </Node>
+            <!--
+
+    ************************ ReplaceFlags ************************
+
+-->
+            <Node Name="ReplaceFlags" Bounds="254,821,316,188" Id="V4VIA0AEeWdLPoVpjZ3H99">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
+                <Choice Kind="OperationDefinition" Name="Operation" />
+                <CategoryReference Kind="Category" Name="Primitive" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Patch Id="HAkr7hHjSjTMgO8ijWZpph">
+                <ControlPoint Id="E6vJGRF4GPeQSdkzzb7wyn" Bounds="306,839" />
+                <Node Bounds="296,899,27,19" Id="RHqy3NWR079P2JbxCUVbMu">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="!=" />
+                  </p:NodeReference>
+                  <Pin Id="TOu7vXdqtbvLLVaw0kPpLS" Name="Input" Kind="InputPin" />
+                  <Pin Id="PNN61hwYCQGNqYw6HAgZdP" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="CtZw3YRpaeWNaGGkfPjOfz" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="266,945,45,19" Id="HTRSZbLHZStObSgnoyc0Cm">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
+                  </p:NodeReference>
+                  <Pin Id="FOsBmtzcz9GLvp5wcvqEYH" Name="Condition" Kind="InputPin" />
+                  <Pin Id="Hubw2nTa6mnNEWn0XaTssF" Name="Input" Kind="InputPin" />
+                  <Pin Id="CokPCJmHLt1QNWXggFUbqQ" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="RquOM5LduxHNHaG0NowcqD" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Link Id="Ptr15AjgZlBPyMZ05ZiPlq" Ids="SZzd982xEVRMA5KLWVDgbE,E6vJGRF4GPeQSdkzzb7wyn" IsHidden="true" />
+                <Link Id="OWzxmMIpX6hLlUSwxg4xeH" Ids="E6vJGRF4GPeQSdkzzb7wyn,TOu7vXdqtbvLLVaw0kPpLS" />
+                <Link Id="OC0psElIFRCMmGE9KPHGcv" Ids="CtZw3YRpaeWNaGGkfPjOfz,FOsBmtzcz9GLvp5wcvqEYH" />
+                <Link Id="A5VxnfKAujUQYrh0X2xrzm" Ids="E6vJGRF4GPeQSdkzzb7wyn,CokPCJmHLt1QNWXggFUbqQ" />
+                <ControlPoint Id="SHnc7hwDpt0LOj5A9iaLEL" Bounds="274,864" />
+                <Link Id="Ca05HGnPrAnOeUKeXgk4sJ" Ids="SHnc7hwDpt0LOj5A9iaLEL,Hubw2nTa6mnNEWn0XaTssF" />
+                <Link Id="Cjz7GE6y5YBPnt0S0Ctges" Ids="PQlagQRQ0kyPcFAsvSP6Vb,SHnc7hwDpt0LOj5A9iaLEL" IsHidden="true" />
+                <ControlPoint Id="Q7Y8xyq4OlyNyP1Jv2MJlA" Bounds="270,992" />
+                <Link Id="MPXsqpeqR2GOYzPq0s5QQh" Ids="RquOM5LduxHNHaG0NowcqD,Q7Y8xyq4OlyNyP1Jv2MJlA" />
+                <Link Id="Pa1bss8s6c8NJmSu2k5Ce7" Ids="Q7Y8xyq4OlyNyP1Jv2MJlA,PGYZ0aDUXx4NRUwDAJOOJm" IsHidden="true" />
+                <Pin Id="PQlagQRQ0kyPcFAsvSP6Vb" Name="Input" Kind="InputPin" Bounds="1067,705" />
+                <Pin Id="SZzd982xEVRMA5KLWVDgbE" Name="New Flags" Kind="InputPin" Bounds="1196,284" Summary="Leave at &quot;None&quot; to use same format as input texture.">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="TypeFlag" Name="TextureFlags" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="PGYZ0aDUXx4NRUwDAJOOJm" Name="Output" Kind="OutputPin" Bounds="1063,833" />
+                <Pad Id="PpbBqiiZuzgM93Z4VRbyRv" Comment="" Bounds="355,872,123,15" ShowValueBox="true" isIOBox="true" Value="None">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="TypeFlag" Name="TextureFlags" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Link Id="Nwu7glQU3dkLMH8G1ppJ1G" Ids="PpbBqiiZuzgM93Z4VRbyRv,PNN61hwYCQGNqYw6HAgZdP" />
               </Patch>
             </Node>
           </Canvas>
@@ -9235,6 +9291,196 @@
             </Patch>
           </Patch>
         </Node>
+        <!--
+
+    ************************ TextureSliceView (Advanced) ************************
+
+-->
+        <Node Name="TextureSliceView (Advanced)" Bounds="517,675" Id="BfRjX5n04GBPT6lxo6VmUa" Summary="Creates a subresource view of a given mip slice and array slice from a texture." Tags="MipMap,Array,TextureArray,TextureView">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
+            <Choice Kind="ContainerDefinition" Name="Process" />
+          </p:NodeReference>
+          <Patch Id="ROLENlPDKfkP1ug8fagbaP">
+            <Canvas Id="DtlpBxkE7TJNtmteNJNsjJ" CanvasType="Group">
+              <ControlPoint Id="MtuGDxEBVZPQBWeParoLyZ" Bounds="178,220" />
+              <ControlPoint Id="TmGQyvW8FtqNBhIZhrONEc" Bounds="637,139" />
+              <ControlPoint Id="UBSfH3ZQ85gQKSYvqxDpiS" Bounds="181,697" />
+              <Node Bounds="142,243,382,413" Id="QgCTJ6FEIrQMFbQpux9QKj">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="QDbIjKEBOBSMKNHNDDbL8T" Name="Force" Kind="InputPin" />
+                <Pin Id="CcpA4BxJyHsMxlJSKRK1SG" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="UtKKAyDcyzSNpWvKQDQIDT" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="Q3ksIXM8pCkOLTJIjHtmTY" ManuallySortedPins="true">
+                  <Patch Id="PmNp0CsWuJRPl1xs3kMUgG" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="UbV2sZPUToULjSquB1kslF" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="258,542,125,19" Id="SbFMzEl0YlJO59n9cwVDEV">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics" LastDependency="VL.Stride.Runtime.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="ProcessNode" Name="TextureViewDescription" />
+                    </p:NodeReference>
+                    <Pin Id="NAsn52Ncn8xMvIFdDDtDCU" Name="Format" Kind="InputPin" />
+                    <Pin Id="P5bixkdnYCSQN5gSkE28P1" Name="Mip Level" Kind="InputPin" />
+                    <Pin Id="QxrGvBxt2ExM70VFmFzh6X" Name="Array Slice" Kind="InputPin" />
+                    <Pin Id="Or1Llgwv0qDOVDCFXHjLvZ" Name="Flags" Kind="InputPin" />
+                    <Pin Id="Ead81jI9QvmLDfp5vXJl7w" Name="Type" Kind="InputPin" />
+                    <Pin Id="C6tCofp9XVQP6xmdiPzHmJ" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="257,475,83,19" Id="PmcoOhODwFpM0qXMmLFo7a">
+                    <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.Graphics.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="ReplaceFormat" />
+                    </p:NodeReference>
+                    <Pin Id="OysrQXMyEF3NcXEBGVvMiu" Name="Input" Kind="InputPin" />
+                    <Pin Id="MfBuSyzlkWhLf5aIJ2XUMI" Name="New Format" Kind="InputPin" />
+                    <Pin Id="RDfjyY3AmFHOIQACfhyl3e" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="257,421,85,26" Id="AU59Tdc3TyxNa5O3ZapX3q">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.TextureDescription" LastDependency="VL.Stride.Runtime.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="4026531840" Name="TextureDescription" />
+                      <Choice Kind="OperationCallFlag" Name="Format" />
+                    </p:NodeReference>
+                    <Pin Id="FJ2O88TDLe6QSXusEzEunx" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="MKAS827RNfpOvrFgdaFyyp" Name="Output" Kind="OutputPin" IsHidden="true" />
+                    <Pin Id="CJvNuDdxAzIPlBGUGLiwBv" Name="Format" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="348,420,85,26" Id="Qo0VamB8ZrQMNTQfFnFImq">
+                    <p:NodeReference LastCategoryFullName="Stride.API.Graphics.TextureDescription" LastDependency="VL.Stride.Runtime.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="4026531840" Name="TextureDescription" />
+                      <Choice Kind="OperationCallFlag" Name="Flags" />
+                    </p:NodeReference>
+                    <Pin Id="Ke8gzihsRwvMppI0nlB46h" Name="Input" Kind="StateInputPin" />
+                    <Pin Id="UglyG3lEcEOPqReUOHNHTL" Name="Output" Kind="OutputPin" IsHidden="true" />
+                    <Pin Id="JpWXKHwotLRPM3GxwYFTmT" Name="Flags" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="348,477,75,19" Id="H5bpMP10nigQWC1NCLLFC3">
+                    <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.Graphics.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="ReplaceFlags" />
+                    </p:NodeReference>
+                    <Pin Id="G2yHEOHhv3KNaSYXMEOKZc" Name="Input" Kind="InputPin" />
+                    <Pin Id="ICpxPTqo2qHOzTCQn5XU3k" Name="New Flags" Kind="InputPin" />
+                    <Pin Id="EqmdYfzalG8O8Q5caPmaWV" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="177,595,73,19" Id="MLmf1Xv0hjcO0t0D9c9W8Y">
+                    <p:NodeReference LastCategoryFullName="Stride.Graphics" LastDependency="VL.Stride.Graphics.Nodes">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Graphics" NeedsToBeDirectParent="true">
+                        <p:OuterCategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
+                      </CategoryReference>
+                      <Choice Kind="ProcessAppFlag" Name="TextureView" />
+                    </p:NodeReference>
+                    <Pin Id="IjgY9KobWJXNYaQ9a8rJaC" Name="Input" Kind="InputPin" />
+                    <Pin Id="KqE80DbuiHoNi7JI5FJ8aP" Name="View Description" Kind="InputPin" />
+                    <Pin Id="FCG2Kt753CrNbNaS1DAely" Name="Recreate" Kind="InputPin" />
+                    <Pin Id="OiM4ILF8CRXNj0ogrxzamO" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="165,316,111,80" Id="H4wOBBfNp5wPHRXDbA0JOB">
+                    <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                      <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                      <CategoryReference Kind="Category" Name="Primitive" />
+                      <Choice Kind="ApplicationStatefulRegion" Name="If" />
+                    </p:NodeReference>
+                    <Pin Id="SLZ497tfX2YMq5yGSh0IhP" Name="Condition" Kind="InputPin" />
+                    <Patch Id="Je8jcjrdThYP3nufPyjB9o" ManuallySortedPins="true">
+                      <Patch Id="Gzd8LRYL835PkqSLw4yCw5" Name="Create" ManuallySortedPins="true" />
+                      <Patch Id="VjWwS9MfFvrN09pAONykbf" Name="Then" ManuallySortedPins="true" />
+                      <Node Bounds="177,345,85,26" Id="PSD9eweKJfYQadwXkA7Izj">
+                        <p:NodeReference LastCategoryFullName="Stride.Graphics.Texture" LastDependency="Stride.Graphics.dll">
+                          <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                          <Choice Kind="OperationCallFlag" Name="Description" />
+                          <CategoryReference Kind="AssemblyCategory" Name="Texture" NeedsToBeDirectParent="true" />
+                        </p:NodeReference>
+                        <Pin Id="GCMhq8G5ve0P0DN4Noh83b" Name="Input" Kind="StateInputPin" />
+                        <Pin Id="IGy5aSCDk1aOa2DBPVRlFw" Name="Output" Kind="StateOutputPin" />
+                        <Pin Id="CkFkVcajHYULBRbU4nM31Z" Name="Description" Kind="OutputPin" />
+                      </Node>
+                    </Patch>
+                    <ControlPoint Id="CA2n8vbHgfwM5TXQ7BdFVw" Bounds="259,390" Alignment="Bottom" />
+                    <ControlPoint Id="LjmoRjrjytbN69ykgvACO0" Bounds="259,322" Alignment="Top" />
+                  </Node>
+                  <Node Bounds="165,280,65,19" Id="TwfG2MKNjCHOLNnZJwOsHp">
+                    <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="IsAssigned" />
+                    </p:NodeReference>
+                    <Pin Id="GujNe9dCuSVMoAd3WPOOtb" Name="X" Kind="InputPin" />
+                    <Pin Id="VSiMQGFaTiANjOPpVaqLX7" Name="Result" Kind="OutputPin" />
+                    <Pin Id="MKDcJ6zjlz9NqP3GlwFsrD" Name="Not Assigned" Kind="OutputPin" />
+                  </Node>
+                  <Pad Id="KzFNYDc8RAHO5BlPtSNQLz" Comment="Type" Bounds="398,515,70,15" ShowValueBox="true" isIOBox="true" Value="Single">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
+                      <Choice Kind="TypeFlag" Name="ViewType" />
+                    </p:TypeAnnotation>
+                  </Pad>
+                </Patch>
+                <ControlPoint Id="F8TwJlwqe3wPWskzLbYpk6" Bounds="178,249" Alignment="Top" />
+                <ControlPoint Id="FncImEGSzK5NDQmOq77kSO" Bounds="180,650" Alignment="Bottom" />
+                <ControlPoint Id="JkKkrhHzzYxO3QbM6Ik24P" Bounds="320,249" Alignment="Top" />
+                <ControlPoint Id="GNfKwogQsEZLR1CJuLnVwz" Bounds="288,249" Alignment="Top" />
+                <ControlPoint Id="H8Fb8vz0fTGOB9g67S99CJ" Bounds="427,249" Alignment="Top" />
+                <ControlPoint Id="RocwdaPBaUcNsp0bJ1AiNs" Bounds="490,249" Alignment="Top" />
+              </Node>
+              <ControlPoint Id="T8plWxQsrVKLxcO9tgKvRK" Bounds="320,170" />
+              <ControlPoint Id="OatSsee3bnFPbNWl9XZ7ZW" Bounds="289,130" />
+              <ControlPoint Id="MfCh9iaKHR9MwxQu6oprET" Bounds="428,203" />
+              <ControlPoint Id="Dmx01dEFN3IPVoyvJD87gH" Bounds="491,219" />
+            </Canvas>
+            <Patch Id="Si6qeFsPTHlQbicID4sIdo" Name="Create" />
+            <Patch Id="JTOIDVOxYKBPTwMdsNbRJq" Name="Update">
+              <Pin Id="Drv5Tc9zWUgOlsj6tGwD4U" Name="Input" Kind="InputPin" Bounds="446,430" />
+              <Pin Id="UifYrZKGuCANcVlpBsza7b" Name="Mip Level" Kind="InputPin" />
+              <Pin Id="PqHvPobfWUiNslX06w3efC" Name="Array Slice" Kind="InputPin" />
+              <Pin Id="QCCTWyx2DlsP6AuG8Og2Or" Name="New Format" Kind="InputPin" Visibility="Optional" Summary="Leave at &quot;None&quot; to use the format of the base texture." />
+              <Pin Id="Oi2qyZCrCEbLTdsoq46GVu" Name="New Flags" Kind="InputPin" Visibility="Optional" Summary="Leave at &quot;None&quot; to use the flags of the base texture." />
+              <Pin Id="RAauqR5xoyeQOoK5dRZxQo" Name="Recreate" Kind="InputPin" Bounds="646,410" />
+              <Pin Id="LJYgaChFfXVPU8IajkjL4L" Name="Output" Kind="OutputPin" Bounds="432,756" />
+            </Patch>
+            <ProcessDefinition Id="FEiIVebpO6VOSnTxII6RqB">
+              <Fragment Id="HVprxPCb9yPOfr4v6bbVPM" Patch="Si6qeFsPTHlQbicID4sIdo" Enabled="true" />
+              <Fragment Id="QK78DTN12HuOjwBtFJy6Wd" Patch="JTOIDVOxYKBPTwMdsNbRJq" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="SNgc19dBwhfNoCEYNVtDN0" Ids="Drv5Tc9zWUgOlsj6tGwD4U,MtuGDxEBVZPQBWeParoLyZ" IsHidden="true" />
+            <Link Id="BUwyaOYKOt0NTR2K0jrnoO" Ids="RAauqR5xoyeQOoK5dRZxQo,TmGQyvW8FtqNBhIZhrONEc" IsHidden="true" />
+            <Link Id="DwRExF6BDxhPyHJgwgrsFT" Ids="UBSfH3ZQ85gQKSYvqxDpiS,LJYgaChFfXVPU8IajkjL4L" IsHidden="true" />
+            <Link Id="CvNWpFPYLmWLxR1clI5kfG" Ids="JkKkrhHzzYxO3QbM6Ik24P,QxrGvBxt2ExM70VFmFzh6X" />
+            <Link Id="VNAEIIjLRNAQBjRoEkOHJB" Ids="T8plWxQsrVKLxcO9tgKvRK,JkKkrhHzzYxO3QbM6Ik24P" />
+            <Link Id="LZQoFZLqV3fMx9CVH1dVxb" Ids="PqHvPobfWUiNslX06w3efC,T8plWxQsrVKLxcO9tgKvRK" IsHidden="true" />
+            <Link Id="P2HDy1KVcKZL0Rt3LHHTxD" Ids="TmGQyvW8FtqNBhIZhrONEc,QDbIjKEBOBSMKNHNDDbL8T" />
+            <Link Id="DVgjEU00kpoNOpy3lM6shR" Ids="FncImEGSzK5NDQmOq77kSO,UBSfH3ZQ85gQKSYvqxDpiS" />
+            <Link Id="IqqsJoLbfoALdCTui5O5aN" Ids="MtuGDxEBVZPQBWeParoLyZ,F8TwJlwqe3wPWskzLbYpk6" />
+            <Link Id="RAZpYykc9TVNS5oeY5Xtey" Ids="GNfKwogQsEZLR1CJuLnVwz,P5bixkdnYCSQN5gSkE28P1" />
+            <Link Id="JofOuTDNpTeMr26PSfge5F" Ids="OatSsee3bnFPbNWl9XZ7ZW,GNfKwogQsEZLR1CJuLnVwz" />
+            <Link Id="Uyelmb36AlPPnB51U0LHst" Ids="UifYrZKGuCANcVlpBsza7b,OatSsee3bnFPbNWl9XZ7ZW" IsHidden="true" />
+            <Link Id="CMcDZoxdkDUNHhawfwhVrT" Ids="RDfjyY3AmFHOIQACfhyl3e,NAsn52Ncn8xMvIFdDDtDCU" />
+            <Link Id="HjSv3WzLMTtPrt4AtpthJr" Ids="F8TwJlwqe3wPWskzLbYpk6,GCMhq8G5ve0P0DN4Noh83b" />
+            <Link Id="MLshKVEgduMQKzPYoug97x" Ids="CJvNuDdxAzIPlBGUGLiwBv,OysrQXMyEF3NcXEBGVvMiu" />
+            <Link Id="KL2lLp1e2tEMnkO2WLYqXA" Ids="H8Fb8vz0fTGOB9g67S99CJ,MfBuSyzlkWhLf5aIJ2XUMI" />
+            <Link Id="TgCrWDsjNDWLxqhVa9xgVE" Ids="MfCh9iaKHR9MwxQu6oprET,H8Fb8vz0fTGOB9g67S99CJ" />
+            <Link Id="ReQsISrtMhWONPCuwpawbc" Ids="QCCTWyx2DlsP6AuG8Og2Or,MfCh9iaKHR9MwxQu6oprET" IsHidden="true" />
+            <Link Id="DmKvihPYnGtMb9sjeBj8Jf" Ids="JpWXKHwotLRPM3GxwYFTmT,G2yHEOHhv3KNaSYXMEOKZc" />
+            <Link Id="HatGyOAJWrQP7uZ0LAbpAV" Ids="EqmdYfzalG8O8Q5caPmaWV,Or1Llgwv0qDOVDCFXHjLvZ" />
+            <Link Id="JJLENU5llrnPgF2TpDH4ED" Ids="RocwdaPBaUcNsp0bJ1AiNs,ICpxPTqo2qHOzTCQn5XU3k" />
+            <Link Id="Pq6IzbWR8yENpguz3IJmeM" Ids="Dmx01dEFN3IPVoyvJD87gH,RocwdaPBaUcNsp0bJ1AiNs" />
+            <Link Id="Au1ELCpbM9UMvc38BHVcvM" Ids="Oi2qyZCrCEbLTdsoq46GVu,Dmx01dEFN3IPVoyvJD87gH" IsHidden="true" />
+            <Link Id="O1SZfXCifzCOprYpEikgbc" Ids="C6tCofp9XVQP6xmdiPzHmJ,KqE80DbuiHoNi7JI5FJ8aP" />
+            <Link Id="V3ncz1Fn02zLZOOvzQX64m" Ids="OiM4ILF8CRXNj0ogrxzamO,FncImEGSzK5NDQmOq77kSO" />
+            <Link Id="RaRKPRpT60pMCVPqxUkqDz" Ids="TmGQyvW8FtqNBhIZhrONEc,FCG2Kt753CrNbNaS1DAely" />
+            <Link Id="DsqNPY6hEabPXwstciE8G4" Ids="F8TwJlwqe3wPWskzLbYpk6,GujNe9dCuSVMoAd3WPOOtb" />
+            <Link Id="QNaN99AU9cHPmf8Yt12Z7L" Ids="VSiMQGFaTiANjOPpVaqLX7,SLZ497tfX2YMq5yGSh0IhP" />
+            <Link Id="Hh7Z0nICY9POHGAv4cbkDK" Ids="LjmoRjrjytbN69ykgvACO0,CA2n8vbHgfwM5TXQ7BdFVw" IsFeedback="true" />
+            <Link Id="I0WUQKDag0OMyw0st3O6yX" Ids="CkFkVcajHYULBRbU4nM31Z,CA2n8vbHgfwM5TXQ7BdFVw" />
+            <Link Id="EvBbcQ7KWALPVzHfMPwkAf" Ids="CA2n8vbHgfwM5TXQ7BdFVw,FJ2O88TDLe6QSXusEzEunx" />
+            <Link Id="Ddy6sObtH8UQaGUrbTui9A" Ids="CA2n8vbHgfwM5TXQ7BdFVw,Ke8gzihsRwvMppI0nlB46h" />
+            <Link Id="OmuMrRnH1GiPyv91gVopXM" Ids="F8TwJlwqe3wPWskzLbYpk6,IjgY9KobWJXNYaQ9a8rJaC" />
+            <Link Id="R6EOjpNKQkwQNv5O7kh70t" Ids="KzFNYDc8RAHO5BlPtSNQLz,Ead81jI9QvmLDfp5vXJl7w" />
+          </Patch>
+        </Node>
       </Canvas>
       <Canvas Id="KjN9WJlwNivPkMbWwjahBF" Name="Windowing" Position="319,463">
         <!--
@@ -10261,4 +10507,5 @@
   <NodeFactoryDependency Id="DrycSboTwzmLbaoQoAQfoq" Location="VL.Stride.Rendering.EffectShaderNodes" />
   <PlatformDependency Id="GSImkKX5tl0LEtI2Ww58yn" Location="../../../../vvvv50/VVVV.Gamma/src/bin/Debug/net472/Stride.Core.dll" />
   <PlatformDependency Id="A1C9yUlv0yJNvB72kiMvuJ" Location="System.Text.RegularExpressions" />
+  <PlatformDependency Id="ERURln8NNDlOGL2UOgNgz7" Location="C:/Users/Christian/AppData/Local/vvvv/_vvvv/vvvv_gamma_2022.5.0-0485-g8f46e4a34a/Stride.Graphics.dll" />
 </Document>


### PR DESCRIPTION
# PR Details

Adds `TextureSliceView` node and improves texture tooltip to show the view and base differences of size and mip level.

## Description

<img width="262" alt="image" src="https://github.com/vvvv/VL.StandardLibs/assets/1094716/7e586f92-4459-4d87-931e-b5f6cc337156">


## Related Issue

Needs merge and a Stride update with this included:
https://github.com/stride3d/stride/pull/2375

## Motivation and Context

Write into Texture3D mip slices in a compute shader. As requested by @texone.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation
