### PR TITLE
[Stride] Updates to latest version (4.2.0.2293)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <!--To run with locally built Stride packages, set the corresponding version here and adapt package-mapping in NuGet.config-->
-    <StrideVersion>4.2.0.2232</StrideVersion>
+    <StrideVersion>4.2.0.2293</StrideVersion>
     <RoslynPkgVersion>4.8.0</RoslynPkgVersion>
-    <NuGetPackageVersion>6.8.1</NuGetPackageVersion>
+    <NuGetPackageVersion>6.12.1</NuGetPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AudioSwitcher.AudioApi.CoreAudio" Version="4.0.0-alpha5" />

--- a/VL.Stride.Runtime/src/Rendering/CommandListExt.cs
+++ b/VL.Stride.Runtime/src/Rendering/CommandListExt.cs
@@ -1,0 +1,16 @@
+﻿using Stride.Graphics;
+using System.Runtime.CompilerServices;
+
+namespace VL.Stride.Rendering
+{
+    internal static class CommandListExt
+    {
+        internal static void UpdateSubresource(this CommandList commandList, GraphicsResource resource, int subResourceIndex, DataBox databox)
+        {
+            UpdateSubresource(commandList, resource, subResourceIndex, databox);
+
+            [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(UpdateSubresource))]
+            extern static void UpdateSubresource(CommandList commandList, GraphicsResource resource, int subResourceIndex, DataBox databox);
+        }
+    }
+}

--- a/VL.Stride.Runtime/src/Rendering/Materials/MaterialNodes.cs
+++ b/VL.Stride.Runtime/src/Rendering/Materials/MaterialNodes.cs
@@ -8,6 +8,7 @@ using Stride.Rendering.Materials.ComputeColors;
 using Stride.Shaders;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reactive.Disposables;
 using VL.Core;
 using VL.Lib.Basics.Resources;
@@ -97,6 +98,7 @@ namespace VL.Stride.Rendering.Materials
                 .AddCachedInput(nameof(MiscAttributes.Transparency), x => x.Transparency, (x, v) => x.Transparency = v)
                 .AddCachedInput(nameof(MiscAttributes.Overrides), x => x.Overrides, (x, v) => x.Overrides = v)
                 .AddCachedInput(nameof(MiscAttributes.CullMode), x => x.CullMode, (x, v) => x.CullMode = v, CullMode.Back)
+                .AddCachedInput(nameof(MiscAttributes.DepthFunction), x => x.DepthFunction, (x, v) => x.DepthFunction = v, CompareFunction.Less)
                 .AddCachedInput(nameof(MiscAttributes.ClearCoat), x => x.ClearCoat, (x, v) => x.ClearCoat = v);
             yield return NewMaterialNode<MaterialOcclusionMapFeature>(nodeFactory, "Occlusion", miscCategory);
             yield return NewMaterialNode<MaterialTransparencyAdditiveFeature>(nodeFactory, "Additive", transparencyCategory);
@@ -242,6 +244,7 @@ namespace VL.Stride.Rendering.Materials
                 Transparency = Misc?.Transparency,
                 Overrides = { UVScale = Misc?.Overrides?.UVScale ?? @default.Overrides.UVScale },
                 CullMode = Misc?.CullMode ?? @default.CullMode,
+                DepthFunction = Misc?.DepthFunction ?? @default.DepthFunction,
                 ClearCoat = Misc?.ClearCoat
             };
         }
@@ -491,6 +494,13 @@ namespace VL.Stride.Rendering.Materials
         /// </summary>
         /// <userdoc>Cull some faces of the model depending on orientation</userdoc>
         public CullMode CullMode { get; set; }
+
+        /// <summary>
+        /// The test used to figure out whether the material should be drawn when behind other models
+        /// </summary>
+        /// <userdoc>The test used to figure out whether the material should be drawn when behind other models</userdoc>
+        [DefaultValue(CompareFunction.Less)]
+        public CompareFunction DepthFunction { get; set; } = CompareFunction.Less;
 
         /// <summary>
         /// Gets or sets the clear coat shading features for the material.

--- a/VL.Stride.Runtime/src/Rendering/VLForwardRenderer.LightProbes.cs
+++ b/VL.Stride.Runtime/src/Rendering/VLForwardRenderer.LightProbes.cs
@@ -245,9 +245,9 @@ namespace VL.Stride.Rendering
                 fixed (Vector4* matrices = lightProbesData.Matrices)
                 fixed (Int4* probeIndices = lightProbesData.LightProbeIndices)
                 {
-                    lightprobesCoefficients.SetData(drawContext.CommandList, new DataPointer((IntPtr)lightProbeCoefficients, lightprobesCoefficients.SizeInBytes));
-                    tetrahedronProbeIndices.SetData(drawContext.CommandList, new DataPointer((IntPtr)probeIndices, tetrahedronProbeIndices.SizeInBytes));
-                    tetrahedronMatrices.SetData(drawContext.CommandList, new DataPointer((IntPtr)matrices, tetrahedronMatrices.SizeInBytes));
+                    drawContext.CommandList.UpdateSubresource(lightprobesCoefficients, 0, new DataBox((IntPtr)lightProbeCoefficients, 0, 0));
+                    drawContext.CommandList.UpdateSubresource(tetrahedronProbeIndices, 0, new DataBox((IntPtr)probeIndices, 0, 0));
+                    drawContext.CommandList.UpdateSubresource(tetrahedronMatrices, 0, new DataBox((IntPtr)matrices, 0, 0));
 
                     // Find which probe we are currently in
                     // TODO: Optimize (use previous coherency info?)

--- a/VL.Stride.Runtime/src/Video/VideoUtils.cs
+++ b/VL.Stride.Runtime/src/Video/VideoUtils.cs
@@ -64,13 +64,7 @@ namespace VL.Stride.Video
         private static Texture AsTexture(VideoTexture videoTexture, GraphicsDevice graphicsDevice)
         {
             var nativeTexture = new Texture2D(videoTexture.NativePointer);
-            var strideTexture = SharpDXInterop.CreateTextureFromNative(graphicsDevice, nativeTexture, takeOwnership: true, isSRgb: false);
-
-            // Undo the ref count increment of an internal QueryInterface call
-            if ((strideTexture.Description.Options & TextureOptions.Shared) != 0)
-                ((SharpDX.IUnknown)nativeTexture).Release();
-
-            return strideTexture;
+            return SharpDXInterop.CreateTextureFromNative(graphicsDevice, nativeTexture, takeOwnership: true, isSRgb: false);
         }
 
         sealed class SRgbTexture : IDisposable


### PR DESCRIPTION
# PR Details

- Change in CoreLib was needed to select proper overload of `ToVector2 [Int2]` (a new one was added in this Stride update)
- Adjusts code around GetData/SetData to use `Span` (`DataPointer` was made obsolete) - opened various help patch dealing with Texture/Buffer down/upload and was all working. So I think the changes are all good.
- Reverts a refcount workaround in video related code - proper fix is now in Stride itself
- Adds new DepthFunction pin to `MiscAttributes [Materials]` - couldn't really figure out how to make use of it though, see https://github.com/stride3d/stride/pull/2415

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation
