### PR TITLE
Adds help flag for ObjectEditor and ObjectEditorFactory to HowTo Build A Custom Editor.vl

### DIFF
--- a/VL.ImGui/help/Editors/HowTo Build A Custom Editor.vl
+++ b/VL.ImGui/help/Editors/HowTo Build A Custom Editor.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="BcGJFN2FtVtNJjg1ciBW1H" LanguageVersion="2024.6.0-0084-g57c1aea893" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="BcGJFN2FtVtNJjg1ciBW1H" LanguageVersion="2024.6.7-0037-ga0136f166f" Version="0.128">
   <NugetDependency Id="PcBB2hnXA4ZNaUMlvg9h6r" Location="VL.CoreLib" Version="2022.5.0-0426-d7abada9e6" />
   <Patch Id="Ha8fREjcCftOHdslRsDah6">
     <Canvas Id="ULxkrQOAhIyOOxahoWwUAM" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
@@ -293,12 +293,12 @@
     ************************ CreateObjectEditor ************************
 
 -->
-          <Node Name="CreateObjectEditor" Bounds="317,360,151,107" Id="FZXIdJ9o4kCLmHAPIhfIi6">
+          <Node Name="CreateObjectEditor" Bounds="318,360,150,107" Id="FZXIdJ9o4kCLmHAPIhfIi6">
             <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="OperationDefinition" Name="Operation" />
             </p:NodeReference>
             <Patch Id="FOM4oChUsvCNqeF6sZwEiw">
-              <ControlPoint Id="KSutnP3gOBFPYF1dx1BOhQ" Bounds="331,378" />
+              <ControlPoint Id="KSutnP3gOBFPYF1dx1BOhQ" Bounds="332,378" />
               <Link Id="Mq6l0U9QAIEMf93tfnvuHq" Ids="RO8Xa1js7hnMkyKfiEcqOm,KSutnP3gOBFPYF1dx1BOhQ" IsHidden="true" />
               <Node Bounds="330,396,61,26" Id="USY0aKxPywMO5Fj8HNWefT">
                 <p:NodeReference LastCategoryFullName="Main.PersonEditor" LastDependency="HowTo Build A Custom Editor.vl">
@@ -310,7 +310,7 @@
                 <Pin Id="D2lku8Gk6yENAXDZZMLudi" Name="Channel" Kind="InputPin" />
                 <Pin Id="JZ7Vsvmvmp1QPJBJpLkudp" Name="Output" Kind="StateOutputPin" />
               </Node>
-              <ControlPoint Id="IheNwOqsjTmPp8E3gznfFl" Bounds="333,450" />
+              <ControlPoint Id="IheNwOqsjTmPp8E3gznfFl" Bounds="332,450" />
               <Link Id="U9aFj2SVVIFLNge2salEny" Ids="JZ7Vsvmvmp1QPJBJpLkudp,IheNwOqsjTmPp8E3gznfFl" />
               <Link Id="N9V5nRbN5QaOyKNxThnP2u" Ids="IheNwOqsjTmPp8E3gznfFl,DsJauFXmzaTOq8IV0bVHBK" IsHidden="true" />
               <ControlPoint Id="UaGN0mVxJ0DPye8FLeqUoD" Bounds="409,378" />
@@ -330,7 +330,7 @@
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Renderer" />
             </p:NodeReference>
-            <Pin Id="PVlzrIWw6ZxOGI1lyTbXim" Name="Bounds" Kind="InputPin" DefaultValue="1201, 353, 616, 584" />
+            <Pin Id="PVlzrIWw6ZxOGI1lyTbXim" Name="Bounds" Kind="InputPin" DefaultValue="1200, 352, 616, 584" />
             <Pin Id="In8i1wV6EaxLcFKuTEdDMf" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
             <Pin Id="A8i1TUYQUJLOQVziBeTuXj" Name="Bound to Document" Kind="InputPin" DefaultValue="True" />
             <Pin Id="GbnEuw8ug1dMRQqTs4TeBy" Name="Node Context" Kind="InputPin" IsHidden="true" />
@@ -369,6 +369,7 @@
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="ObjectEditor" />
                 </p:NodeReference>
+                <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
                 <Pin Id="EhReBmar5fTQPxtKmlbWIx" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="POAawaopf5NLMif3Yb623q" Name="Context" Kind="InputPin" />
                 <Pin Id="RHBsZERTpi1L7R5Q7THC0x" Name="Channel" Kind="InputPin" />
@@ -378,7 +379,9 @@
                 <Pin Id="LpQre7SFgl9NR0xMNQhwgm" Name="Factory" Kind="InputPin" IsHidden="true" />
                 <Pin Id="MQVfHBe3rmcPbyCdTtrmnp" Name="Primitive Only" Kind="InputPin" IsHidden="true" />
                 <Pin Id="SHjIHwFGiHpP3tnEVkvP0I" Name="Context" Kind="OutputPin" />
+                <Pin Id="UaGRzt6WZV4O94DgBGHqwb" Name="Has Editor" Kind="OutputPin" />
               </Node>
+              <Patch Id="NJr3g1mtWU4Os8wxSx4lEu" Name="Dispose" />
             </Patch>
           </Node>
           <Node Bounds="130,505,47,19" Id="UjUyaXi9TRLLKSxajl7TIE">
@@ -466,7 +469,7 @@
     ************************ CustomEditors ************************
 
 -->
-          <Node Name="CustomEditors" Bounds="671,427" Id="EMqqoNTMZfqLRvfeKbDP8a">
+          <Node Name="CustomEditors" Bounds="672,432" Id="EMqqoNTMZfqLRvfeKbDP8a">
             <p:NodeReference>
               <Choice Kind="ClassDefinition" Name="Class" />
               <CategoryReference Kind="Category" Name="Primitive" />
@@ -557,6 +560,7 @@
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="ProcessAppFlag" Name="ObjectEditorFactory" />
                       </p:NodeReference>
+                      <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
                       <Pin Id="S9jZzX59KlfNVvbOYExbqI" Name="Node Context" Kind="InputPin" IsHidden="true" />
                       <Pin Id="DDsUyBrODnrL3o0N5ZJPdb" Name="Output" Kind="StateOutputPin" />
                     </Node>
@@ -720,7 +724,7 @@
               <Link Id="KffwMHD6Oz8P4QQBHHsPi5" Ids="PLsoOxHMu6PLsDcDRJqaTq,R1V83WxDkf9OCOlGVayT1Y" />
             </Patch>
           </Node>
-          <Pad Id="VoSnvWcgfraQXKN0RI27eB" Bounds="811,409,166,21" ShowValueBox="true" isIOBox="true" Value="&lt; See inside for details.">
+          <Pad Id="VoSnvWcgfraQXKN0RI27eB" Bounds="811,409,207,20" ShowValueBox="true" isIOBox="true" Value="&lt; See inside for details. Uses &gt;">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -764,6 +768,15 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
+          <Node Bounds="1019,402,105,19" Id="H8SRmiwTxqvPGWxG2X8Lih">
+            <p:NodeReference LastCategoryFullName="ImGui.Editors" LastDependency="VL.ImGui.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="ObjectEditorFactory" />
+            </p:NodeReference>
+            <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
+            <Pin Id="Kg7OChaYZbaNsPBfl5MqVW" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="RnGHs4JSz9wNW650XjUoNf" Name="Output" Kind="StateOutputPin" />
+          </Node>
         </Canvas>
         <Patch Id="UW88hA2fqg7LZoNKtzr9zq" Name="Create" />
         <Patch Id="P3cyI65ToIFQbpXPQjmEuU" Name="Update" />
@@ -783,5 +796,5 @@
   <NugetDependency Id="NUAlVh63NfHMeT2QiBUiss" Location="VL.ImGui" Version="0.0.0" />
   <NugetDependency Id="DoIESsSEuGbP56YSOYRGF4" Location="VL.ImGui.Skia" Version="0.0.0" />
   <NugetDependency Id="AxkDOnBT980O2NDQiUvBNA" Location="VL.Skia" Version="0.0.0" />
-  <NugetDependency Id="QfvQbbBTwC7PlJHrdaYCIk" Location="VL.UI.Core" Version="2021.4.0-0394-g605995049f" />
+  <NugetDependency Id="QfvQbbBTwC7PlJHrdaYCIk" Location="VL.UI.Core" Version="2024.6.4" />
 </Document>


### PR DESCRIPTION
# PR Details

See Title.

## Description

Adds help flag for ObjectEditor to HowTo Build A Custom Editor.vl.
Added a "dummy" ObjectEditorFactory node to the patch to be able to set the help flag for it since
adding the flag to the node that is uses inside the CustomEditors class didn't work.

![image](https://github.com/user-attachments/assets/e1460c71-2116-4212-9c28-643b16310e14)


## Motivation and Context

ObjectEditor and ObjectEditorFactory had no help patch associated. 
Searching for ObjectEditor in help browser yielded no results.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

