### PR TITLE
Adds RenderDocManager and --debug-gpu commandline flag

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,6 +74,7 @@
     <PackageVersion Include="Stride.UI" Version="$(StrideVersion)" />
     <PackageVersion Include="Stride.Video" Version="$(StrideVersion)" />
     <PackageVersion Include="Stride.VirtualReality" Version="$(StrideVersion)" />
+    <PackageVersion Include="Stride.Graphics.RenderDocPlugin" Version="$(StrideVersion)" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="TeamCity.VSTest.TestAdapter" Version="1.0.38" />
     <PackageVersion Include="WebSocketSharp" Version="1.0.3-rc11" />

--- a/VL.Stride.Runtime/VL.Stride.Rendering.vl
+++ b/VL.Stride.Runtime/VL.Stride.Rendering.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="PwY6LKPeo6iO0yovVrdC7t" LanguageVersion="2024.6.7-0136-ga34ff89f71" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="PwY6LKPeo6iO0yovVrdC7t" LanguageVersion="2024.6.7-0195-gbeba45077f" Version="0.128">
   <NugetDependency Id="RpPAo2Mz2hINnzdyPwCgpq" Location="VL.CoreLib" Version="2021.4.10-1007-g66c84f8e50" />
   <Patch Id="J2Vq6inJsyVOtMcCMNylcQ">
     <Canvas Id="JSu0taSJ8rOOa9Gx7GIL6b" DefaultCategory="Stride" CanvasType="FullCategory">
@@ -866,6 +866,96 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="MVum37covj2M2xMLZRZhvy" Name="Output" Kind="OutputPin" Bounds="566,470" />
+            </Patch>
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ RenderDocManager ************************
+
+-->
+        <Node Name="RenderDocManager" Bounds="320,476" Id="Un4iSgbhqB1PHKf3iDLO2U">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+            <Choice Kind="ContainerDefinition" Name="Process" />
+          </p:NodeReference>
+          <Patch Id="DwTzmfmh293Pd2uLLYTYR9">
+            <Canvas Id="PM6ApMVYXnoMcxO3bemic9" CanvasType="Group">
+              <Node Bounds="342,414,94,26" Id="HEhIPv1eG9mLVLbEyJp4U1">
+                <p:NodeReference LastCategoryFullName="VL.Stride.Games.VLGame" LastDependency="VL.Stride.Runtime.dll">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="AssemblyCategory" Name="VLGame" />
+                  <Choice Kind="OperationCallFlag" Name="SetCaptureFrame" />
+                </p:NodeReference>
+                <Pin Id="FA3XDtMzlxVL8nADM4Fxps" Name="Input" Kind="StateInputPin" />
+                <Pin Id="VVnQYU4hoTWNssWoc6YKxx" Name="Value" Kind="InputPin" />
+                <Pin Id="KtDmqtJQQAcMMEa7AmYZXK" Name="Output" Kind="StateOutputPin" />
+              </Node>
+              <Node Bounds="452,363,65,19" Id="E8pnftqT6HAQMHG2k1ErfR">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="MonoFlop (FrameBased)" />
+                </p:NodeReference>
+                <Pin Id="DnGEeEDFU9vLWAcfuil2ix" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="DzfYQSHFDl2Oh5TrdJ2b8Y" Name="Set" Kind="InputPin" />
+                <Pin Id="BV6iVMomEEqNbHDRJAfN7J" Name="Frames" Kind="InputPin" />
+                <Pin Id="LJD9mMeP2fAPn2KvZE0MIY" Name="Retriggerable" Kind="InputPin" />
+                <Pin Id="TvyjvH89vJqPU27TEzY60U" Name="Reset" Kind="InputPin" />
+                <Pin Id="M5CKHuE95pWPNFPybqHeI3" Name="Value" Kind="OutputPin" />
+                <Pin Id="KA47yntIUmRMljlqSIotVv" Name="Inverse Output" Kind="OutputPin" />
+                <Pin Id="NEuIUZyd6uoLKSUMhoAfc3" Name="Current Frame" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="K3Brt4hoQvYMydpThv57JU" Bounds="474,337" />
+              <Node Bounds="452,270,56,19" Id="Kx2mIPY3h9YOGWZ6yKNJmm">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="TogEdge" />
+                </p:NodeReference>
+                <Pin Id="CvH7t1cPeWPOSRSqDD04Wq" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="Rkm8ckGoRu6L19sKqjmYXv" Name="Value" Kind="InputPin" />
+                <Pin Id="QUFcLIxvFsyMH5ve417ECI" Name="Up Edge" Kind="OutputPin" />
+                <Pin Id="HGBhJKveBLVPZNOcBMuYNq" Name="Down Edge" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="342,215,42,19" Id="Fj1E2gKvJe8QQtuMLdYhxX">
+                <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.Games.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
+                    <p:OuterCategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
+                  </CategoryReference>
+                  <Choice Kind="ProcessAppFlag" Name="Game" />
+                </p:NodeReference>
+                <Pin Id="RfcCjuhZhrUQB7YXn6JGVS" Name="Output" Kind="OutputPin" />
+                <Pin Id="PulwT1pLQbeO6sZf9vH34C" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              </Node>
+              <Node Bounds="342,270,48,19" Id="JZQe0SYB9dQMK6lMbFMWLt">
+                <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="CastAs" />
+                </p:NodeReference>
+                <Pin Id="DfEfWFUEkyZPrAbRn7sau0" Name="Input" Kind="StateInputPin" />
+                <Pin Id="L9DZR8bHg12NX46Jpd7aUq" Name="Default" Kind="InputPin" />
+                <Pin Id="GPF0TkB74UULZycg6n8qV5" Name="Result" Kind="OutputPin" />
+                <Pin Id="P43hqQXXqkwOVlF1yypFvZ" Name="Success" Kind="OutputPin" />
+              </Node>
+              <Pad Id="CnUGKvsYzcZNOttNOfU7c1" Bounds="344,337" />
+              <ControlPoint Id="Apbg5dFOtMnOLLTURjNLXt" Bounds="454,240" />
+            </Canvas>
+            <ProcessDefinition Id="SD537hjt6CAQEMCshbczHn">
+              <Fragment Id="FbDefkZI5cLLIM14Pp3cOH" Patch="VcpxI65nQzYQC9USqjSfT4" Enabled="true" />
+              <Fragment Id="E0XO1TgVGtSM3FDKjFNOLm" Patch="CiyEm1ZV4v4OMczOZjF2jo" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="RZqTnlc3KSiNPIQoLStb3N" Ids="K3Brt4hoQvYMydpThv57JU,BV6iVMomEEqNbHDRJAfN7J" />
+            <Link Id="NRVH4L6Of7rNfpnpb4rvoV" Ids="K0WXvY1zbgcLjxthoV091k,K3Brt4hoQvYMydpThv57JU" IsHidden="true" />
+            <Link Id="Q3AoiIXo8r7MZmTNV4cZC2" Ids="QUFcLIxvFsyMH5ve417ECI,DzfYQSHFDl2Oh5TrdJ2b8Y" />
+            <Link Id="SW9hATpXaH7MFjKQB7WXdD" Ids="M5CKHuE95pWPNFPybqHeI3,VVnQYU4hoTWNssWoc6YKxx" />
+            <Link Id="GW0epycvhWlNL4WBK3wVtc" Ids="RfcCjuhZhrUQB7YXn6JGVS,DfEfWFUEkyZPrAbRn7sau0" />
+            <Link Id="SsB6xLIbzQSO9a7xrnSzfh" Ids="CnUGKvsYzcZNOttNOfU7c1,FA3XDtMzlxVL8nADM4Fxps" />
+            <Link Id="MZbT4BCVWttLnvw6bkew68" Ids="GPF0TkB74UULZycg6n8qV5,CnUGKvsYzcZNOttNOfU7c1" />
+            <Link Id="HQLmThchMDFPBXbALLt507" Ids="Apbg5dFOtMnOLLTURjNLXt,Rkm8ckGoRu6L19sKqjmYXv" />
+            <Link Id="SPpx5G1ihjJNopGznR7XWt" Ids="KGqzK26KKnfPtgdQa2RdDr,Apbg5dFOtMnOLLTURjNLXt" IsHidden="true" />
+            <Patch Id="VcpxI65nQzYQC9USqjSfT4" Name="Create" ParticipatingElements="GW0epycvhWlNL4WBK3wVtc" />
+            <Patch Id="CiyEm1ZV4v4OMczOZjF2jo" Name="Update">
+              <Pin Id="KGqzK26KKnfPtgdQa2RdDr" Name="Capture Next Frame" Kind="InputPin" Bounds="458,243" />
+              <Pin Id="K0WXvY1zbgcLjxthoV091k" Name="Number Frames to Capture" Kind="InputPin" Bounds="511,164" />
             </Patch>
           </Patch>
         </Node>

--- a/VL.Stride.Runtime/src/Games/VLGame.cs
+++ b/VL.Stride.Runtime/src/Games/VLGame.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using VL.Core;
+using VL.Stride.Core;
 using VL.Stride.Engine;
 using VL.Stride.Rendering;
 
@@ -21,6 +22,8 @@ namespace VL.Stride.Games
         private bool forceElapsedTimeToZero;
 
         internal readonly SchedulerSystem SchedulerSystem;
+        public bool CaptureFrame { get; set; }
+        private bool captureInProgress;
         private readonly NodeFactoryRegistry NodeFactoryRegistry;
 
         internal event EventHandler BeforeDestroy;
@@ -165,6 +168,13 @@ namespace VL.Stride.Games
             // Ensure all the paths referenced by VL are visible to the effect system
             UpdateShaderPaths(NodeFactoryRegistry);
 
+            if (CaptureFrame)
+            {
+                CaptureFrame = false;
+                RenderDocConnector.RenderDocManager?.StartFrameCapture(GraphicsDevice, IntPtr.Zero);
+                captureInProgress = true;
+            }
+
             base.Update(gameTime);
         }
 
@@ -180,6 +190,12 @@ namespace VL.Stride.Games
             finally
             {
                 PendingPresentCalls.Clear();
+
+                if (captureInProgress)
+                {
+                    captureInProgress = false;
+                    RenderDocConnector.RenderDocManager?.EndFrameCapture(GraphicsDevice, IntPtr.Zero);
+                }
             }
         }
 

--- a/VL.Stride.Runtime/src/Initialization.cs
+++ b/VL.Stride.Runtime/src/Initialization.cs
@@ -29,6 +29,27 @@ using ServiceRegistry = global::Stride.Core.ServiceRegistry;
 
 namespace VL.Stride.Core
 {
+    public static class RenderDocConnector
+    {
+        public static RenderDocManager RenderDocManager;
+        // The static ctor runs before the module initializer
+
+        [ModuleInitializer] //needs to be called before any Skia code is called by the vvvv UI
+        public static void Initialize()
+        {
+            if (Array.Exists(Environment.GetCommandLineArgs(), argument => argument == "--debug-gpu"))
+            {
+                var renderDocManager = new RenderDocManager();
+
+                if (!renderDocManager.IsInitialized)
+                    renderDocManager.Initialize();
+
+                if (renderDocManager.IsInitialized)
+                    RenderDocManager = renderDocManager;
+            }
+        }
+    }
+
     public sealed class Initialization : AssemblyInitializer<Initialization>
     {
         public static string GetPathToAssetDatabase()

--- a/VL.Stride.Runtime/src/VL.Stride.Runtime.csproj
+++ b/VL.Stride.Runtime/src/VL.Stride.Runtime.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Stride.UI" />
     <PackageReference Include="Stride.Video" />
     <PackageReference Include="Stride.VirtualReality" />
+	<PackageReference Include="Stride.Graphics.RenderDocPlugin" />
   </ItemGroup>
   <Target Name="IncludeStridePackageContent" BeforeTargets="InferPackageContents" DependsOnTargets="_StridePrepareAssetsForPack">
     <Message Importance="high" Text="Called Stride package targets" />

--- a/VL.Stride/src/Initialization.cs
+++ b/VL.Stride/src/Initialization.cs
@@ -58,6 +58,10 @@ namespace VL.Stride.Lib
             {
                 var game = new VLGame(appHost.NodeFactoryRegistry).DisposeBy(appHost);
 
+                // Check for --debug-gpu commandline flag to load debug graphics device
+                if (Array.Exists(Environment.GetCommandLineArgs(), argument => argument == "--debug-gpu"))
+                    game.GraphicsDeviceManager.DeviceCreationFlags |= DeviceCreationFlags.Debug;
+
                 var assetBuildService = new AssetBuilderServiceScript();
                 game.Services.AddService(assetBuildService);
                 game.Services.AddService(appHost.Factory);
@@ -124,6 +128,8 @@ namespace VL.Stride.Lib
                     // Remove the message filter
                     if (messageFilter != null)
                         Application.RemoveMessageFilter(messageFilter);
+
+                    game.Services.GetService<RenderDocManager>()?.RemoveHooks();
                 };
 
                 return ResourceProvider.Return<Game>(game);


### PR DESCRIPTION
# PR Details

Adds RenderDocManager node and `--debug-gpu` command line flag.

## Description

Adds automatic frame capture for RenderDoc in vvvv. RenderDoc can then connect to the running vvvv instance, view the captures, and listen for new captures. 

![image](https://github.com/user-attachments/assets/3437b473-ed15-4a3b-91c2-223923dd28c7)

To get the call hierarchy the Stride Profiler needs to be enabled with F3 on any Stride output window.

<img width="923" alt="image" src="https://github.com/user-attachments/assets/3a3f0963-792f-48bb-ac9d-ab8b230df1cc">


## Motivation and Context


Debug GPU calls and shaders in large projects.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation
