### PR TITLE
[Stride] Custom present call

### DIFF
--- a/VL.Stride.Runtime/VL.Stride.Engine.vl
+++ b/VL.Stride.Runtime/VL.Stride.Engine.vl
@@ -29909,6 +29909,7 @@
                 <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
               </p:ValueBoxSettings>
             </Pad>
+            <ControlPoint Id="FgrxzUx1zWDOpm0Bip8nEO" Bounds="851,1115" />
           </Canvas>
           <Link Id="JKnUileeJ7FNJsu7KpPf94" Ids="G7SBfHwE22bMfljT0fnHrW,EEQ60u0n9ATNadblUovIX7" IsHidden="true" />
           <Link Id="ToLCItn5JyDMzpOHiAEnJu" Ids="RzkQ5YRhHQALLkSoQA085R,Hdw9ETxxng9OxCDbLeNcTB" IsHidden="true" />
@@ -29991,6 +29992,7 @@
             <Fragment Id="VRb8ukE1nlbPeRZWewguZc" Patch="JC5zNcazfe5PemN2vFTgvH" Enabled="true" />
             <Fragment Id="IzWNXnYO95QN8WwpoYgyJi" Patch="VnB7dRwuoWoN5IyXhYChtZ" Enabled="true" />
             <Fragment Id="OBVUa3UNeN2O90hR2mG9Ni" Patch="TBD6Xc1bmYhN5YxHX2qcT2" Enabled="true" />
+            <Fragment Id="TC9lmgX5fuAMT9L6Ywdxjl" Patch="V5gZKPsKfVnPPbpzhvpRnl" Enabled="true" />
           </ProcessDefinition>
           <Link Id="BS81b9ULH0MQYXrSiMN1n2" Ids="OOsflcfqABvOwzGSsfvwIp,VghSJuU3XH2O2lcYUdshlp" />
           <Link Id="SoJL1vvHW3DPkRMJvgYxze" Ids="HFWw5ZrzJ1UOHAt7pZfH7T,OOsflcfqABvOwzGSsfvwIp" IsHidden="true" />
@@ -30101,6 +30103,11 @@
           <Link Id="Ul4Gfn0XberLyusUrg60uQ" Ids="PI9BhwnKl5EOSJCYjYec0A,HS8AFTF4GwfOxnmfSb9CJ2" />
           <Link Id="Ikx9GPmYCviMTZzJ6BzOkt" Ids="Rw0E0P8SsZ9LxLwATlWsFq,A3JyzVwHER4LYTM2etXg0Z,S4JJNxbVrcoMiSDkvu6SRb" />
           <Link Id="BRdhXBAd6hoNyp5jKJGU39" Ids="OkLdqSLY5wMLT1SD7KSRDq,UT5YxeVHip6Oby5fzZjFTd" />
+          <Patch Id="V5gZKPsKfVnPPbpzhvpRnl" Name="GameWindowRenderer">
+            <Pin Id="HEJ0TUUtwq9MQxZabRvRn4" MergeId="64220" Name="Game Window Renderer" Kind="OutputPin" Visibility="Optional" />
+          </Patch>
+          <Link Id="DFGN4GB1K93NdkNen9peJM" Ids="FgrxzUx1zWDOpm0Bip8nEO,HEJ0TUUtwq9MQxZabRvRn4" IsHidden="true" />
+          <Link Id="LWQwMH4EgZ9LDB5U4NOhWP" Ids="FLJicPRM1jjNuKEzliy6xy,FgrxzUx1zWDOpm0Bip8nEO" />
         </Patch>
       </Node>
       <!--

--- a/VL.Stride.Runtime/VL.Stride.Engine.vl
+++ b/VL.Stride.Runtime/VL.Stride.Engine.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="UFzEbZy7D3GNY8xnLUU17p" LanguageVersion="2025.7.0-0069-g739776fa63" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="UFzEbZy7D3GNY8xnLUU17p" LanguageVersion="2025.7.0-0078-gedfd4fed5f" Version="0.128">
   <NugetDependency Id="EKAeSpl0TUSO67sl9VuE19" Location="VL.CoreLib" Version="2021.4.12-1361-g53776bfdff" />
   <Patch Id="M3fVx2jjvOSLPGL4EJGFf9">
     <Canvas Id="JugVUmEZoitO7m1cCzT7W3" DefaultCategory="Stride" CanvasType="FullCategory">
@@ -22561,6 +22561,7 @@
                 <Pin Id="M98wEiPNb4JPlbPeF5CzxJ" Name="Input Source" Kind="OutputPin" />
                 <Pin Id="JuAV2mqQgOIPQjOl1Ha15o" Name="Back Buffer" Kind="OutputPin" />
                 <Pin Id="Rw6NsHb3Uu8LYJYrC23MLl" Name="Depth Buffer" Kind="OutputPin" />
+                <Pin Id="CAScjzqr9wQQDEoJKob10i" Name="Game Window Renderer" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="Lp5kt1M2hMpN5Oiga86qiG" Bounds="1428,359" />
               <ControlPoint Id="FdAq8DTTKowLDjjv4KigYR" Bounds="1158,241" />
@@ -26522,6 +26523,7 @@
                 <Pin Id="SMnyQi0ar7oMDogYewCBeo" Name="Input Source" Kind="OutputPin" />
                 <Pin Id="Gh5F4Rb2TO4P15QGELVyug" Name="Back Buffer" Kind="OutputPin" />
                 <Pin Id="NtvIm4N9BUIPL1kD3Urbad" Name="Depth Buffer" Kind="OutputPin" />
+                <Pin Id="HUuujTRPSdGMBehGpnjy81" Name="Game Window Renderer" Kind="OutputPin" />
               </Node>
               <ControlPoint Id="PukR1teAvW5NhcXXfUWwqo" Bounds="265,411" />
               <ControlPoint Id="TvQVSIc1QD4PQoPl3V0VBB" Bounds="297,433" />
@@ -29647,6 +29649,7 @@
               <Pin Id="QzptxYI9x2fPSS37uMQk1w" Name="Input Source" Kind="OutputPin" />
               <Pin Id="S3gzgF5mh3xMvb0DQhN91z" Name="Back Buffer" Kind="OutputPin" />
               <Pin Id="GgA7RAEKzT4PxFF12XjVHd" Name="Depth Buffer" Kind="OutputPin" />
+              <Pin Id="FLJicPRM1jjNuKEzliy6xy" Name="Game Window Renderer" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="DvjFGxnGxaSPTK1FcsQgVt" Bounds="505,1028" />
             <ControlPoint Id="Eki1GrF8SxSLRnbvFtLux0" Bounds="203,880" />
@@ -31471,6 +31474,16 @@
               <Pin Id="O2Gk0YyCqS7ObWpIPYTfWm" Name="Current" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="Ko9uuE6xSYQOKehGYDUwtU" Bounds="149,-240" />
+            <Node Bounds="653,-75,118,26" Id="HG4ehUnqUx0O2luBAuu7jG">
+              <p:NodeReference LastCategoryFullName="Stride.Windowing.GameWindowManager" LastDependency="VL.Stride.Engine.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="GameWindowRenderer" />
+              </p:NodeReference>
+              <Pin Id="OHhdg2GRkVELVGmKSpUKKs" Name="Input" Kind="StateInputPin" />
+              <Pin Id="U16EOcUhUXuNTzduUCplmv" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="HIGSEByx5kuO7OHdErVVq9" Name="Game Window Renderer" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="IIphhGujK3KLSFIYKVXQ25" Bounds="658,-25" />
           </Canvas>
           <Slot Id="PAV2QLEHIawLiiMQjeCSBx" Name="Game Window" />
           <Link Id="V7zVQDv7tilLMv638pLUGg" Ids="Aovd7gXzFIqPW6xwdW7oln,MUiMMxbgDwTMwpBxtCke2j" IsHidden="true" />
@@ -31617,6 +31630,7 @@
             <Fragment Id="JsUk1C1cOr6L1CHQ0YHlXi" Patch="Vmj97POsIV1P1Lc2TuVHEj" />
             <Fragment Id="TY9R43BBB4RN9ZbSLjpveX" Patch="RStOsMz4gHoN3igS9gs3PX" />
             <Fragment Id="Dxki9OHvXSUMUMtKkmXzuK" Patch="G1Kr1lam7kaLmLyJNKwfAf" />
+            <Fragment Id="KwMwVgTcAHAO5Y2jG2tFuX" Patch="IctHqTDnaeCP5gGDPEO3bl" Enabled="true" />
           </ProcessDefinition>
           <Link Id="MsiroA9GNILLt5N74XnrKK" Ids="OI862sAjPluPTiWjiXcnvB,Kxc0JPrhMdNONquxpqH63G" />
           <Link Id="IwK8HOUNRNFPQMDsAxOrAn" Ids="D9xZQrFgJLKOqsHxeLZoH7,Itw9qLp5wddQAYWLmdkBH5" />
@@ -31708,6 +31722,12 @@
           <Link Id="AxfI9qbz7JPQYJAPVzPBXT" Ids="Ko9uuE6xSYQOKehGYDUwtU,PIidFC8nIt4QPiWjP1FGCb" />
           <Link Id="NppoXs4FSBkPXg60dnv8vB" Ids="DtK4T8xqWtHOEbsodBUxWy,Ko9uuE6xSYQOKehGYDUwtU" IsHidden="true" />
           <Link Id="HlO6KYMHUxTNuBa29TjmyL" Ids="DnccpXrES6HLa9Yt0GhhXg,SQuuhVXC8eQQHsbJt25ui9" />
+          <Patch Id="IctHqTDnaeCP5gGDPEO3bl" Name="GameWindowRenderer">
+            <Pin Id="G5mPzn7KS2wNpQo7gmupa6" MergeId="274901" Name="Game Window Renderer" Kind="OutputPin" Visibility="Optional" />
+          </Patch>
+          <Link Id="PBBHHMRRPTqPveiXKDsTt8" Ids="IIphhGujK3KLSFIYKVXQ25,G5mPzn7KS2wNpQo7gmupa6" IsHidden="true" />
+          <Link Id="BM4Bzoj50PqNrQfvMawpWx" Ids="HIGSEByx5kuO7OHdErVVq9,IIphhGujK3KLSFIYKVXQ25" />
+          <Link Id="TXH42o9DIcpPs0GAbLPS4P" Ids="Ijvt2pnk9AqMBE5x1Y8R3G,OHhdg2GRkVELVGmKSpUKKs" />
         </Patch>
       </Node>
       <!--

--- a/VL.Stride.Runtime/VL.Stride.Engine.vl
+++ b/VL.Stride.Runtime/VL.Stride.Engine.vl
@@ -22561,7 +22561,7 @@
                 <Pin Id="M98wEiPNb4JPlbPeF5CzxJ" Name="Input Source" Kind="OutputPin" />
                 <Pin Id="JuAV2mqQgOIPQjOl1Ha15o" Name="Back Buffer" Kind="OutputPin" />
                 <Pin Id="Rw6NsHb3Uu8LYJYrC23MLl" Name="Depth Buffer" Kind="OutputPin" />
-                <Pin Id="CAScjzqr9wQQDEoJKob10i" Name="Game Window Renderer" Kind="OutputPin" />
+                <Pin Id="MfjprE88LGMMZeoSTmAg2U" Name="Present Call Intercept" Kind="InputPin" IsHidden="true" />
               </Node>
               <ControlPoint Id="Lp5kt1M2hMpN5Oiga86qiG" Bounds="1428,359" />
               <ControlPoint Id="FdAq8DTTKowLDjjv4KigYR" Bounds="1158,241" />
@@ -26318,6 +26318,16 @@
                   <Pin Id="CuhFDrf5ARlP5JIlT1mCid" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="ORbGAf9TevZNSfcseWxtmU" Name="Context Type" Kind="OutputPin" />
                 </Node>
+                <Node Bounds="570,1590,121,26" Id="ITssruvl2n0LinJMX1LSML">
+                  <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="SetPresentCallIntercept" />
+                  </p:NodeReference>
+                  <Pin Id="TPOLQhMp4jUMZ1leT4CMRn" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="OeYjrsEICWpOsm9mLwMEv8" Name="Value" Kind="InputPin" />
+                  <Pin Id="SJwrI6L0QsSQBnlfiCftAe" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <ControlPoint Id="OKwW0XytubxPE6dW0CadS3" Bounds="688,1537" />
               </Canvas>
               <Link Id="KU6k8ilhe88PSHGLTisurU" Ids="FgZ58iFc480Omy7xGU7UCP,Ejh34mhLJ0SN7n8YoDT9f0" />
               <Link Id="VJujxDLpOeALpH3xN7Mc7x" Ids="DxI050qzrDWNwaHiG5S4my,NyMXzWN18n4NNPOEu5aYqY" />
@@ -26378,6 +26388,7 @@
                 <Fragment Id="AAOoqZNqO2aK9sBm2JytgW" Patch="LJlovFpHGfvNTZaEhu2RwC" Enabled="true" />
                 <Fragment Id="Rs3W8ZvmWmdMVsxodpbXDN" Patch="MlKI1gR1ZBBQQB4jcAH9hr" />
                 <Fragment Id="DckLGbBnXevOuL3cPhBn0D" Patch="FaVDYKdK40RNHxBwUwLX2w" Enabled="true" />
+                <Fragment Id="COY5kwFBSqNL0H32pNXsPj" Patch="OHG0dDBc1aTLPHSZIIv3uv" Enabled="true" />
               </ProcessDefinition>
               <Slot Id="RcCDkb7QvReMM8H09CrM7N" Name="Game Window Renderer" />
               <Link Id="FCQ5OYbWeTyNwt9j2OOM4a" Ids="JFsI2ECX2UwMUDzlnbEM0D,Mm6fXGFBJFkQcGHfIUERm1" />
@@ -26476,6 +26487,12 @@
               <Link Id="OdZwWlMAbRjP9bgWbyBOtp" Ids="TCcsoVXbeT4Le2spNp50uy,BsdqjslhBb3PB89GPxrdA9" />
               <Link Id="NDwjyvb6SlKNCEumE4DYyk" Ids="EaeCvdF0rPqOFvusMnidwv,O7FQHoT12VNPbEAGNOUfhl" />
               <Link Id="Sye7SS2NBKlLfkdzP70th5" Ids="ORbGAf9TevZNSfcseWxtmU,PrWD8VDkOdhLj35wHE73pK" />
+              <Link Id="VEfLbRm2ORoOh5TyE25HDs" Ids="RUwDipfF40rPpVRgGJ4MIA,TPOLQhMp4jUMZ1leT4CMRn" />
+              <Link Id="FcoBfWeOqTWNdxVXKJNiGd" Ids="OKwW0XytubxPE6dW0CadS3,OeYjrsEICWpOsm9mLwMEv8" />
+              <Link Id="KSY1JjEd5sALcEkYf5cXpX" Ids="EvotnGFKBgCMnrmF3umNg0,OKwW0XytubxPE6dW0CadS3" IsHidden="true" />
+              <Patch Id="OHG0dDBc1aTLPHSZIIv3uv" Name="SetCustomPresent">
+                <Pin Id="EvotnGFKBgCMnrmF3umNg0" Name="Present Call Intercept" Kind="InputPin" />
+              </Patch>
             </Patch>
           </Node>
         </Canvas>
@@ -26523,7 +26540,7 @@
                 <Pin Id="SMnyQi0ar7oMDogYewCBeo" Name="Input Source" Kind="OutputPin" />
                 <Pin Id="Gh5F4Rb2TO4P15QGELVyug" Name="Back Buffer" Kind="OutputPin" />
                 <Pin Id="NtvIm4N9BUIPL1kD3Urbad" Name="Depth Buffer" Kind="OutputPin" />
-                <Pin Id="HUuujTRPSdGMBehGpnjy81" Name="Game Window Renderer" Kind="OutputPin" />
+                <Pin Id="NwhRVp4YITvNfynyGyDyqf" Name="Present Call Intercept" Kind="InputPin" IsHidden="true" />
               </Node>
               <ControlPoint Id="PukR1teAvW5NhcXXfUWwqo" Bounds="265,411" />
               <ControlPoint Id="TvQVSIc1QD4PQoPl3V0VBB" Bounds="297,433" />
@@ -29612,7 +29629,7 @@
         </p:NodeReference>
         <Patch Id="Q1CM3G4fc7KMaNaIzvGabR">
           <Canvas Id="Kk5Fqcv7oMtNpqDAGfvtQY" CanvasType="Group">
-            <ControlPoint Id="EEQ60u0n9ATNadblUovIX7" Bounds="823,999" />
+            <ControlPoint Id="EEQ60u0n9ATNadblUovIX7" Bounds="811,985" />
             <ControlPoint Id="RzkQ5YRhHQALLkSoQA085R" Bounds="200,1124,312,0" />
             <Node Bounds="198,1062,577,19" Id="FXcVasK44MaL8n0KHQsqR1">
               <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
@@ -29649,7 +29666,7 @@
               <Pin Id="QzptxYI9x2fPSS37uMQk1w" Name="Input Source" Kind="OutputPin" />
               <Pin Id="S3gzgF5mh3xMvb0DQhN91z" Name="Back Buffer" Kind="OutputPin" />
               <Pin Id="GgA7RAEKzT4PxFF12XjVHd" Name="Depth Buffer" Kind="OutputPin" />
-              <Pin Id="FLJicPRM1jjNuKEzliy6xy" Name="Game Window Renderer" Kind="OutputPin" />
+              <Pin Id="MAY2fcZOXjZOI9ZEftOBAQ" Name="Present Call Intercept" Kind="InputPin" />
             </Node>
             <ControlPoint Id="DvjFGxnGxaSPTK1FcsQgVt" Bounds="505,1028" />
             <ControlPoint Id="Eki1GrF8SxSLRnbvFtLux0" Bounds="203,880" />
@@ -29698,7 +29715,7 @@
             <ControlPoint Id="O47KDr3owUhQcN9cnrGbZf" Bounds="541,182" />
             <ControlPoint Id="PQP1TZ2S1W3MLWD5fLOMfF" Bounds="368,1028" />
             <ControlPoint Id="Q3O2d1CyOULPIxcSKWLEcf" Bounds="335,997" />
-            <ControlPoint Id="TZfMyfX2rqJM11U0su2g39" Bounds="851,1033" />
+            <ControlPoint Id="TZfMyfX2rqJM11U0su2g39" Bounds="839,1019" />
             <ControlPoint Id="VxHj0XquA3kNJIqYwR7RO6" Bounds="604,268" />
             <Node Bounds="219,330,349,88" Id="JhGoT8aH3cBOwhIT6H4UOT">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
@@ -29909,7 +29926,7 @@
                 <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
               </p:ValueBoxSettings>
             </Pad>
-            <ControlPoint Id="FgrxzUx1zWDOpm0Bip8nEO" Bounds="851,1115" />
+            <ControlPoint Id="NoEYVtjX1mmNAJACHppexu" Bounds="869,1042" />
           </Canvas>
           <Link Id="JKnUileeJ7FNJsu7KpPf94" Ids="G7SBfHwE22bMfljT0fnHrW,EEQ60u0n9ATNadblUovIX7" IsHidden="true" />
           <Link Id="ToLCItn5JyDMzpOHiAEnJu" Ids="RzkQ5YRhHQALLkSoQA085R,Hdw9ETxxng9OxCDbLeNcTB" IsHidden="true" />
@@ -29992,7 +30009,7 @@
             <Fragment Id="VRb8ukE1nlbPeRZWewguZc" Patch="JC5zNcazfe5PemN2vFTgvH" Enabled="true" />
             <Fragment Id="IzWNXnYO95QN8WwpoYgyJi" Patch="VnB7dRwuoWoN5IyXhYChtZ" Enabled="true" />
             <Fragment Id="OBVUa3UNeN2O90hR2mG9Ni" Patch="TBD6Xc1bmYhN5YxHX2qcT2" Enabled="true" />
-            <Fragment Id="TC9lmgX5fuAMT9L6Ywdxjl" Patch="V5gZKPsKfVnPPbpzhvpRnl" Enabled="true" />
+            <Fragment Id="NIspjfyJGYhNeMojkskfvK" Patch="EVKYc8mGuP7MPiherWjoJc" Enabled="true" />
           </ProcessDefinition>
           <Link Id="BS81b9ULH0MQYXrSiMN1n2" Ids="OOsflcfqABvOwzGSsfvwIp,VghSJuU3XH2O2lcYUdshlp" />
           <Link Id="SoJL1vvHW3DPkRMJvgYxze" Ids="HFWw5ZrzJ1UOHAt7pZfH7T,OOsflcfqABvOwzGSsfvwIp" IsHidden="true" />
@@ -30103,11 +30120,11 @@
           <Link Id="Ul4Gfn0XberLyusUrg60uQ" Ids="PI9BhwnKl5EOSJCYjYec0A,HS8AFTF4GwfOxnmfSb9CJ2" />
           <Link Id="Ikx9GPmYCviMTZzJ6BzOkt" Ids="Rw0E0P8SsZ9LxLwATlWsFq,A3JyzVwHER4LYTM2etXg0Z,S4JJNxbVrcoMiSDkvu6SRb" />
           <Link Id="BRdhXBAd6hoNyp5jKJGU39" Ids="OkLdqSLY5wMLT1SD7KSRDq,UT5YxeVHip6Oby5fzZjFTd" />
-          <Patch Id="V5gZKPsKfVnPPbpzhvpRnl" Name="GameWindowRenderer">
-            <Pin Id="HEJ0TUUtwq9MQxZabRvRn4" MergeId="64220" Name="Game Window Renderer" Kind="OutputPin" Visibility="Optional" />
+          <Patch Id="EVKYc8mGuP7MPiherWjoJc" Name="SetCustomPresent">
+            <Pin Id="Ezbj7IR1gAjNRn8TRbmTCL" MergeId="77318" Name="Present Call Intercept" Kind="InputPin" Visibility="Optional" />
           </Patch>
-          <Link Id="DFGN4GB1K93NdkNen9peJM" Ids="FgrxzUx1zWDOpm0Bip8nEO,HEJ0TUUtwq9MQxZabRvRn4" IsHidden="true" />
-          <Link Id="LWQwMH4EgZ9LDB5U4NOhWP" Ids="FLJicPRM1jjNuKEzliy6xy,FgrxzUx1zWDOpm0Bip8nEO" />
+          <Link Id="MW2AmKoQQkLOqUdLpbqS5j" Ids="Ezbj7IR1gAjNRn8TRbmTCL,NoEYVtjX1mmNAJACHppexu" IsHidden="true" />
+          <Link Id="BxxPO55jgKDN7jj8cVdSEY" Ids="NoEYVtjX1mmNAJACHppexu,MAY2fcZOXjZOI9ZEftOBAQ" />
         </Patch>
       </Node>
       <!--
@@ -30604,6 +30621,7 @@
               <Pin Id="PCComlz88hqOYsAuc5w513" Name="Input Source" Kind="OutputPin" />
               <Pin Id="CPiM9qGNWQTO5fxfG0PKIP" Name="Back Buffer" Kind="OutputPin" />
               <Pin Id="TeF5xbbG8WgP3WweJcrENT" Name="Depth Buffer" Kind="OutputPin" />
+              <Pin Id="RcwjrG2zJ1FPuD8XNfUxfc" Name="Present Call Intercept" Kind="InputPin" />
             </Node>
             <ControlPoint Id="JWaZkXlUJPuQBGBryZcVCO" Bounds="-78,230" />
             <ControlPoint Id="LrehaedcjjPLkYyRRnQg2T" Bounds="883,69" />
@@ -31481,16 +31499,7 @@
               <Pin Id="O2Gk0YyCqS7ObWpIPYTfWm" Name="Current" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="Ko9uuE6xSYQOKehGYDUwtU" Bounds="149,-240" />
-            <Node Bounds="653,-75,118,26" Id="HG4ehUnqUx0O2luBAuu7jG">
-              <p:NodeReference LastCategoryFullName="Stride.Windowing.GameWindowManager" LastDependency="VL.Stride.Engine.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="OperationCallFlag" Name="GameWindowRenderer" />
-              </p:NodeReference>
-              <Pin Id="OHhdg2GRkVELVGmKSpUKKs" Name="Input" Kind="StateInputPin" />
-              <Pin Id="U16EOcUhUXuNTzduUCplmv" Name="Output" Kind="StateOutputPin" />
-              <Pin Id="HIGSEByx5kuO7OHdErVVq9" Name="Game Window Renderer" Kind="OutputPin" />
-            </Node>
-            <ControlPoint Id="IIphhGujK3KLSFIYKVXQ25" Bounds="658,-25" />
+            <ControlPoint Id="HLYYVJMAh9lO4OtRfpllBs" Bounds="1040,-47" />
           </Canvas>
           <Slot Id="PAV2QLEHIawLiiMQjeCSBx" Name="Game Window" />
           <Link Id="V7zVQDv7tilLMv638pLUGg" Ids="Aovd7gXzFIqPW6xwdW7oln,MUiMMxbgDwTMwpBxtCke2j" IsHidden="true" />
@@ -31637,7 +31646,7 @@
             <Fragment Id="JsUk1C1cOr6L1CHQ0YHlXi" Patch="Vmj97POsIV1P1Lc2TuVHEj" />
             <Fragment Id="TY9R43BBB4RN9ZbSLjpveX" Patch="RStOsMz4gHoN3igS9gs3PX" />
             <Fragment Id="Dxki9OHvXSUMUMtKkmXzuK" Patch="G1Kr1lam7kaLmLyJNKwfAf" />
-            <Fragment Id="KwMwVgTcAHAO5Y2jG2tFuX" Patch="IctHqTDnaeCP5gGDPEO3bl" Enabled="true" />
+            <Fragment Id="Pr3bktKGtFUMfIcGpUfUO6" Patch="M8O4yzgliPeO0sSuF6h9fg" Enabled="true" />
           </ProcessDefinition>
           <Link Id="MsiroA9GNILLt5N74XnrKK" Ids="OI862sAjPluPTiWjiXcnvB,Kxc0JPrhMdNONquxpqH63G" />
           <Link Id="IwK8HOUNRNFPQMDsAxOrAn" Ids="D9xZQrFgJLKOqsHxeLZoH7,Itw9qLp5wddQAYWLmdkBH5" />
@@ -31729,12 +31738,11 @@
           <Link Id="AxfI9qbz7JPQYJAPVzPBXT" Ids="Ko9uuE6xSYQOKehGYDUwtU,PIidFC8nIt4QPiWjP1FGCb" />
           <Link Id="NppoXs4FSBkPXg60dnv8vB" Ids="DtK4T8xqWtHOEbsodBUxWy,Ko9uuE6xSYQOKehGYDUwtU" IsHidden="true" />
           <Link Id="HlO6KYMHUxTNuBa29TjmyL" Ids="DnccpXrES6HLa9Yt0GhhXg,SQuuhVXC8eQQHsbJt25ui9" />
-          <Patch Id="IctHqTDnaeCP5gGDPEO3bl" Name="GameWindowRenderer">
-            <Pin Id="G5mPzn7KS2wNpQo7gmupa6" MergeId="274901" Name="Game Window Renderer" Kind="OutputPin" Visibility="Optional" />
+          <Patch Id="M8O4yzgliPeO0sSuF6h9fg" Name="SetCustomPresent">
+            <Pin Id="PvUe47tLDVGLOjuAxmPLx2" MergeId="77083" Name="Present Call Intercept" Kind="InputPin" Visibility="Optional" />
           </Patch>
-          <Link Id="PBBHHMRRPTqPveiXKDsTt8" Ids="IIphhGujK3KLSFIYKVXQ25,G5mPzn7KS2wNpQo7gmupa6" IsHidden="true" />
-          <Link Id="BM4Bzoj50PqNrQfvMawpWx" Ids="HIGSEByx5kuO7OHdErVVq9,IIphhGujK3KLSFIYKVXQ25" />
-          <Link Id="TXH42o9DIcpPs0GAbLPS4P" Ids="Ijvt2pnk9AqMBE5x1Y8R3G,OHhdg2GRkVELVGmKSpUKKs" />
+          <Link Id="HxBUrFBoR14LuwbYYebgN1" Ids="PvUe47tLDVGLOjuAxmPLx2,HLYYVJMAh9lO4OtRfpllBs" IsHidden="true" />
+          <Link Id="MnRxiBaldKQM73e2PT4D8B" Ids="HLYYVJMAh9lO4OtRfpllBs,RcwjrG2zJ1FPuD8XNfUxfc" />
         </Patch>
       </Node>
       <!--

--- a/VL.Stride.Runtime/VL.Stride.Graphics.vl
+++ b/VL.Stride.Runtime/VL.Stride.Graphics.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="Dky5PMnuvcKN4CxmfNs7Uv" LanguageVersion="2024.6.7-0233-g2086759bc8" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="Dky5PMnuvcKN4CxmfNs7Uv" LanguageVersion="2025.7.0-0078-gedfd4fed5f" Version="0.128">
   <NugetDependency Id="EKAeSpl0TUSO67sl9VuE19" Location="VL.CoreLib" Version="2021.4.11-1152-g29d61bbe61" />
   <Patch Id="M3fVx2jjvOSLPGL4EJGFf9">
     <Canvas Id="JugVUmEZoitO7m1cCzT7W3" DefaultCategory="Stride" CanvasType="FullCategory">
@@ -10734,6 +10734,26 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
+          <!--
+
+    ************************ IPresentCallIntercept ************************
+
+-->
+          <Node Name="IPresentCallIntercept" Bounds="507,222" Id="ISoRdGeKv1jQZfzwSMotyU">
+            <p:NodeReference>
+              <Choice Kind="ForwardDefinition" Name="Forward" />
+              <CategoryReference Kind="Category" Name="Primitive" />
+            </p:NodeReference>
+            <p:TypeAnnotation LastCategoryFullName="VL.Stride.Games" LastDependency="VL.Stride.Runtime.dll">
+              <Choice Kind="TypeFlag" Name="IPresentCallIntercept" />
+              <FullNameCategoryReference ID="VL.Stride.Games" />
+              <AssemblyReference ID="VL.Stride.Runtime.dll" />
+            </p:TypeAnnotation>
+            <Patch Id="Ohz1ywlk7uBP3VfPRCL36R">
+              <Canvas Id="M61zDO0oDLZQdKNu3hEcAs" BordersChecked="false" CanvasType="Group" />
+              <ProcessDefinition Id="NxcMjIx0sinPMnBMICkdLN" IsHidden="true" />
+            </Patch>
+          </Node>
         </Canvas>
       </Canvas>
     </Canvas>

--- a/VL.Stride.Runtime/src/Games/GameWindowRenderer.cs
+++ b/VL.Stride.Runtime/src/Games/GameWindowRenderer.cs
@@ -13,7 +13,7 @@ namespace VL.Stride.Games
 {
     public interface IPresentCallIntercept
     {
-        void Present();
+        void Present(GraphicsPresenter presenter);
     }
 
     /// <summary>
@@ -195,7 +195,7 @@ namespace VL.Stride.Games
                     if (PresentCallIntercept is null)
                         Presenter.Present();
                     else
-                        PresentCallIntercept.Present();
+                        PresentCallIntercept.Present(Presenter);
                 }
                 catch (GraphicsException ex)
                 {

--- a/VL.Stride.Runtime/src/Games/GameWindowRenderer.cs
+++ b/VL.Stride.Runtime/src/Games/GameWindowRenderer.cs
@@ -11,6 +11,11 @@ using VL.Core.Utils;
 
 namespace VL.Stride.Games
 {
+    public interface IPresentCallIntercept
+    {
+        void Present();
+    }
+
     /// <summary>
     /// A GameSystem that allows to draw to another window or control. Currently only valid on desktop with Windows.Forms.
     /// </summary>
@@ -58,6 +63,11 @@ namespace VL.Stride.Games
         /// The window manager.
         /// </value>
         public GameWindowRendererManager WindowManager { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the present call intercept. Can be set to manage the present call on your own.
+        /// </summary>
+        public IPresentCallIntercept PresentCallIntercept { get; set; }
 
         public override void Initialize()
         {
@@ -182,7 +192,10 @@ namespace VL.Stride.Games
 
                 try
                 {
-                    Presenter.Present();
+                    if (PresentCallIntercept is null)
+                        Presenter.Present();
+                    else
+                        PresentCallIntercept.Present();
                 }
                 catch (GraphicsException ex)
                 {


### PR DESCRIPTION
# PR Details

## Description

This PR introduces the `IPresentCallIntercept` interface, which allows users to manage the present call of the `GameWindowRenderer`. This is useful where an alternative present method is required.

A use case is NVIDIA Quadro Sync, which has a dedicated `Present` method in `NvApi` that works with Quadro sync groups and sync barriers.

Additionally, this PR adds a hidden output pin to `GameWindow` and `SceneWindow`, outputting the `GameWindowRenderer` to set the present intercept and retrieve the swap chain used for the custom present.

## Motivation and Context

This change is necessary to enable proper synchronization with NVIDIA Quadro Sync groups and sync barriers.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation
