### PR TITLE
Feature/asset url optional output

### DIFF
--- a/VL.Stride.Windows/VL.Stride.Assets.Windows.vl
+++ b/VL.Stride.Windows/VL.Stride.Assets.Windows.vl
@@ -6863,7 +6863,7 @@
           </p:NodeReference>
           <Patch Id="GF6YzyYzfF0PZvRcJd02Cr">
             <Canvas Id="Vyrzy6rKlXBNahPa0nC4Un" CanvasType="Group">
-              <Node Bounds="381,294,419,398" Id="NTmqgosLR0ELCvd7XHq4AJ">
+              <Node Bounds="381,294,429,398" Id="NTmqgosLR0ELCvd7XHq4AJ">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -6881,7 +6881,7 @@
                 <Patch Id="Rjlh4EY5EOZPH216jGEZ2T" ManuallySortedPins="true">
                   <Patch Id="GDlutUGnh5KNdvK834Emgx" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="UHc5EcYckhSOOmarjXpsdG" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="469,479,291,175" Id="OOXzU5Md12rPG68z0xTGeV">
+                  <Node Bounds="469,479,319,175" Id="OOXzU5Md12rPG68z0xTGeV">
                     <p:NodeReference LastCategoryFullName="Stride.Assets" LastDependency="VL.Stride.Assets.Windows.vl">
                       <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
                       <Choice Kind="ProcessAppFlag" Name="RuntimeAsset" />
@@ -6912,7 +6912,7 @@
                         <Pin Id="J4sflNgCh0dQNPNjitIQ6R" Name="Type" Kind="InputPin" />
                         <Pin Id="D34mYhb7opILy8B3VODVtd" Name="Asset" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="621,565,122,19" Id="BuBjpvNVkPROSCZSxnhoLx">
+                      <Node Bounds="621,565,155,19" Id="BuBjpvNVkPROSCZSxnhoLx">
                         <p:NodeReference LastCategoryFullName="Stride.Assets" LastDependency="VL.Stride.Assets.Windows.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="CreateNormalMapTextureType" />
@@ -6922,7 +6922,7 @@
                       </Node>
                     </Patch>
                   </Node>
-                  <Node Bounds="643,375,65,26" Id="Nl1hIXyCqtLLnIBdiNN8CJ">
+                  <Node Bounds="643,375,90,26" Id="Nl1hIXyCqtLLnIBdiNN8CJ">
                     <p:NodeReference LastCategoryFullName="System.ValueTuple`3" LastDependency="mscorlib.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Create" />
@@ -6945,7 +6945,7 @@
                     <Pin Id="TUJ2CWLkeKNLjAEyJmBMaI" Name="Directory" Kind="OutputPin" />
                     <Pin Id="LWmfBn4bZaMO4UnwCA8Rb5" Name="Name" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="439,379" Id="JI3bI44Q6w8PRuQ2MajTDY">
+                  <Node Bounds="439,379,59,26" Id="JI3bI44Q6w8PRuQ2MajTDY">
                     <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Path" NeedsToBeDirectParent="true">
@@ -6957,6 +6957,7 @@
                     <Pin Id="KilZVmYxEmHLdl3WG5GAVT" Name="Exists" Kind="OutputPin" />
                   </Node>
                 </Patch>
+                <ControlPoint Id="N5DEvFw3Y3nN7NwFs39ZFK" Bounds="794,686" Alignment="Bottom" />
               </Node>
               <ControlPoint Id="SIKPtLamhlBN8BCkPTSiuR" Bounds="393,215" />
               <ControlPoint Id="MZlY5T0gtrLL1ohYUbAUYa" Bounds="758,248" />
@@ -6978,6 +6979,7 @@
                 <Pin Id="AVqSoIariayL1Q6FxiIcxO" Name="Loading" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="J7GyIhjk9aeLdweX9LBWAB" Bounds="487,783" />
+              <ControlPoint Id="QMJJk6DLXsmPVj1A9ZM0vS" Bounds="794,722" />
             </Canvas>
             <ProcessDefinition Id="GV6qcLYuft4PZ1F2FdKWFm">
               <Fragment Id="M8c7h4AuZ8PLXZfrTHrRnw" Patch="EB6SL0a7NMkPV9UCjzBKIE" Enabled="true" />
@@ -7040,7 +7042,11 @@
               </Pin>
               <Pin Id="RD13IKjLQYlM2g4Pii7B5g" Name="Is Loading" Kind="OutputPin" Bounds="654,757" />
               <Pin Id="SB8rH0qjQLTOTpgClDbKpa" Name="Already Loaded" Kind="OutputPin" Bounds="993,580" />
+              <Pin Id="LPQBCY8Q1E0MydCSiwq0VV" Name="Url" Kind="OutputPin" Visibility="Optional" />
             </Patch>
+            <Link Id="MEIf1zMAeCsOg10GZ4Dgl6" Ids="Kpi1tEIR8EpL4ncxeWkIK4,N5DEvFw3Y3nN7NwFs39ZFK" />
+            <Link Id="H0GPpwvzl8ML8xgG371orR" Ids="N5DEvFw3Y3nN7NwFs39ZFK,QMJJk6DLXsmPVj1A9ZM0vS" />
+            <Link Id="BM4iez7MWe2LYUIkoftYRC" Ids="QMJJk6DLXsmPVj1A9ZM0vS,LPQBCY8Q1E0MydCSiwq0VV" IsHidden="true" />
           </Patch>
         </Node>
         <!--

--- a/VL.Stride.Windows/VL.Stride.Assets.Windows.vl
+++ b/VL.Stride.Windows/VL.Stride.Assets.Windows.vl
@@ -7060,7 +7060,7 @@
           </p:NodeReference>
           <Patch Id="BEQ5pTziNvsOumZctdCRZ2">
             <Canvas Id="F80NwEkFebqNTsC77nAXyg" CanvasType="Group">
-              <Node Bounds="387,258,366,365" Id="RCc0jJQ6Ly0LZxn4sDBzbS">
+              <Node Bounds="387,258,398,366" Id="RCc0jJQ6Ly0LZxn4sDBzbS">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -7070,7 +7070,7 @@
                 <Pin Id="NLTv8rsHeyKPplBGYPFYVf" Name="Dispose Cached Outputs" Kind="InputPin" />
                 <Pin Id="JUN4PQMvuvjOyCPhIwvgOQ" Name="Has Changed" Kind="OutputPin" />
                 <ControlPoint Id="CY6DbbzUELaLV3fFUfyA3D" Bounds="399,264" Alignment="Top" />
-                <ControlPoint Id="EaxZyic6k50MROouMt4aGh" Bounds="676,617" Alignment="Bottom" />
+                <ControlPoint Id="EaxZyic6k50MROouMt4aGh" Bounds="676,618" Alignment="Bottom" />
                 <ControlPoint Id="IpDG46fe9jhMIVQFdJLEku" Bounds="580,264" Alignment="Top" />
                 <ControlPoint Id="En3vX894nHxMJ09EkKahw1" Bounds="622,264" Alignment="Top" />
                 <ControlPoint Id="FpfFdJFFIzHPWozfJqJq5H" Bounds="660,264" Alignment="Top" />
@@ -7078,7 +7078,7 @@
                 <Patch Id="SwaQS64ytilMPJ7z3cUDCf" ManuallySortedPins="true">
                   <Patch Id="Azafk3JinfJLdOLQKRQpI8" Name="Create" ManuallySortedPins="true" />
                   <Patch Id="HYdrbM1clbBN7hosDpL6gj" Name="Then" ManuallySortedPins="true" />
-                  <Node Bounds="473,451,139,90" Id="AkoYcqVqAOoMUXDfqOd485">
+                  <Node Bounds="473,451,207,90" Id="AkoYcqVqAOoMUXDfqOd485">
                     <p:NodeReference LastCategoryFullName="Stride.Assets" LastDependency="VL.Stride.Assets.Windows.vl">
                       <Choice Kind="ProcessAppFlag" Name="RuntimeAsset" />
                       <Choice Kind="RegionFlag" Name="Region (Stateless)" Fixed="true" />
@@ -7110,7 +7110,7 @@
                       </Node>
                     </Patch>
                   </Node>
-                  <Node Bounds="676,341,65,26" Id="Iiqs3aaTgRoLO0XvK6zKri">
+                  <Node Bounds="676,341,90,26" Id="Iiqs3aaTgRoLO0XvK6zKri">
                     <p:NodeReference LastCategoryFullName="System.ValueTuple`3" LastDependency="mscorlib.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Create" />
@@ -7144,6 +7144,7 @@
                     <Pin Id="QDahMSqiTuGMicEhNoc4jw" Name="Exists" Kind="OutputPin" />
                   </Node>
                 </Patch>
+                <ControlPoint Id="G1J5hxuMkjkOwPGES1iHb4" Bounds="769,618" Alignment="Bottom" />
               </Node>
               <ControlPoint Id="NOztfcn0GnuNJyP2NwbYD8" Bounds="399,217" />
               <ControlPoint Id="BvO0kpqxwCNNTuSFjLo061" Bounds="759,231" />
@@ -7151,7 +7152,7 @@
               <ControlPoint Id="Ob6N5ipkGRoOGKAMoPio36" Bounds="578,179" />
               <ControlPoint Id="D9OYFNt4kMiPyaIdX0J1sb" Bounds="621,200" />
               <ControlPoint Id="Ak8JoY2unVnQMAS8oes2vw" Bounds="659,226" />
-              <Node Bounds="476,664" Id="H3n9vDzi73ENNGSJJJY3PB">
+              <Node Bounds="476,664,66,26" Id="H3n9vDzi73ENNGSJJJY3PB">
                 <p:NodeReference LastCategoryFullName="Stride.API.Assets.AssetWrapper" LastDependency="VL.Stride.Assets.Windows.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="GetValues" />
@@ -7165,6 +7166,7 @@
               </Node>
               <ControlPoint Id="MzG7ZOUn6qqMtGwVMRmxAQ" Bounds="475,747" />
               <ControlPoint Id="LjGel177F8vM4JdKRETmvL" Bounds="559,717" />
+              <ControlPoint Id="HOQyi1XLTION4mrFeMD6T8" Bounds="769,649" />
             </Canvas>
             <ProcessDefinition Id="RmEUIRSzYjDPCMZ0XJ7i4J">
               <Fragment Id="LPu3YixpvKRPrAe9yVb5NI" Patch="KyYnkXRhPzJPIgVgKBxp7w" Enabled="true" />
@@ -7230,7 +7232,11 @@
               </Pin>
               <Pin Id="IzdG6mEe0J4L1yuPxeM3G2" Name="Is Loading" Kind="OutputPin" Bounds="559,717" />
               <Pin Id="B2xCad1Xh29QLAmndU1n5F" Name="Already Loaded" Kind="OutputPin" Bounds="993,580" />
+              <Pin Id="Kpr3o2KmprEP8vNlpJR3Q4" Name="Url" Kind="OutputPin" Visibility="Optional" />
             </Patch>
+            <Link Id="BWAXQSD1Vl0Lb3QZ0eio3T" Ids="HG6SOHd7EnoPgiLJcwfn21,G1J5hxuMkjkOwPGES1iHb4" />
+            <Link Id="KgVaJs3iq76MLu2B6KB3Yh" Ids="G1J5hxuMkjkOwPGES1iHb4,HOQyi1XLTION4mrFeMD6T8" />
+            <Link Id="RJLC4LYvTqqOTS64LMY5Ec" Ids="HOQyi1XLTION4mrFeMD6T8,Kpr3o2KmprEP8vNlpJR3Q4" IsHidden="true" />
           </Patch>
         </Node>
         <!--

--- a/VL.Stride.Windows/VL.Stride.Assets.Windows.vl
+++ b/VL.Stride.Windows/VL.Stride.Assets.Windows.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="OpwXTKxodpcLMuzoaGSQfF" LanguageVersion="2024.6.7-0233-g2086759bc8" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="OpwXTKxodpcLMuzoaGSQfF" LanguageVersion="2024.6.7-0257-g4045fa6755" Version="0.128">
   <NugetDependency Id="F5PUq8fPVCDO1EGFvZJgLA" Location="VL.CoreLib" Version="2021.4.9-0952-g46b30df1f5" />
   <Patch Id="U5v4tfopLKQNbWZ7OZRPST">
     <Canvas Id="JxWjJexiKp3QBRP2vXcX6T" DefaultCategory="Stride" CanvasType="FullCategory">
@@ -6444,7 +6444,7 @@
           </p:NodeReference>
           <Patch Id="TId5YA3NgmRMxkaqL9WsED">
             <Canvas Id="U1HVhzVu8U7PmulUBUM2Tj" CanvasType="Group">
-              <Node Bounds="381,294,425,396" Id="GCecB09Ckh1POQDkKRmC9o">
+              <Node Bounds="381,294,429,396" Id="GCecB09Ckh1POQDkKRmC9o">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -6495,7 +6495,7 @@
                         <Pin Id="AM2VLVGpi5yLtrxph9iL0S" Name="Type" Kind="InputPin" />
                         <Pin Id="NTKA9Jxl9BNN1lvXd6I5Uo" Name="Asset" Kind="OutputPin" />
                       </Node>
-                      <Node Bounds="621,565,122,19" Id="AVJLHCnVl9nN6pIbhNo8Ys">
+                      <Node Bounds="621,565,127,19" Id="AVJLHCnVl9nN6pIbhNo8Ys">
                         <p:NodeReference LastCategoryFullName="Stride.Assets" LastDependency="VL.Stride.Assets.Windows.vl">
                           <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                           <Choice Kind="OperationCallFlag" Name="CreateColorTextureType" />
@@ -6509,7 +6509,7 @@
                       </Node>
                     </Patch>
                   </Node>
-                  <Node Bounds="689,377,85,26" Id="KPPWCHn4oR3N4ZWivywQVp">
+                  <Node Bounds="689,377,105,26" Id="KPPWCHn4oR3N4ZWivywQVp">
                     <p:NodeReference LastCategoryFullName="System.ValueTuple`6" LastDependency="mscorlib.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Create" />
@@ -6535,7 +6535,7 @@
                     <Pin Id="FLVozxIgF6KNcqF0EJV4u0" Name="Directory" Kind="OutputPin" />
                     <Pin Id="Mk7BV7EMd4GNHXLjw5m4Dp" Name="Name" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="449,385" Id="JyHpxVQq7jULPhn01j8Kas">
+                  <Node Bounds="449,385,59,26" Id="JyHpxVQq7jULPhn01j8Kas">
                     <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Path" NeedsToBeDirectParent="true">
@@ -6547,6 +6547,7 @@
                     <Pin Id="If9US0NyTTePrHnGD1H0dk" Name="Exists" Kind="OutputPin" />
                   </Node>
                 </Patch>
+                <ControlPoint Id="UyBpZzGjInINOBkpxV72hw" Bounds="794,684" Alignment="Bottom" />
               </Node>
               <ControlPoint Id="LVGGIo7Cy1LLP9Kw5ckhUy" Bounds="393,215" />
               <ControlPoint Id="QJqKTTbBtnbP5fjFgYobjB" Bounds="758,248" />
@@ -6570,6 +6571,7 @@
                 <Pin Id="EJ8obAg9rHXQXuossAgs5o" Name="Loading" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="VLftdNDHDdjQHVTpUYM8er" Bounds="477,797" />
+              <ControlPoint Id="OzMk0OhY6wtNF8Wt7LABa4" Bounds="794,720" />
             </Canvas>
             <ProcessDefinition Id="IUR9zGSrsiZNWdtZkhxy2h">
               <Fragment Id="EYX2HX8mEgBNN0JLIrra15" Patch="KwErEpjj6gmLBRhighORoF" Enabled="true" />
@@ -6655,7 +6657,11 @@
               </Pin>
               <Pin Id="Ahk3TeoV2dZLs96WzHSo7X" Name="Is Loading" Kind="OutputPin" Bounds="654,757" />
               <Pin Id="E95GDMOAMUmOQwoaS9poio" Name="Already Loaded" Kind="OutputPin" Bounds="993,580" />
+              <Pin Id="Lepwp6H3zTuOeX1Mi7A0Y1" Name="Url" Kind="OutputPin" Visibility="Optional" />
             </Patch>
+            <Link Id="OUA94uJoRcqMNpml4yHDKl" Ids="AQPF8Gj9asxPlz4ycfDzs3,UyBpZzGjInINOBkpxV72hw" />
+            <Link Id="U216jVBPhIVPT015e1d4V5" Ids="UyBpZzGjInINOBkpxV72hw,OzMk0OhY6wtNF8Wt7LABa4" />
+            <Link Id="SnYjFNbVWHcP1qFc2NwkOi" Ids="OzMk0OhY6wtNF8Wt7LABa4,Lepwp6H3zTuOeX1Mi7A0Y1" IsHidden="true" />
           </Patch>
         </Node>
         <!--

--- a/VL.Stride.Windows/VL.Stride.Assets.Windows.vl
+++ b/VL.Stride.Windows/VL.Stride.Assets.Windows.vl
@@ -6675,7 +6675,7 @@
           </p:NodeReference>
           <Patch Id="UdSw2WdMmzqQZV23BNe5A5">
             <Canvas Id="QlLsxkysCgGOqbrf7479Ly" CanvasType="Group">
-              <Node Bounds="381,292,418,398" Id="SttTrd0bLpnP6PY12mM6te">
+              <Node Bounds="381,292,431,398" Id="SttTrd0bLpnP6PY12mM6te">
                 <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessStatefulRegion" Name="Cache" />
@@ -6684,10 +6684,10 @@
                 <Pin Id="DP81YtLaLu1MKg2GHru2Yz" Name="Force" Kind="InputPin" />
                 <Pin Id="PWUK2zCzTRxLhiq2cHAulX" Name="Dispose Cached Outputs" Kind="InputPin" />
                 <Pin Id="Mo0w7pUjMFTLbGSsFGcQvr" Name="Has Changed" Kind="OutputPin" />
-                <ControlPoint Id="D1dmvQSoIrdNdZKtd8zniO" Bounds="393,299" Alignment="Top" />
+                <ControlPoint Id="D1dmvQSoIrdNdZKtd8zniO" Bounds="393,298" Alignment="Top" />
                 <ControlPoint Id="QdUCA5H5kdlMkGhnAbjulU" Bounds="757,684" Alignment="Bottom" />
-                <ControlPoint Id="TpbWN6fMhJHPUx57mnWhiD" Bounds="497,299" Alignment="Top" />
-                <ControlPoint Id="Punuof4nB9VN2YH2YgWMir" Bounds="597,299" Alignment="Top" />
+                <ControlPoint Id="TpbWN6fMhJHPUx57mnWhiD" Bounds="497,298" Alignment="Top" />
+                <ControlPoint Id="Punuof4nB9VN2YH2YgWMir" Bounds="597,298" Alignment="Top" />
                 <ControlPoint Id="CUraVj4QBmtNwfyc8q6sWJ" Bounds="459,684" Alignment="Bottom" />
                 <Patch Id="HeQ48bGU4EKQLUl1dW1LVf" ManuallySortedPins="true">
                   <Patch Id="JuLBuoVDzFJNhnpB9IFArd" Name="Create" ManuallySortedPins="true" />
@@ -6732,7 +6732,7 @@
                       </Node>
                     </Patch>
                   </Node>
-                  <Node Bounds="703,368,65,26" Id="GglrCggdtB5MQ8mIKZEgsG">
+                  <Node Bounds="703,368,90,26" Id="GglrCggdtB5MQ8mIKZEgsG">
                     <p:NodeReference LastCategoryFullName="System.ValueTuple`2" LastDependency="mscorlib.dll">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="Create" />
@@ -6743,7 +6743,7 @@
                     <Pin Id="NT2ncTmWQ2cOdClRR8dEm4" Name="Output" Kind="StateOutputPin" />
                   </Node>
                   <ControlPoint Id="H99M8xtDmVJMPypmOI4mna" Bounds="547,355" />
-                  <Node Bounds="602,405,45,19" Id="OoZfxdi4bmgQdWprrJe3p8">
+                  <Node Bounds="602,405,106,19" Id="OoZfxdi4bmgQdWprrJe3p8">
                     <p:NodeReference LastCategoryFullName="Stride.Assets" LastDependency="VL.Stride.Assets.Windows.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="GetUniqueAssetURL" />
@@ -6754,7 +6754,7 @@
                     <Pin Id="HkBX8vv4wHLOsMrvg44oqk" Name="Directory" Kind="OutputPin" />
                     <Pin Id="TaGBlKwJID3NjKFDd2tFdr" Name="Name" Kind="OutputPin" />
                   </Node>
-                  <Node Bounds="435,359,43,26" Id="DI5VoPhPhOlMZONQxwQdAe">
+                  <Node Bounds="435,359,59,26" Id="DI5VoPhPhOlMZONQxwQdAe">
                     <p:NodeReference LastCategoryFullName="IO.Path" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="Path" NeedsToBeDirectParent="true">
@@ -6766,6 +6766,7 @@
                     <Pin Id="AxgNmbjJHbTOUbMpx9nxHa" Name="Exists" Kind="OutputPin" />
                   </Node>
                 </Patch>
+                <ControlPoint Id="Mqx7N7TXSyMNPDyGfGHEA8" Bounds="796,684" Alignment="Bottom" />
               </Node>
               <ControlPoint Id="Vgx3kns1LehMyE2oSGFygH" Bounds="393,215" />
               <ControlPoint Id="FV58QPtNDsFNJAtOgzSC5X" Bounds="758,248" />
@@ -6786,6 +6787,7 @@
                 <Pin Id="OvGkTHIW5oIPoChW1HG7bM" Name="Loading" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="UIBymTwXNwNMtEdleni3Ow" Bounds="488,792" />
+              <ControlPoint Id="LMSHwrM3JhDQc1vkdDsEB7" Bounds="796,727" />
             </Canvas>
             <ProcessDefinition Id="OR74ZgNhUYgPxRIgj8PaZG">
               <Fragment Id="RgtwnPDkiTvLAINPHFSU6a" Patch="ABLWZm5WjeUMjavzFGrGT7" Enabled="true" />
@@ -6843,7 +6845,11 @@
               </Pin>
               <Pin Id="JKpd9t3ftMXOZmiE4BC7Yy" Name="Is Loading" Kind="OutputPin" Bounds="654,757" />
               <Pin Id="OestZHO90XOMpGblmGIRr8" Name="Already Loaded" Kind="OutputPin" Bounds="993,580" />
+              <Pin Id="SoHrTBkFla3Mr6u22fqdbc" Name="Url" Kind="OutputPin" Visibility="Optional" />
             </Patch>
+            <Link Id="QiL7VFwA5JROnIzFFOTv0S" Ids="J2q82Bs9EdAOgjbDb5zgKO,Mqx7N7TXSyMNPDyGfGHEA8" />
+            <Link Id="LosKbYpCyBCLQOZ7oyIthD" Ids="Mqx7N7TXSyMNPDyGfGHEA8,LMSHwrM3JhDQc1vkdDsEB7" />
+            <Link Id="OIXggEpilG4O0kE7SkrZCd" Ids="LMSHwrM3JhDQc1vkdDsEB7,SoHrTBkFla3Mr6u22fqdbc" IsHidden="true" />
           </Patch>
         </Node>
         <!--


### PR DESCRIPTION
# PR Details

Adds an optional `Url` output pin to asset loading nodes.

## Description

This PR adds an optional `Url` pin to the following nodes :

- `FileTexture`
- `FileTextureGrayscale`
- `FileTextureNormalMap`
- `FileModel`

This pin returns the computed asset Url. The added link is highlighted in the following screenshot :

<img src=https://github.com/user-attachments/assets/7613ddf5-1379-4c71-9f6e-0f1f2782a467 width=512/>

From the outside, after enabling the `Url` pin via Configure, the user would see the following :

<img src=https://github.com/user-attachments/assets/3065ead2-3c09-4dd1-bd5d-2de51130f422 width=512/>


## Related Issue

_None_

## Motivation and Context

Getting the asset Url would allow to query the asset manager to see if this asset has already been loaded, or in use somewhere in the running application.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation