### PR TITLE
TextureFX deal with block compressed dds textures

### DIFF
--- a/VL.Stride.Runtime/src/Graphics/TextureExtensions.cs
+++ b/VL.Stride.Runtime/src/Graphics/TextureExtensions.cs
@@ -45,7 +45,6 @@ namespace VL.Stride.Graphics
         public static bool IsBlockCompressed(this StridePixelFormat format)
         {
             return format.ToString().Contains("BC");
-
         }
 
         /// <summary>

--- a/VL.Stride.Runtime/src/Graphics/TextureExtensions.cs
+++ b/VL.Stride.Runtime/src/Graphics/TextureExtensions.cs
@@ -41,6 +41,13 @@ namespace VL.Stride.Graphics
             return false;
         }
 
+
+        public static bool IsBlockCompressed(this StridePixelFormat format)
+        {
+            return format.ToString().Contains("BC");
+
+        }
+
         /// <summary>
         /// Copies the <paramref name="fromData"/> to the given <paramref name="texture"/> on GPU memory.
         /// </summary>

--- a/VL.Stride.Runtime/src/Graphics/TextureExtensions.cs
+++ b/VL.Stride.Runtime/src/Graphics/TextureExtensions.cs
@@ -41,12 +41,6 @@ namespace VL.Stride.Graphics
             return false;
         }
 
-
-        public static bool IsBlockCompressed(this StridePixelFormat format)
-        {
-            return format.ToString().Contains("BC");
-        }
-
         /// <summary>
         /// Copies the <paramref name="fromData"/> to the given <paramref name="texture"/> on GPU memory.
         /// </summary>

--- a/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.TextureFX.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.TextureFX.cs
@@ -373,12 +373,16 @@ namespace VL.Stride.Rendering
                                     var desc = (size: defaultSize, format: defaultFormat, renderFormat: defaultRenderFormat);
                                     if (inputTexture != null)
                                     {
+
                                         // Base it on the input texture if it is not block compressed (BC1 - B7)
-                                        var viewFormat = (inputTexture.ViewFormat.IsCompressed(), inputTexture.ViewFormat.IsSRgb()) switch
+                                        var viewFormat = inputTexture.ViewFormat;
+
+                                        viewFormat = (viewFormat.IsCompressed(), viewFormat.IsSRgb(), viewFormat.IsHDR()) switch
                                         {
-                                            (false, _) => inputTexture.ViewFormat,
-                                            (true, false) => PixelFormat.R8G8B8A8_UNorm,
-                                            (true, true) => PixelFormat.R8G8B8A8_UNorm_SRgb
+                                            (false, _, _) => viewFormat,
+                                            (true, false, false) => PixelFormat.R8G8B8A8_UNorm,
+                                            (true, true, false) => PixelFormat.R8G8B8A8_UNorm_SRgb,
+                                            (true, _, true) => PixelFormat.R16G16B16A16_Float
                                         };
                                       
                                         // Figure out render format

--- a/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.TextureFX.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.TextureFX.cs
@@ -373,8 +373,9 @@ namespace VL.Stride.Rendering
                                     var desc = (size: defaultSize, format: defaultFormat, renderFormat: defaultRenderFormat);
                                     if (inputTexture != null)
                                     {
-                                        // Base it on the input texture
-                                        var viewFormat = inputTexture.ViewFormat;
+                                        // Base it on the input texture if it is not block compressed (BC1 - B7)
+                                        var viewFormat = inputTexture.ViewFormat.IsBlockCompressed() ? PixelFormat.R8G8B8A8_UNorm_SRgb : inputTexture.ViewFormat;
+
 
                                         // Figure out render format
                                         if (!shaderMetadata.IsTextureSource && shaderMetadata.DontConvertToSRgbOnOnWrite)

--- a/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.TextureFX.cs
+++ b/VL.Stride.Runtime/src/Rendering/Effects/EffectShaderNodes.TextureFX.cs
@@ -374,9 +374,13 @@ namespace VL.Stride.Rendering
                                     if (inputTexture != null)
                                     {
                                         // Base it on the input texture if it is not block compressed (BC1 - B7)
-                                        var viewFormat = inputTexture.ViewFormat.IsBlockCompressed() ? PixelFormat.R8G8B8A8_UNorm_SRgb : inputTexture.ViewFormat;
-
-
+                                        var viewFormat = (inputTexture.ViewFormat.IsCompressed(), inputTexture.ViewFormat.IsSRgb()) switch
+                                        {
+                                            (false, _) => inputTexture.ViewFormat,
+                                            (true, false) => PixelFormat.R8G8B8A8_UNorm,
+                                            (true, true) => PixelFormat.R8G8B8A8_UNorm_SRgb
+                                        };
+                                      
                                         // Figure out render format
                                         if (!shaderMetadata.IsTextureSource && shaderMetadata.DontConvertToSRgbOnOnWrite)
                                         {


### PR DESCRIPTION
# PR Details

Currently TextureFX can not deal with block compressed dds (BC1 - B7) textures.  This PR aims to remedy that.


## Description

When loading block compressed dds textures with the _ImagePlayer_ they get output in their original _PixelFormat_ e.g. `BC7_UNorm_SRgb  `(as opposed to loading with _FileTexture_ which will "convert" the texture to `R8G8B8A8_UNorm_SRgb`). 
These compressed formats cause issues with TextureFX since they create theit ouput texture based on the input texture _PixelFormat_. BC formats are not valid in that context leading to an exception:
![image](https://github.com/user-attachments/assets/6f6efc44-1cdc-4f75-af8d-e91259396431)

This PR adds a extension method to _Stride.Graphics.PixelFormat_ that checks if the format uses block compression (TextureExtensions.cs).
This method is then used by TextureFX  (EffectShaderNodes.TextureFX.cs) to determine if their input is block compressed if so the output texture is created with 
`PixelFormat.R8G8B8A8_UNorm_SRgb`(which is also the Default for TextureFX sources) instead of the input _PixelFormat_ . 


## Related Issue

https://discourse.vvvv.org/t/tfx-dont-work-with-bc7-encoded-textures/22864

## Motivation and Context

See Description.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation