### PR TITLE
[Stride] Adds rendering to HDR displays.

### DIFF
--- a/VL.Stride.Runtime/VL.Stride.Engine.vl
+++ b/VL.Stride.Runtime/VL.Stride.Engine.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="UFzEbZy7D3GNY8xnLUU17p" LanguageVersion="2025.7.0-0257-gd18ce6abe1" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="UFzEbZy7D3GNY8xnLUU17p" LanguageVersion="2025.7.0-0310-gb23441fc56" Version="0.128">
   <NugetDependency Id="EKAeSpl0TUSO67sl9VuE19" Location="VL.CoreLib" Version="2021.4.12-1361-g53776bfdff" />
   <Patch Id="M3fVx2jjvOSLPGL4EJGFf9">
     <Canvas Id="JugVUmEZoitO7m1cCzT7W3" DefaultCategory="Stride" CanvasType="FullCategory">
@@ -22592,6 +22592,8 @@
                 <Pin Id="JuAV2mqQgOIPQjOl1Ha15o" Name="Back Buffer" Kind="OutputPin" />
                 <Pin Id="Rw6NsHb3Uu8LYJYrC23MLl" Name="Depth Buffer" Kind="OutputPin" />
                 <Pin Id="MfjprE88LGMMZeoSTmAg2U" Name="Present Call Intercept" Kind="InputPin" IsHidden="true" />
+                <Pin Id="QD3HamQGZcIPwSoM4Myy4U" Name="Output Color Space" Kind="InputPin" />
+                <Pin Id="UEHAyNgdW9uMJjl4ZOElAg" Name="Backbuffer Format" Kind="InputPin" />
               </Node>
               <ControlPoint Id="Lp5kt1M2hMpN5Oiga86qiG" Bounds="1428,359" />
               <ControlPoint Id="FdAq8DTTKowLDjjv4KigYR" Bounds="1158,241" />
@@ -25646,7 +25648,7 @@
                   <Pin Id="TIRz2QF32gbO4DxQEFXeKj" Name="Game Context" Kind="InputPin" />
                   <Pin Id="Q9xzGnjAmzNMdBNPWMDeGl" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="RUwDipfF40rPpVRgGJ4MIA" SlotId="RcCDkb7QvReMM8H09CrM7N" Bounds="392,1539" />
+                <Pad Id="RUwDipfF40rPpVRgGJ4MIA" SlotId="RcCDkb7QvReMM8H09CrM7N" Bounds="389,1617" />
                 <Node Bounds="439,344,145,26" Id="UWTmagyQoGOMSfrOOCEcAJ">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRendererManager" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -25667,7 +25669,7 @@
                   <Pin Id="SInWOhUTLMzOvC0NIz34Mp" Name="Value" Kind="InputPin" />
                   <Pin Id="DxI050qzrDWNwaHiG5S4my" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="421,973,97,26" Id="UNksQaJSz8zPMcdcgOu2PG">
+                <Node Bounds="418,1051,97,26" Id="UNksQaJSz8zPMcdcgOu2PG">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Initialize" />
@@ -25684,14 +25686,14 @@
                   <Pin Id="Q0YY17gX9AyNhUxnuGT9D3" Name="Output" Kind="StateOutputPin" />
                 </Node>
                 <Pad Id="ARBIfoKpgn8L6ZOGriMrbV" SlotId="RcCDkb7QvReMM8H09CrM7N" Bounds="-82,487" />
-                <Node Bounds="409,1017,112,146" Id="SEcqnMOxIz9MQ8NVGYHSjy">
+                <Node Bounds="406,1095,112,146" Id="SEcqnMOxIz9MQ8NVGYHSjy">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <FullNameCategoryReference ID="Primitive" />
                   </p:NodeReference>
-                  <ControlPoint Id="JFsI2ECX2UwMUDzlnbEM0D" Bounds="423,1023" Alignment="Top" />
-                  <ControlPoint Id="CgTkaL2zlcIL936WENveC6" Bounds="423,1157" Alignment="Bottom" />
+                  <ControlPoint Id="JFsI2ECX2UwMUDzlnbEM0D" Bounds="420,1101" Alignment="Top" />
+                  <ControlPoint Id="CgTkaL2zlcIL936WENveC6" Bounds="420,1235" Alignment="Bottom" />
                   <Pin Id="OCminZ6aLC3LpPHJzKlzF1" Name="Condition" Kind="InputPin" DefaultValue="True">
                     <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
@@ -25700,7 +25702,7 @@
                   <Patch Id="J5UGTDIJgdjQKIkB5bLHjW" ManuallySortedPins="true">
                     <Patch Id="PrgP9gthbJjQZXJqWEIll0" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="QZCtlYb7FfeOWmHIUmC1TH" Name="Then" ManuallySortedPins="true" />
-                    <Node Bounds="435,1096,74,26" Id="GpfMyqbqXypL9w6wvkpw4H">
+                    <Node Bounds="432,1174,74,26" Id="GpfMyqbqXypL9w6wvkpw4H">
                       <p:NodeReference LastCategoryFullName="Stride.Games.IContentable" LastDependency="Stride.Games.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="LoadContent" />
@@ -25710,7 +25712,7 @@
                       <Pin Id="VjKtAvmVM81P8YNh94iMFQ" Name="Output" Kind="StateOutputPin" />
                       <Pin Id="Vv6RZ6xs8ZfPMQR7eqxGpD" Name="Apply" Kind="InputPin" />
                     </Node>
-                    <Node Bounds="435,1062,48,19" Id="BkXHiRt6TM4MtxHuUkucs3">
+                    <Node Bounds="432,1140,48,19" Id="BkXHiRt6TM4MtxHuUkucs3">
                       <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="CastAs" />
@@ -25753,7 +25755,7 @@
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="617,1189,97,26" Id="BPwuP7LrJi3O5MKf3sbisj">
+                <Node Bounds="614,1267,97,26" Id="BPwuP7LrJi3O5MKf3sbisj">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Window" />
@@ -25770,7 +25772,7 @@
                   <Pin Id="RoIaUpDOaJML9NMgAVuqrD" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="S3phCCtqga0PueevrIl4iu" Name="Window" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="841,1417,113,26" Id="FH149KvUBpFOM1L4GX5FyX">
+                <Node Bounds="838,1495,113,26" Id="FH149KvUBpFOM1L4GX5FyX">
                   <p:NodeReference LastCategoryFullName="Stride.API.Games.GameWindow" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="GameWindow" />
@@ -25780,12 +25782,12 @@
                   <Pin Id="EBRGiP0zdGcLSMqAb0DeRD" Name="Value" Kind="InputPin" />
                   <Pin Id="VFJWxkJYl2XLvm0yH9JmJC" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="PZP5MmKJWT7LuoJCDyVXSD" Comment="" Bounds="998,1385,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+                <Pad Id="PZP5MmKJWT7LuoJCDyVXSD" Comment="" Bounds="995,1463,35,35" ShowValueBox="true" isIOBox="true" Value="True">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pad>
-                <ControlPoint Id="NY4ITxcRGR9N0dug3a1HCx" Bounds="843,1589" />
+                <ControlPoint Id="NY4ITxcRGR9N0dug3a1HCx" Bounds="840,1667" />
                 <Node Bounds="220,71,42,19" Id="VfTYoeJSknKNcaF1xwiBnF">
                   <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.Games.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -25846,7 +25848,7 @@
                 <Pad Id="UL4YfLtnestMxtD0FPl0Hb" SlotId="K2NvRgFVfiqOF3jbcgLmDf" Bounds="937,376" />
                 <Pad Id="S5SqczNIlSlOSNwYGauNZI" SlotId="K2NvRgFVfiqOF3jbcgLmDf" Bounds="21,390" />
                 <ControlPoint Id="OfBeGLHi3cpNtAyM3auz9X" Bounds="937,414" />
-                <Node Bounds="841,1467,97,26" Id="TZVUd5rtVOtMek7sMCTxR7">
+                <Node Bounds="838,1545,97,26" Id="TZVUd5rtVOtMek7sMCTxR7">
                   <p:NodeReference LastCategoryFullName="Stride.API.Games.GameWindow" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="GameWindow" />
@@ -25856,13 +25858,13 @@
                   <Pin Id="TMKwRDHJUYaLtxyAqHef27" Name="Value" Kind="InputPin" />
                   <Pin Id="ST3Mh5EoMYlOlMn9ZNgiea" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="QS7nCzup8deLQ1I2OTz2LL" Comment="" Bounds="999,1433,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+                <Pad Id="QS7nCzup8deLQ1I2OTz2LL" Comment="" Bounds="996,1511,35,35" ShowValueBox="true" isIOBox="true" Value="True">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pad>
                 <ControlPoint Id="HKj23lc9o4eLItfSSDoiJc" Bounds="509,17" />
-                <Node Bounds="770,1128,51,19" Id="CddLSFS2HvAPmGDFHKrMqq">
+                <Node Bounds="767,1206,51,19" Id="CddLSFS2HvAPmGDFHKrMqq">
                   <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="Rectangle" />
@@ -25871,7 +25873,7 @@
                   <Pin Id="P4JFI60fa3KOu4uQ51acbW" Name="Input" Kind="StateInputPin" />
                   <Pin Id="UmPrB4Djy0ILaxIjf5YTtl" Name="Top Left" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="709,1230,66,26" Id="FXp1kGmb56OOB0FSwnqbdS">
+                <Node Bounds="706,1308,66,26" Id="FXp1kGmb56OOB0FSwnqbdS">
                   <p:NodeReference LastCategoryFullName="Stride.API.Games.GameWindow" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="GameWindow" />
@@ -25881,7 +25883,7 @@
                   <Pin Id="AYxEQKjcGp3LgtQAutGW3t" Name="Value" Kind="InputPin" />
                   <Pin Id="QMxZUuooWUVM2kR9SK9MJL" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="770,1181,46,26" Id="KUZYRgXVM6BNGkSkAjuTue">
+                <Node Bounds="767,1259,46,26" Id="KUZYRgXVM6BNGkSkAjuTue">
                   <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="Int2" />
@@ -25931,7 +25933,7 @@
                   <Pin Id="Ce3BmmX8cdJOlucyIorFVM" Name="Input" Kind="InputPin" />
                   <Pin Id="AzA9TrCyN4YN68Y02WTRGq" Name="Result" Kind="OutputPin" />
                 </Node>
-                <ControlPoint Id="Rlkt9qoYsiaOpsSMby3SGj" Bounds="772,1095" />
+                <ControlPoint Id="Rlkt9qoYsiaOpsSMby3SGj" Bounds="769,1173" />
                 <Node Bounds="439,491,151,26" Id="T4r6HL9AmjEMuzplA8Ag7U">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRendererManager" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -25942,9 +25944,9 @@
                   <Pin Id="GVQouEdEv5LOn7KGiXiFiN" Name="Value" Kind="InputPin" />
                   <Pin Id="Q3F9GJbsLD4P8945AQisIw" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <ControlPoint Id="VZVgiK5Urm6OCe2VAzYCBX" Bounds="647,413" />
+                <ControlPoint Id="VZVgiK5Urm6OCe2VAzYCBX" Bounds="630,411" />
                 <ControlPoint Id="GvWaLFMdr4XNWeWdI9e561" Bounds="619,451" />
-                <Node Bounds="270,1638,97,26" Id="LjklxCJaAQjO05aeasOajU">
+                <Node Bounds="267,1716,97,26" Id="LjklxCJaAQjO05aeasOajU">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Presenter" />
@@ -25961,7 +25963,7 @@
                   <Pin Id="S5arN5efoAdLxZE4wQZLbu" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="BBYP35LZIVNMbhnRncWMAg" Name="Presenter" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="127,1677,81,26" Id="ALWN6A1CmzTLzYKHVv2HaJ">
+                <Node Bounds="124,1755,81,26" Id="ALWN6A1CmzTLzYKHVv2HaJ">
                   <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsPresenter" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="GraphicsPresenter" />
@@ -25971,7 +25973,7 @@
                   <Pin Id="JlTOAFluIH5O0Vqq9zUqNs" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="QO0S8a4KDaDOpeSDKhG0EH" Name="Back Buffer" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="362,1677,101,26" Id="H78lhVgq2r8QNQlzrKRYSO">
+                <Node Bounds="359,1755,101,26" Id="H78lhVgq2r8QNQlzrKRYSO">
                   <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsPresenter" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="GraphicsPresenter" />
@@ -25981,7 +25983,7 @@
                   <Pin Id="RqfqayqsdJnMXEYrbUUnVb" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="QY4DDi5q0qEPtBjme2d6op" Name="Depth Stencil Buffer" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="35,1638,97,26" Id="VT3F5Q2TrVENbGTy3ebgwE">
+                <Node Bounds="32,1716,97,26" Id="VT3F5Q2TrVENbGTy3ebgwE">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="Presenter" />
@@ -25998,10 +26000,10 @@
                   <Pin Id="TlOHavzwJiZOiDySSB2lxy" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="Cv7GIdyIDtaLxKOxiSpfRh" Name="Presenter" Kind="OutputPin" />
                 </Node>
-                <ControlPoint Id="Ve2AzovREY7QJZFdnSYxTO" Bounds="205,1736" />
-                <ControlPoint Id="QopDTcCgis4NW8vyBG646A" Bounds="460,1736" />
-                <ControlPoint Id="O9VIkAnLJxtM8jcOVEClDo" Bounds="393,1603" />
-                <Pad Id="S8225gPdDxSLqk2EW6E2RM" Bounds="843,1546" />
+                <ControlPoint Id="Ve2AzovREY7QJZFdnSYxTO" Bounds="202,1814" />
+                <ControlPoint Id="QopDTcCgis4NW8vyBG646A" Bounds="457,1814" />
+                <ControlPoint Id="O9VIkAnLJxtM8jcOVEClDo" Bounds="390,1681" />
+                <Pad Id="S8225gPdDxSLqk2EW6E2RM" Bounds="840,1624" />
                 <Pad Id="PK4MhutqpflO4OuRPcFH0o" SlotId="RcCDkb7QvReMM8H09CrM7N" Bounds="1212,376" />
                 <Node Bounds="1210,409,97,26" Id="MRd4Q6MLSkdOSinfylvJ1W">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
@@ -26051,7 +26053,7 @@
                   <Pin Id="VPBl2LIpwj6O2krhreTdG6" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="LhzGORP979pOLwtfHQsIZl" Name="Window Manager" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="409,912,55,31" Id="OqUWkBBQZm4OckM1FYyA8e">
+                <Node Bounds="406,990,55,31" Id="OqUWkBBQZm4OckM1FYyA8e">
                   <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
@@ -26062,12 +26064,12 @@
                     <Patch Id="PqI0QK7s3FnMObTO5U6zJe" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="F35GWYy9kY0N2rtRysz4A5" Name="Then" ManuallySortedPins="true" />
                   </Patch>
-                  <ControlPoint Id="QyGyqMWYTJqOKeOlE3wMQV" Bounds="445,918" Alignment="Top" />
-                  <ControlPoint Id="CkRKSt5QzrbLaME196n2uM" Bounds="447,937" Alignment="Bottom" />
-                  <ControlPoint Id="O30L3GMlfsRP2cLMFRbC3l" Bounds="423,918" Alignment="Top" />
-                  <ControlPoint Id="SFjeJEy0WwTOx5wpdoEWFH" Bounds="423,937" Alignment="Bottom" />
+                  <ControlPoint Id="QyGyqMWYTJqOKeOlE3wMQV" Bounds="442,996" Alignment="Top" />
+                  <ControlPoint Id="CkRKSt5QzrbLaME196n2uM" Bounds="444,1015" Alignment="Bottom" />
+                  <ControlPoint Id="O30L3GMlfsRP2cLMFRbC3l" Bounds="420,996" Alignment="Top" />
+                  <ControlPoint Id="SFjeJEy0WwTOx5wpdoEWFH" Bounds="420,1015" Alignment="Bottom" />
                 </Node>
-                <Node Bounds="439,586,127,26" Id="MoC9esosUzCPyT0bKzENyY">
+                <Node Bounds="439,675,127,26" Id="MoC9esosUzCPyT0bKzENyY">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRendererManager" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetShaderProfile" />
@@ -26077,7 +26079,7 @@
                   <Pin Id="NKEqbzzbnQTPGcaRhtcMRv" Name="Value" Kind="InputPin" />
                   <Pin Id="DcKgMAsag1CMys0Biz5X6t" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="439,625,140,26" Id="OxlJhSSD09wP9TVzWEx9ho">
+                <Node Bounds="439,714,140,26" Id="OxlJhSSD09wP9TVzWEx9ho">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRendererManager" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetPreferredGraphicsProfile" />
@@ -26088,7 +26090,7 @@
                   <Pin Id="GUioSi6BMmKLqXZeFTmZRg" Name="Value" Kind="InputPin" />
                   <Pin Id="G8sVjmGFMzKOwKnt18sPvJ" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="574,586,64,26" Id="UOwYbh7ROyoMg0QvtxcBkm">
+                <Node Bounds="574,675,64,26" Id="UOwYbh7ROyoMg0QvtxcBkm">
                   <p:NodeReference LastCategoryFullName="Collections.Mutable.MutableArray" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ArrayType" Name="MutableArray" />
@@ -26097,8 +26099,8 @@
                   <Pin Id="Qj0T6A2AD1DOY6Zn9hRGV5" Name="Input" Kind="StateInputPin" />
                   <Pin Id="CtTRB48PnK5OARTalTsnHG" Name="Result" Kind="OutputPin" />
                 </Node>
-                <ControlPoint Id="PMC7in9T3hOLdHNhw3N9Eq" Bounds="652,524" />
-                <Node Bounds="561,546,46,26" Id="VMI1kXZopj5OedeOk1yS2d">
+                <ControlPoint Id="PMC7in9T3hOLdHNhw3N9Eq" Bounds="652,613" />
+                <Node Bounds="561,635,46,26" Id="VMI1kXZopj5OedeOk1yS2d">
                   <p:NodeReference LastCategoryFullName="Primitive.Nullable" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="Nullable" />
@@ -26108,7 +26110,7 @@
                   <Pin Id="KckbQZEx8h9LMH3P18P51l" Name="Value" Kind="InputPin" />
                   <Pin Id="EMaPtfTOs5oOd3Eeh4aZyP" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="DdqnacSAlpfPJTdeIS6ei0" Bounds="651,563,221,62" ShowValueBox="true" isIOBox="true" Value="TODO: This should be global per app. Also read it from game settings (only available in Engine)">
+                <Pad Id="DdqnacSAlpfPJTdeIS6ei0" Bounds="651,652,221,62" ShowValueBox="true" isIOBox="true" Value="TODO: This should be global per app. Also read it from game settings (only available in Engine)">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
@@ -26117,7 +26119,7 @@
                     <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
                   </p:ValueBoxSettings>
                 </Pad>
-                <Node Bounds="841,1272,166,26" Id="LzyGu7xX85WPS19OWYPaeE">
+                <Node Bounds="838,1350,166,26" Id="LzyGu7xX85WPS19OWYPaeE">
                   <p:NodeReference LastCategoryFullName="Stride.API.Games.GameWindow" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="ClassType" Name="GameWindow" />
@@ -26127,12 +26129,12 @@
                   <Pin Id="Q2rr2LtsRILNttuXIUKW6q" Name="Value" Kind="InputPin" />
                   <Pin Id="VhHuCnUxc7yMSxaPjiLcWf" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="QisgTWmrwObOejYapuub2c" Comment="" Bounds="1004,1226,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+                <Pad Id="QisgTWmrwObOejYapuub2c" Comment="" Bounds="1001,1304,35,35" ShowValueBox="true" isIOBox="true" Value="True">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="442,758,127,26" Id="DfdPK02ac0oMJU50SRKEoA">
+                <Node Bounds="439,836,127,26" Id="DfdPK02ac0oMJU50SRKEoA">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRendererManager" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetPreferredColorSpace" />
@@ -26142,7 +26144,7 @@
                   <Pin Id="RQBsEg76RdZNM0ZvhlwTOq" Name="Value" Kind="InputPin" />
                   <Pin Id="GgYsR6yCuB7Qdvd6HTLXz5" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="498,710,71,26" Id="IzFwJCJJNohQPNKGhbp1nj">
+                <Node Bounds="495,788,71,26" Id="IzFwJCJJNohQPNKGhbp1nj">
                   <p:NodeReference LastCategoryFullName="Stride.Graphics.GraphicsDevice" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="ColorSpace" />
@@ -26152,7 +26154,7 @@
                   <Pin Id="T9EGUv2xaYfNJziGHxBxEX" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="RtvZZHmgk3iNYKUVT3oyF8" Name="Color Space" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="498,676,86,19" Id="UUMLT6HpHUoM0tKQiuvRQ5">
+                <Node Bounds="495,754,86,19" Id="UUMLT6HpHUoM0tKQiuvRQ5">
                   <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.Graphics.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="GraphicsDevice" />
@@ -26163,7 +26165,7 @@
                   <Pin Id="QxzxL87eg2vLmx3mOq5Sw4" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="UZoAQwf7sraPhnQzfy2gKE" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="841,1339,136,26" Id="LqNJDWDmJ4MNW0Npov0TbZ">
+                <Node Bounds="838,1417,136,26" Id="LqNJDWDmJ4MNW0Npov0TbZ">
                   <p:NodeReference LastCategoryFullName="Stride.Games.GameWindow" LastDependency="Stride.Games.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="GameWindow" />
@@ -26173,7 +26175,7 @@
                   <Pin Id="QIxhf6hg3y6QAlBNLenWmX" Name="Value" Kind="InputPin" />
                   <Pin Id="PFirNgaDODIOIxm9KeaY6l" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Pad Id="Mj6fYBIr6gWPU8Qa9XRDNp" Bounds="1085,1308,138,19" ShowValueBox="true" isIOBox="true" Value="adapt to desktop size">
+                <Pad Id="Mj6fYBIr6gWPU8Qa9XRDNp" Bounds="1082,1386,138,19" ShowValueBox="true" isIOBox="true" Value="adapt to desktop size">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
@@ -26182,7 +26184,7 @@
                     <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
                   </p:ValueBoxSettings>
                 </Pad>
-                <Node Bounds="442,834,154,26" Id="GZAOvfenuANM5IFhdgR4bz">
+                <Node Bounds="439,912,154,26" Id="GZAOvfenuANM5IFhdgR4bz">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRendererManager" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetPreferredMultisampleCount" />
@@ -26192,13 +26194,13 @@
                   <Pin Id="TSIIqDOO7T5OQzZiio7F2B" Name="Value" Kind="InputPin" />
                   <Pin Id="QTteQx5U7ngMjBwSSLorBW" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <ControlPoint Id="LHyxYMQWQf1MM4aiE28gVN" Bounds="619,812" />
-                <Pad Id="DuC6Uep72ONLSMHrk7PR3L" Comment="" Bounds="1039,1303,35,28" ShowValueBox="true" isIOBox="true" Value="-1, -1">
+                <ControlPoint Id="LHyxYMQWQf1MM4aiE28gVN" Bounds="616,890" />
+                <Pad Id="DuC6Uep72ONLSMHrk7PR3L" Comment="" Bounds="1036,1381,35,28" ShowValueBox="true" isIOBox="true" Value="-1, -1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Int2" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="390,1219,121,187" Id="DrcXAo520VHLczCP6OQCiq">
+                <Node Bounds="387,1297,121,187" Id="DrcXAo520VHLczCP6OQCiq">
                   <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ProcessStatefulRegion" Name="Try (1 Output)" />
@@ -26208,8 +26210,8 @@
                     <Patch Id="AAMu1U774DZOUe6SKy3qyu" Name="Try" ManuallySortedPins="true">
                       <Pin Id="UCBBah4xEecNmbffPWVekR" Name="Output" Kind="OutputPin" />
                     </Patch>
-                    <ControlPoint Id="SJUJcRrJVExMkByJyxBw7C" Bounds="404,1399" />
-                    <Node Bounds="402,1242,97,26" Id="VjAsJyCnyKrOS69BbXcc49">
+                    <ControlPoint Id="SJUJcRrJVExMkByJyxBw7C" Bounds="401,1477" />
+                    <Node Bounds="399,1320,97,26" Id="VjAsJyCnyKrOS69BbXcc49">
                       <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="BeginDraw" />
@@ -26226,7 +26228,7 @@
                       <Pin Id="G3Ju9rIKCJAMWQG8KF0PAn" Name="Output" Kind="StateOutputPin" />
                       <Pin Id="GP8CLGh3faqMKw60nYFcV9" Name="Result" Kind="OutputPin" />
                     </Node>
-                    <Node Bounds="402,1305,97,26" Id="JRDwNALuwdFMtysm8NY66b">
+                    <Node Bounds="399,1383,97,26" Id="JRDwNALuwdFMtysm8NY66b">
                       <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="EndDraw" />
@@ -26243,7 +26245,7 @@
                       <Pin Id="QrmgPL4ZSH4P0oHWsjSDbI" Name="Output" Kind="StateOutputPin" />
                       <Pin Id="KnfFw8oBid7MKbRxascV4j" Name="Apply" Kind="InputPin" />
                     </Node>
-                    <Node Bounds="402,1349,97,26" Id="D6maeugGCwXQO4QzKq20aA">
+                    <Node Bounds="399,1427,97,26" Id="D6maeugGCwXQO4QzKq20aA">
                       <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Window" />
@@ -26269,7 +26271,7 @@
                   <Pin Id="KCnhyEEog21QWxovUtkSAe" Name="Success" Kind="OutputPin" />
                   <Pin Id="DjefnFvTtz7NdiO5VQRjWK" Name="Error Message" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="884,1512,83,26" Id="PWUvPt6h62ONSauBdfdqEx">
+                <Node Bounds="881,1590,83,26" Id="PWUvPt6h62ONSauBdfdqEx">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.WindowExtensions" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="BringToFront" />
@@ -26329,7 +26331,7 @@
                   <Pin Id="CuhFDrf5ARlP5JIlT1mCid" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="ORbGAf9TevZNSfcseWxtmU" Name="Context Type" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="570,1590,121,26" Id="ITssruvl2n0LinJMX1LSML">
+                <Node Bounds="567,1668,121,26" Id="ITssruvl2n0LinJMX1LSML">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SetPresentCallIntercept" />
@@ -26338,7 +26340,7 @@
                   <Pin Id="OeYjrsEICWpOsm9mLwMEv8" Name="Value" Kind="InputPin" />
                   <Pin Id="SJwrI6L0QsSQBnlfiCftAe" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <ControlPoint Id="OKwW0XytubxPE6dW0CadS3" Bounds="688,1537" />
+                <ControlPoint Id="OKwW0XytubxPE6dW0CadS3" Bounds="685,1615" />
                 <ControlPoint Id="JSrGDjOCvBkLD7nDMWkVki" Bounds="1006,300" />
                 <Node Bounds="922,320,87,26" Id="CxgRzTVX3lCMrsyf1pnCDh">
                   <p:NodeReference LastCategoryFullName="VL.Stride.Input.InputExtensions" LastDependency="VL.Stride.Runtime.dll">
@@ -26348,6 +26350,84 @@
                   <Pin Id="JYFhI2ZInXGO6RiDQfJaLs" Name="Input" Kind="StateInputPin" />
                   <Pin Id="Vk069kUx29qPYW7xyaZ8DV" Name="Input Source" Kind="InputPin" />
                   <Pin Id="NvwAdbz9H5vQDHGboOODWO" Name="Priority" Kind="InputPin" />
+                </Node>
+                <Node Bounds="439,580,165,26" Id="LLbNKP24tPsMMwO7WmjFiA">
+                  <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRendererManager" LastDependency="VL.Stride.Runtime.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="VL.Stride.Games.GameWindowRendererManager" />
+                    <Choice Kind="OperationCallFlag" Name="SetPreferredPresenterColorSpace" />
+                  </p:NodeReference>
+                  <Pin Id="ODUrz7tCCO4M5WKsA1t0sr" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="TVJWExw1JtDQCsnCGFFXEt" Name="Value" Kind="InputPin" />
+                  <Pin Id="LnJ6ukYZ6LBNTaHFgBVWzs" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <ControlPoint Id="LNnu7pVwvVBNdjB4NukKPE" Bounds="666,530" />
+                <Pad Id="QEYz0p6W8MeQZuvSlArT6n" SlotId="RcCDkb7QvReMM8H09CrM7N" Bounds="1195,611" />
+                <ControlPoint Id="L581hi4Q5s8Pq4k96lHkV6" Bounds="1341,610" />
+                <ControlPoint Id="UJv4WuOOxieMOcjRVHQaqw" Bounds="1394,641" />
+                <Node Bounds="1181,665,295,181" Id="EK5kZH4OezDOKmgiGSeDTD">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                    <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                  </p:NodeReference>
+                  <Pin Id="K6GMEZ909VsQbPWxQrbSt3" Name="Force" Kind="InputPin" />
+                  <Pin Id="TWCYFWI5WwSOUdWTk5xPKj" Name="Dispose Cached Outputs" Kind="InputPin" />
+                  <Pin Id="Gcrtr7OpmZiL8FJwAGBivb" Name="Has Changed" Kind="OutputPin" />
+                  <Patch Id="AR9bXQfWiFRMghmZbYfjMY" ManuallySortedPins="true">
+                    <Patch Id="JlFvymzONljPnxm0HmyUKD" Name="Create" ManuallySortedPins="true" />
+                    <Patch Id="KozJYzi2XN0QBlHerauH45" Name="Then" ManuallySortedPins="true" />
+                    <Node Bounds="1193,690,97,26" Id="RMrErZYxaJXN3oGPZizmC3">
+                      <p:NodeReference LastCategoryFullName="VL.Stride.Games.GameWindowRenderer" LastDependency="VL.Stride.Runtime.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="Presenter" />
+                        <CategoryReference Kind="AssemblyCategory" Name="GameWindowRenderer" NeedsToBeDirectParent="true" />
+                        <CategoryReference Kind="AssemblyCategory" Name="GameWindowRenderer" NeedsToBeDirectParent="true">
+                          <p:OuterCategoryReference Kind="AssemblyCategory" Name="Games" NeedsToBeDirectParent="true">
+                            <p:OuterCategoryReference Kind="AssemblyCategory" Name="Stride" NeedsToBeDirectParent="true">
+                              <p:OuterCategoryReference Kind="AssemblyCategory" Name="VL" NeedsToBeDirectParent="true" />
+                            </p:OuterCategoryReference>
+                          </p:OuterCategoryReference>
+                        </CategoryReference>
+                      </p:NodeReference>
+                      <Pin Id="H6Yil4tz9LtMVfruRQy3Kq" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="Fky69cOM9lfNSEscf9uws6" Name="Output" Kind="StateOutputPin" />
+                      <Pin Id="NQJ0KGFciStLC4D7DDIBK3" Name="Presenter" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="1285,747,112,29" Id="KTAAtA6n6XrQJf0NRJmu3p">
+                      <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="Control" />
+                        <Choice Kind="ProcessAppFlag" Name="Try" />
+                      </p:NodeReference>
+                      <Pin Id="QrYyYitEBHlM5mp4SROpYk" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="LbcJw3biR41PsMwzK7t1Jo" Name="User Exceptions Channel" Kind="InputPin" IsHidden="true" />
+                      <Pin Id="VzmvhTlGfNhOg70USvDnVw" Name="Stick To Last Valid Outputs" Kind="InputPin" />
+                      <Pin Id="VXBH6kWCj1XMvzECEP7mkT" Name="Reset Region On Failure" Kind="InputPin" />
+                      <Pin Id="UigFPnhesQ8NvKF7RUW88H" Name="Success" Kind="OutputPin" />
+                      <Pin Id="JwiFRx1m937M5x1BWwZsLP" Name="Failure" Kind="OutputPin" />
+                      <Pin Id="QLmwPNuODPJP6X0OLrXUqy" Name="Error Message" Kind="OutputPin" />
+                      <Pin Id="FvfiIfpEUzSLnI4P1vf70a" Name="Exceptions" Kind="OutputPin" />
+                      <Patch Id="DKgeJzqZ5sKLHPu5DvqwDQ" ManuallySortedPins="true">
+                        <Patch Id="QmcjqkQQi81NZL5lujqOum" Name="Create" ManuallySortedPins="true" />
+                        <Patch Id="T5DfLI1ZCrNLzGAu5iWF2h" Name="Update" ManuallySortedPins="true" />
+                        <Patch Id="MdG85YJoPWqNv9r30Cm9Y4" Name="Dispose" ManuallySortedPins="true" />
+                        <Node Bounds="1285,750,112,26" Id="Qi2wCupIO1tNqduoIKiaW0">
+                          <p:NodeReference LastCategoryFullName="Stride.API.Graphics.GraphicsPresenter" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                            <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                            <CategoryReference Kind="ClassType" Name="GraphicsPresenter" NeedsToBeDirectParent="true" />
+                            <Choice Kind="OperationCallFlag" Name="SetOutputColorSpace" />
+                          </p:NodeReference>
+                          <Pin Id="NNGNYt2lScaP0CiM3MRAZR" Name="Input" Kind="StateInputPin" />
+                          <Pin Id="VgrVInlTs2rMLGb0GxZFIZ" Name="Color Space" Kind="InputPin" />
+                          <Pin Id="QjB0H7nOSKwPnUlWNxUmq1" Name="Format" Kind="InputPin" />
+                          <Pin Id="LgndccnuUpMQZ3Es8X2AtF" Name="Output" Kind="StateOutputPin" />
+                        </Node>
+                      </Patch>
+                    </Node>
+                  </Patch>
+                  <ControlPoint Id="HoIj1cjV8reNwzM1vqGsx0" Bounds="1341,671" Alignment="Top" />
+                  <ControlPoint Id="GCCMO5QJCZgMWQ51cLXg7J" Bounds="1394,671" Alignment="Top" />
                 </Node>
               </Canvas>
               <Link Id="KU6k8ilhe88PSHGLTisurU" Ids="FgZ58iFc480Omy7xGU7UCP,Ejh34mhLJ0SN7n8YoDT9f0" />
@@ -26406,6 +26486,7 @@
                 <Fragment Id="Rs3W8ZvmWmdMVsxodpbXDN" Patch="MlKI1gR1ZBBQQB4jcAH9hr" />
                 <Fragment Id="DckLGbBnXevOuL3cPhBn0D" Patch="FaVDYKdK40RNHxBwUwLX2w" Enabled="true" />
                 <Fragment Id="COY5kwFBSqNL0H32pNXsPj" Patch="OHG0dDBc1aTLPHSZIIv3uv" Enabled="true" />
+                <Fragment Id="VfHYLT92LK3PizVyhrc0Ue" Patch="DpBIwW2bDWZLvd20zZQ400" Enabled="true" />
               </ProcessDefinition>
               <Slot Id="RcCDkb7QvReMM8H09CrM7N" Name="Game Window Renderer" />
               <Link Id="FCQ5OYbWeTyNwt9j2OOM4a" Ids="JFsI2ECX2UwMUDzlnbEM0D,Mm6fXGFBJFkQcGHfIUERm1" />
@@ -26421,7 +26502,7 @@
               <Link Id="BSKHA8Uj3Z7PQi4i13nMiI" Ids="Q9xzGnjAmzNMdBNPWMDeGl,VZecZrQoLrLLVKWSM4hnsU" />
               <Link Id="Vrk7FiwyJyePHR7a23KgMf" Ids="LhzGORP979pOLwtfHQsIZl,VCjGAuVSfLmNZdcyCR8jiY" />
               <Link Id="DbugQsfrs3nQHgoQSrEjnh" Ids="QyGyqMWYTJqOKeOlE3wMQV,CkRKSt5QzrbLaME196n2uM" IsFeedback="true" />
-              <Link Id="Hu3QzLmqo6oM8Vf2QZBAlk" Ids="Q3F9GJbsLD4P8945AQisIw,UWjCZS4LgO3PT7aZVzadiF" />
+              <Link Id="Hu3QzLmqo6oM8Vf2QZBAlk" Ids="Q3F9GJbsLD4P8945AQisIw,ODUrz7tCCO4M5WKsA1t0sr" />
               <Link Id="R30fn22XcTYLsYhrhsEff9" Ids="O30L3GMlfsRP2cLMFRbC3l,SFjeJEy0WwTOx5wpdoEWFH" IsFeedback="true" />
               <Link Id="JmMrOteFdDJQZsIs2Qu8d3" Ids="VPBl2LIpwj6O2krhreTdG6,O30L3GMlfsRP2cLMFRbC3l" />
               <Link Id="Lf89kX5mRpOOtm9SpLuJQP" Ids="SFjeJEy0WwTOx5wpdoEWFH,CUMJm0WfKqEOvD75QK5fyj" />
@@ -26450,14 +26531,14 @@
               <Link Id="OI5BPc6H2d8N6m8G93Cee1" Ids="DuC6Uep72ONLSMHrk7PR3L,QIxhf6hg3y6QAlBNLenWmX" />
               <Patch Id="PZAMeI2dm4pLkR3Cgwnyng" Name="Create" ParticipatingElements="MzSeL4VVhzGMkasho8wZz7">
                 <Pin Id="Cn7ZNqq7FxUN5uUCNGFJdp" Name="Bounds In Pixels" Kind="InputPin" />
-                <Pin Id="CHrgiMoWRdnLOwBSI9w1lU" Name="Back Buffer Format" Kind="InputPin" DefaultValue="R16G16B16A16_Float">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
-                    <Choice Kind="TypeFlag" Name="PixelFormat" />
-                  </p:TypeAnnotation>
-                </Pin>
                 <Pin Id="BbixdutW3aEL5xAbiz5rDX" Name="Multisample Count" Kind="InputPin" Bounds="618,646" DefaultValue="None">
                   <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
                     <Choice Kind="TypeFlag" Name="MultisampleCount" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="CHrgiMoWRdnLOwBSI9w1lU" Name="Back Buffer Format" Kind="InputPin" DefaultValue="R16G16B16A16_Float">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="TypeFlag" Name="PixelFormat" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="A3WgjdDJNtjLEApnN05mO9" Name="Depth Buffer Format" Kind="InputPin" />
@@ -26466,6 +26547,7 @@
                     <Choice Kind="TypeFlag" Name="GraphicsProfile" />
                   </p:TypeAnnotation>
                 </Pin>
+                <Pin Id="V0uSVKliyuVQEkiKeb6gbe" Name="Presenter Color Space" Kind="InputPin" DefaultValue="RgbFullG22NoneP709" />
                 <Pin Id="ILbIYDjL3g2Om8RzkjnIED" Name="Input Priority" Kind="InputPin" />
               </Patch>
               <Patch Id="DHGZdX2IeHkNNHhTU2dzMG" Name="Dispose" ParticipatingElements="LwSiY5qMUcUPVnyg8NKMXb" />
@@ -26485,11 +26567,7 @@
                 <Pin Id="Tg15E2TZF52LAQ71DY8G82" Name="Window" Kind="OutputPin" />
               </Patch>
               <Patch Id="FaVDYKdK40RNHxBwUwLX2w" Name="SetPresentInterval">
-                <Pin Id="RZMUjjzoU0XN56Iwt1OSEv" Name="Present Interval" Kind="InputPin" DefaultValue="Immediate">
-                  <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="Stride.Graphics.dll">
-                    <Choice Kind="TypeFlag" Name="PresentInterval" />
-                  </p:TypeAnnotation>
-                </Pin>
+                <Pin Id="RZMUjjzoU0XN56Iwt1OSEv" Name="Present Interval" Kind="InputPin" />
               </Patch>
               <Link Id="F8oDZKLWO34PwMIbt3maaI" Ids="SJUJcRrJVExMkByJyxBw7C,UCBBah4xEecNmbffPWVekR" IsHidden="true" />
               <Link Id="IjflFMnpGoWMgEuFDsvOf3" Ids="GP8CLGh3faqMKw60nYFcV9,KnfFw8oBid7MKbRxascV4j" />
@@ -26516,6 +26594,21 @@
               <Link Id="P2OrvwZlysvMPmcR0RphJx" Ids="Kp9ZdKnZfbVLyLvmHr4l8Y,Vk069kUx29qPYW7xyaZ8DV" />
               <Link Id="Em3kIWffdv2MXzQMRk4Hb3" Ids="JSrGDjOCvBkLD7nDMWkVki,NvwAdbz9H5vQDHGboOODWO" />
               <Link Id="ULZTatLOLe5LkcxEzBbV6S" Ids="Kp9ZdKnZfbVLyLvmHr4l8Y,UL4YfLtnestMxtD0FPl0Hb" />
+              <Link Id="GnAbKuDiJkKMtMxO8xn3Ea" Ids="LnJ6ukYZ6LBNTaHFgBVWzs,UWjCZS4LgO3PT7aZVzadiF" />
+              <Link Id="RNf2wPuRnFANhaq5oG4ccS" Ids="LNnu7pVwvVBNdjB4NukKPE,TVJWExw1JtDQCsnCGFFXEt" />
+              <Link Id="TXAm8QwX12aMCsIHtjBDZD" Ids="V0uSVKliyuVQEkiKeb6gbe,LNnu7pVwvVBNdjB4NukKPE" IsHidden="true" />
+              <Link Id="E99vxz32JlIPSQ9AhhlM40" Ids="QEYz0p6W8MeQZuvSlArT6n,H6Yil4tz9LtMVfruRQy3Kq" />
+              <Link Id="Q9YBrPg1Py6MAJKZSLssBl" Ids="NQJ0KGFciStLC4D7DDIBK3,NNGNYt2lScaP0CiM3MRAZR" />
+              <Patch Id="DpBIwW2bDWZLvd20zZQ400" Name="SetOutputColorSpace">
+                <Pin Id="AWVCrBfyUMTOuNBiV5XRBn" Name="Output Color Space" Kind="InputPin" />
+                <Pin Id="VEFOICTGadfOp2QCi22JxI" Name="Backbuffer Format" Kind="InputPin" DefaultValue="R8G8B8A8_UNorm_SRgb" />
+              </Patch>
+              <Link Id="Jq1HIPMyOd7PiQQ6x6MPwR" Ids="AWVCrBfyUMTOuNBiV5XRBn,L581hi4Q5s8Pq4k96lHkV6" IsHidden="true" />
+              <Link Id="QJCJmGMPdqgOvWE9XbnsxF" Ids="VEFOICTGadfOp2QCi22JxI,UJv4WuOOxieMOcjRVHQaqw" IsHidden="true" />
+              <Link Id="FG9LUKlm6lFPJOJs3RSNWO" Ids="L581hi4Q5s8Pq4k96lHkV6,HoIj1cjV8reNwzM1vqGsx0" />
+              <Link Id="HulqOmaSDJ8PizqB2YBsJg" Ids="HoIj1cjV8reNwzM1vqGsx0,VgrVInlTs2rMLGb0GxZFIZ" />
+              <Link Id="R8d4XEVC7kdOK6dMrS1itt" Ids="UJv4WuOOxieMOcjRVHQaqw,GCCMO5QJCZgMWQ51cLXg7J" />
+              <Link Id="T1ilSRPu6UiPdiP53rGcUF" Ids="GCCMO5QJCZgMWQ51cLXg7J,QjB0H7nOSKwPnUlWNxUmq1" />
             </Patch>
           </Node>
         </Canvas>
@@ -26565,6 +26658,8 @@
                 <Pin Id="Gh5F4Rb2TO4P15QGELVyug" Name="Back Buffer" Kind="OutputPin" />
                 <Pin Id="NtvIm4N9BUIPL1kD3Urbad" Name="Depth Buffer" Kind="OutputPin" />
                 <Pin Id="NwhRVp4YITvNfynyGyDyqf" Name="Present Call Intercept" Kind="InputPin" IsHidden="true" />
+                <Pin Id="FM6rs60Mre2MWC8qSc3jCB" Name="Output Color Space" Kind="InputPin" />
+                <Pin Id="DqAMSXEnKSaObfwuQ8d6g2" Name="Backbuffer Format" Kind="InputPin" />
               </Node>
               <ControlPoint Id="PukR1teAvW5NhcXXfUWwqo" Bounds="265,411" />
               <ControlPoint Id="TvQVSIc1QD4PQoPl3V0VBB" Bounds="297,433" />
@@ -28985,7 +29080,7 @@
               <Pin Id="TN6fAHcDBEDObvk3mj7vEX" Name="Offset" Kind="InputPin" />
             </Patch>
             <Patch Id="S464ytM6OFJN3A5VrBuzHp" Name="SetChildren">
-              <Pin Id="S6ThIKr1MHeMut5HH9r0h3" Name="Child" Kind="InputPin" PinGroupDefaultCount="1">
+              <Pin Id="S6ThIKr1MHeMut5HH9r0h3" Name="Child" Kind="InputPin">
                 <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
@@ -29253,6 +29348,159 @@
             <Link Id="MnXY9bSjK6xO4sCaMAptmN" Ids="P9A7zVLvio2QZsgU3DJf4H,Couh8JcMSiINpugzDtnzQU" IsHidden="true" />
             <Link Id="LZ1rrqAhXckM7IZithESqy" Ids="VXIjUUpH6MeOhm1n6DwVLL,NFj1QS1bidEMcmx5WXZMv1" />
             <Link Id="CYvX8NIk3yWPAzCmV6QcQt" Ids="Bn0sAUXd8eEMXtx8fdJiVU,VXIjUUpH6MeOhm1n6DwVLL" IsHidden="true" />
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ OutputColorSpaces ************************
+
+-->
+        <Node Name="OutputColorSpaces" Bounds="579,261" Id="Lt9nwrSVvIIMmWKvPyN6Sw" Summary="Creates the 3 most common rendering output configurations for color space and pixelformat.">
+          <p:NodeReference>
+            <Choice Kind="ContainerDefinition" />
+          </p:NodeReference>
+          <Patch Id="VPSCjDNrd9yNnwL1GWi6XC">
+            <Canvas Id="QMOQn16ofNpMFxQfpRdFQT" CanvasType="Group">
+              <ControlPoint Id="KXuqqH9zMdzLZ47s1ULDw2" Bounds="353,200" />
+              <Node Bounds="339,233,519,206" Id="I580PQiwcarMXP3DQi8btW">
+                <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                  <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Primitive" />
+                  <Choice Kind="ProcessStatefulRegion" Name="Cache" />
+                </p:NodeReference>
+                <Pin Id="D3GqmTjM63gOEj0oW8C7Lo" Name="Force" Kind="InputPin" />
+                <Pin Id="Ivk4MEY8qOgNVMA5870Edh" Name="Dispose Cached Outputs" Kind="InputPin" />
+                <Pin Id="U2TNNc2AgRLOT47eORIGud" Name="Has Changed" Kind="OutputPin" />
+                <Patch Id="GcJjSxfGBbXON9x4eJqnv2" ManuallySortedPins="true">
+                  <Patch Id="G9v5gsEOngXLGeSGN4T5R0" Name="Create" ManuallySortedPins="true" />
+                  <Patch Id="GmXGCUm4NzUN9Clnalcg4r" Name="Then" ManuallySortedPins="true" />
+                  <Node Bounds="351,370,45,19" Id="TTy3fDtuK1QOiLF7zHEZ9d">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
+                    </p:NodeReference>
+                    <Pin Id="NPEu2zdTlWOPnPX1LjnXrV" Name="Condition" Kind="InputPin" />
+                    <Pin Id="J4Knc3UKHClP7locqSiD5q" Name="Input" Kind="InputPin" />
+                    <Pin Id="PVdfN5jzH1lLPAm9pmfzhx" Name="Input 2" Kind="InputPin" />
+                    <Pin Id="GfCbJRDphA8NmmDtXaYJWX" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Pad Id="Tr0yCOBKv1wM5BJsUT4gJ2" Comment="" Bounds="373,262,169,15" ShowValueBox="true" isIOBox="true" Value="RgbFullG22NoneP709">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="VL.Stride.Rendering.vl">
+                      <Choice Kind="TypeFlag" Name="ColorSpaceType" />
+                    </p:TypeAnnotation>
+                  </Pad>
+                  <Pad Id="GnvHfCArpD8OK8zY6lUNGu" Comment="" Bounds="413,291,169,15" ShowValueBox="true" isIOBox="true" Value="RgbFullG10NoneP709">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="VL.Stride.Rendering.vl">
+                      <Choice Kind="TypeFlag" Name="ColorSpaceType" />
+                    </p:TypeAnnotation>
+                  </Pad>
+                  <Node Bounds="578,370,45,19" Id="PhRWoWiiqBPMKci5VFYdYK">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
+                    </p:NodeReference>
+                    <Pin Id="OsTBCRc5YImPnzZ6MM6M8B" Name="Condition" Kind="InputPin" />
+                    <Pin Id="JlB0tUYIUtTLTPg5awkoD8" Name="Input" Kind="InputPin" />
+                    <Pin Id="LpBJCUPClqsPJv9wflPPUF" Name="Input 2" Kind="InputPin" />
+                    <Pin Id="DwSjRB3z7chLR5TtvFiFsc" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Pad Id="FmsVY3vGXjSOedMpYTssOO" Comment="" Bounds="600,261,167,15" ShowValueBox="true" isIOBox="true" Value="R8G8B8A8_UNorm_SRgb">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                      <Choice Kind="TypeFlag" Name="PixelFormat" />
+                    </p:TypeAnnotation>
+                  </Pad>
+                  <Pad Id="S2MPODuFXGkOa5rnaYgnbo" Comment="" Bounds="640,290,167,15" ShowValueBox="true" isIOBox="true" Value="R16G16B16A16_Float">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                      <Choice Kind="TypeFlag" Name="PixelFormat" />
+                    </p:TypeAnnotation>
+                  </Pad>
+                  <Node Bounds="618,330,45,19" Id="F8Zyhgi02CxLAeHELrORkT">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
+                    </p:NodeReference>
+                    <Pin Id="FcA1trWJ2xeL27pdRgKEOw" Name="Condition" Kind="InputPin" />
+                    <Pin Id="IW3DKk3DI68MTgHBPs5nHb" Name="Input" Kind="InputPin" />
+                    <Pin Id="A0meVUUlgxUNXJGh9PpIAM" Name="Input 2" Kind="InputPin" />
+                    <Pin Id="T8MaB4FkZ3kOdA2SzxCIqc" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Node Bounds="391,340,45,19" Id="K1y0AXiA6MyMWLRKXnvSMx">
+                    <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                      <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
+                    </p:NodeReference>
+                    <Pin Id="Lqwf0fu6EGOLgQgvuqU5O0" Name="Condition" Kind="InputPin" />
+                    <Pin Id="B8AIoRaiTnUPUzOmQ9YNGQ" Name="Input" Kind="InputPin" />
+                    <Pin Id="SMDO6sxBxrTMU5Trsb0tjm" Name="Input 2" Kind="InputPin" />
+                    <Pin Id="RKslE4tdqh0OsLBCilOgo2" Name="Output" Kind="OutputPin" />
+                  </Node>
+                  <Pad Id="D0mjcYS43riMMUkyXIPofi" Comment="" Bounds="660,311,167,15" ShowValueBox="true" isIOBox="true" Value="R10G10B10A2_UNorm">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                      <Choice Kind="TypeFlag" Name="PixelFormat" />
+                    </p:TypeAnnotation>
+                  </Pad>
+                  <Pad Id="IVGEgdPHcgBQUsLPUgNM2s" Comment="" Bounds="433,320,169,15" ShowValueBox="true" isIOBox="true" Value="RgbFullG2084NoneP2020">
+                    <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="VL.Stride.Rendering.vl">
+                      <Choice Kind="TypeFlag" Name="ColorSpaceType" />
+                    </p:TypeAnnotation>
+                  </Pad>
+                </Patch>
+                <ControlPoint Id="UB3f2JogRsDQVZyt6c9ZxY" Bounds="353,239" Alignment="Top" />
+                <ControlPoint Id="MoHlwXQUdoqLESQTJ0V1US" Bounds="353,433" Alignment="Bottom" />
+                <ControlPoint Id="LkjOM31vXtLLXRYKecpOM9" Bounds="580,433" Alignment="Bottom" />
+                <ControlPoint Id="DFDhKVVr6IZMTyMdVpMN0g" Bounds="451,239" Alignment="Top" />
+              </Node>
+              <ControlPoint Id="DieW5ajoIZtPA7DVM6vHNt" Bounds="353,469" />
+              <ControlPoint Id="IONzf8UA1asO1yevFz30SX" Bounds="580,470" />
+              <ControlPoint Id="A55xOoBraM7NriHUhH7w3q" Bounds="451,200" />
+            </Canvas>
+            <Patch Id="L7TpUB1WwOhLVSFrMqQVZ3" Name="Create" />
+            <Patch Id="VyPztbh0cYwO1qlGT4M1R0" Name="Update">
+              <Pin Id="QEFl21lHe7PLGDqZguvpFj" Name="Is HDR" Kind="InputPin" Summary="Switch between SDR and HDR output modes." />
+              <Pin Id="JtJB9cnQDIZPpD7sVgeHYd" Name="Color Space" Kind="OutputPin">
+                <p:TypeAnnotation LastCategoryFullName="Stride.Graphics" LastDependency="VL.Stride.Rendering.vl">
+                  <Choice Kind="TypeFlag" Name="ColorSpaceType" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="Kr9d7j7LmKEN8l9yqUTIHr" Name="Format" Kind="OutputPin">
+                <p:TypeAnnotation LastCategoryFullName="Stride.API.Graphics" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                  <Choice Kind="TypeFlag" Name="PixelFormat" />
+                  <FullNameCategoryReference ID="Stride.API.Graphics" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="EmKnTEKToHxPuwYJ1pAATn" Name="Is HDR10" Kind="InputPin" Summary="If true, 10-bit with PQ transfer function and Rec.2020 primaries color space is expected, else linear color space (scRGB) is expectd and windows will take care of the color conversion." />
+            </Patch>
+            <!--
+
+    ************************  ************************
+
+-->
+            <ProcessDefinition Id="NJf0kVaDaxcOzQVlZdNzgT">
+              <Fragment Id="UtBwuGcqHIML3fB71n1mnw" Patch="L7TpUB1WwOhLVSFrMqQVZ3" Enabled="true" />
+              <Fragment Id="GRvXwmrifzNOuvbQOXXE9O" Patch="VyPztbh0cYwO1qlGT4M1R0" Enabled="true" />
+            </ProcessDefinition>
+            <Link Id="Ao9Iw8Fv4MiP9rtESqh91A" Ids="QEFl21lHe7PLGDqZguvpFj,KXuqqH9zMdzLZ47s1ULDw2" IsHidden="true" />
+            <Link Id="DUzTZ69zfhVN9PIzrcsjDW" Ids="KXuqqH9zMdzLZ47s1ULDw2,UB3f2JogRsDQVZyt6c9ZxY" />
+            <Link Id="OBfsFg6g7OQPyeg648CKSr" Ids="UB3f2JogRsDQVZyt6c9ZxY,NPEu2zdTlWOPnPX1LjnXrV" />
+            <Link Id="Qn1tnfYJVzFLP09yXtVMCc" Ids="GfCbJRDphA8NmmDtXaYJWX,MoHlwXQUdoqLESQTJ0V1US" />
+            <Link Id="DPHQ9coGgf2MHGZGkb3AXI" Ids="MoHlwXQUdoqLESQTJ0V1US,DieW5ajoIZtPA7DVM6vHNt" />
+            <Link Id="P0WoxpAdCc8PLGH33snnJS" Ids="Tr0yCOBKv1wM5BJsUT4gJ2,J4Knc3UKHClP7locqSiD5q" />
+            <Link Id="H2LDwmYNVZSMxmsOwroR8r" Ids="DwSjRB3z7chLR5TtvFiFsc,LkjOM31vXtLLXRYKecpOM9" />
+            <Link Id="OQi6qUxIhguNfm3QFo6ZSn" Ids="LkjOM31vXtLLXRYKecpOM9,IONzf8UA1asO1yevFz30SX" />
+            <Link Id="MeNf55BGTi6NebTgU6MGB9" Ids="IONzf8UA1asO1yevFz30SX,Kr9d7j7LmKEN8l9yqUTIHr" IsHidden="true" />
+            <Link Id="UC5XcVr688XP3B2dXNukYs" Ids="DieW5ajoIZtPA7DVM6vHNt,JtJB9cnQDIZPpD7sVgeHYd" IsHidden="true" />
+            <Link Id="KvSbuS66Q7pOMqSvB2I7l3" Ids="UB3f2JogRsDQVZyt6c9ZxY,OsTBCRc5YImPnzZ6MM6M8B" />
+            <Link Id="Fv7ju6l7vmYN0lraHyvLPh" Ids="FmsVY3vGXjSOedMpYTssOO,JlB0tUYIUtTLTPg5awkoD8" />
+            <Link Id="DMsuLDRvIFBM6kfmKmfs9S" Ids="T8MaB4FkZ3kOdA2SzxCIqc,LpBJCUPClqsPJv9wflPPUF" />
+            <Link Id="RIhZZoAM9MFO3XWeAxjeI5" Ids="S2MPODuFXGkOa5rnaYgnbo,IW3DKk3DI68MTgHBPs5nHb" />
+            <Link Id="KuDtpMV0eHoQDdxv1JOA5o" Ids="GnvHfCArpD8OK8zY6lUNGu,B8AIoRaiTnUPUzOmQ9YNGQ" />
+            <Link Id="Mb1WaCIID4vLyjP1mNX88O" Ids="RKslE4tdqh0OsLBCilOgo2,PVdfN5jzH1lLPAm9pmfzhx" />
+            <Link Id="OwhSxfypWTgPt238PANWvt" Ids="D0mjcYS43riMMUkyXIPofi,A0meVUUlgxUNXJGh9PpIAM" />
+            <Link Id="RvcBBV4tHD0NPb8IppxXgo" Ids="IVGEgdPHcgBQUsLPUgNM2s,SMDO6sxBxrTMU5Trsb0tjm" />
+            <Link Id="ND2JWMbqASJQLmvRSceJwZ" Ids="DFDhKVVr6IZMTyMdVpMN0g,Lqwf0fu6EGOLgQgvuqU5O0" />
+            <Link Id="FQKBmvfi3ivPdzJaqO0Z8d" Ids="A55xOoBraM7NriHUhH7w3q,DFDhKVVr6IZMTyMdVpMN0g" />
+            <Link Id="FO4KBV2O4LuMcVAnV7pyxg" Ids="EmKnTEKToHxPuwYJ1pAATn,A55xOoBraM7NriHUhH7w3q" IsHidden="true" />
+            <Link Id="Ryxp9DGzUDVLCs1lHGcjil" Ids="DFDhKVVr6IZMTyMdVpMN0g,FcA1trWJ2xeL27pdRgKEOw" />
           </Patch>
         </Node>
       </Canvas>
@@ -29655,8 +29903,8 @@
         <Patch Id="Q1CM3G4fc7KMaNaIzvGabR">
           <Canvas Id="Kk5Fqcv7oMtNpqDAGfvtQY" CanvasType="Group">
             <ControlPoint Id="EEQ60u0n9ATNadblUovIX7" Bounds="811,985" />
-            <ControlPoint Id="RzkQ5YRhHQALLkSoQA085R" Bounds="200,1124,312,0" />
-            <Node Bounds="198,1062,577,19" Id="FXcVasK44MaL8n0KHQsqR1">
+            <ControlPoint Id="RzkQ5YRhHQALLkSoQA085R" Bounds="201,1233,312,0" />
+            <Node Bounds="199,1171,577,19" Id="FXcVasK44MaL8n0KHQsqR1">
               <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="RenderWindow" />
@@ -29693,6 +29941,8 @@
               <Pin Id="S3gzgF5mh3xMvb0DQhN91z" Name="Back Buffer" Kind="OutputPin" />
               <Pin Id="GgA7RAEKzT4PxFF12XjVHd" Name="Depth Buffer" Kind="OutputPin" />
               <Pin Id="MAY2fcZOXjZOI9ZEftOBAQ" Name="Present Call Intercept" Kind="InputPin" />
+              <Pin Id="E9jCTHvorhKO00GEkgu45z" Name="Output Color Space" Kind="InputPin" />
+              <Pin Id="NiGpuFDdNiuLwN8K7PGNfZ" Name="Backbuffer Format" Kind="InputPin" />
             </Node>
             <ControlPoint Id="DvjFGxnGxaSPTK1FcsQgVt" Bounds="505,1028" />
             <ControlPoint Id="Eki1GrF8SxSLRnbvFtLux0" Bounds="203,880" />
@@ -29842,15 +30092,15 @@
               <Pin Id="NJxx9OPqh2RP7bkY7DjLNa" Name="Output" Kind="StateOutputPin" />
             </Node>
             <ControlPoint Id="KGqYDP8qA9rLvR5YMRR0Qp" Bounds="583,233" />
-            <ControlPoint Id="CvNisdXaqO9LpQiIZRGho7" Bounds="581,1121" />
-            <ControlPoint Id="EehkFgavn2rMQdIIeu59wH" Bounds="772,1121" />
-            <ControlPoint Id="TcqlUgsYNvuPmnmxgiinjs" Bounds="392,1127" />
+            <ControlPoint Id="CvNisdXaqO9LpQiIZRGho7" Bounds="582,1230" />
+            <ControlPoint Id="EehkFgavn2rMQdIIeu59wH" Bounds="773,1230" />
+            <ControlPoint Id="TcqlUgsYNvuPmnmxgiinjs" Bounds="393,1236" />
             <ControlPoint Id="Nnfxz5WeNreNFoWhN6rXWx" Bounds="774,409" />
             <ControlPoint Id="DvJXBiwCBHhPRu1sA4q3pP" Bounds="793,434" />
             <ControlPoint Id="IVrLLHXz5AwLo1wrT8T42F" Bounds="735,368" />
             <ControlPoint Id="RoQOpqHnX0ZNOOol5cG4Mz" Bounds="755,387" />
             <ControlPoint Id="DXGyS6vUKGcMBG3BhN6Adw" Bounds="854,499" />
-            <ControlPoint Id="B0fF6iNZd6BMup6lSUCef1" Bounds="278,1127" />
+            <ControlPoint Id="B0fF6iNZd6BMup6lSUCef1" Bounds="279,1236" />
             <ControlPoint Id="F0ICA9wCXwCPwMN141dGHe" Bounds="834,479" />
             <ControlPoint Id="Mql7wdXUaRULouesZSL31N" Bounds="641,305" />
             <ControlPoint Id="TY4dv6OZmS7M3rh4aH1Crr" Bounds="814,456" />
@@ -29985,6 +30235,9 @@
             <ControlPoint Id="NoEYVtjX1mmNAJACHppexu" Bounds="869,1042" />
             <ControlPoint Id="R2iqL9L7SMdN7b4lYq9sPq" Bounds="459,1000" />
             <ControlPoint Id="I4YAzH2esqiMozMTnDYXPI" Bounds="182,590" />
+            <ControlPoint Id="LNaBdG1eIwtNwcLtgh0qtD" Bounds="606,949" />
+            <ControlPoint Id="VvR0KsTl5WOQOigygS4Pws" Bounds="869,1090" />
+            <ControlPoint Id="MwgNLs25K9FP7KfBpat9ox" Bounds="893,1110" />
           </Canvas>
           <Link Id="JKnUileeJ7FNJsu7KpPf94" Ids="G7SBfHwE22bMfljT0fnHrW,EEQ60u0n9ATNadblUovIX7" IsHidden="true" />
           <Link Id="ToLCItn5JyDMzpOHiAEnJu" Ids="RzkQ5YRhHQALLkSoQA085R,Hdw9ETxxng9OxCDbLeNcTB" IsHidden="true" />
@@ -30068,6 +30321,7 @@
             <Fragment Id="IzWNXnYO95QN8WwpoYgyJi" Patch="VnB7dRwuoWoN5IyXhYChtZ" Enabled="true" />
             <Fragment Id="OBVUa3UNeN2O90hR2mG9Ni" Patch="TBD6Xc1bmYhN5YxHX2qcT2" Enabled="true" />
             <Fragment Id="NIspjfyJGYhNeMojkskfvK" Patch="EVKYc8mGuP7MPiherWjoJc" Enabled="true" />
+            <Fragment Id="A2jdOrMUoL7NXfNc88sFUl" Patch="QTxVBHWf26UNYgqW8rq8Mw" Enabled="true" />
           </ProcessDefinition>
           <Link Id="BS81b9ULH0MQYXrSiMN1n2" Ids="OOsflcfqABvOwzGSsfvwIp,VghSJuU3XH2O2lcYUdshlp" />
           <Link Id="SoJL1vvHW3DPkRMJvgYxze" Ids="HFWw5ZrzJ1UOHAt7pZfH7T,OOsflcfqABvOwzGSsfvwIp" IsHidden="true" />
@@ -30166,7 +30420,7 @@
           <Link Id="Td4sjiVvu2lOHeRgv3uZMo" Ids="ICFUApJ2RqfNrbiZMFGYWY,JsKzYIErYjKPrCV6tW9lfP" />
           <Link Id="OSVCAFJ1CYnOallubQEcHH" Ids="ICFUApJ2RqfNrbiZMFGYWY,Bx5OwBHzGi0QOBGtXYXSUx" />
           <Link Id="QHJJNjsU904Md23gDrDDuD" Ids="PI9BhwnKl5EOSJCYjYec0A,SBtYUzUfUtrO1wdE00zadJ" />
-          <Link Id="VSu6H5wWYc2O5BampudIyB" Ids="PI9BhwnKl5EOSJCYjYec0A,I8Cr2sv3dleOepnlnYYtX0" />
+          <Link Id="VSu6H5wWYc2O5BampudIyB" Ids="PI9BhwnKl5EOSJCYjYec0A,LNaBdG1eIwtNwcLtgh0qtD,I8Cr2sv3dleOepnlnYYtX0" />
           <Slot Id="VRHawibchJBNRIwaKMJNiZ" Name="idle" />
           <Link Id="QixUnzocuvtOtsoraUlO10" Ids="NzlD3yuZDM6Lpovhml8BRA,JLsv06ll0AONQSXfLI68tr" />
           <Link Id="QbOhLMhbwrgM92ye5IYgvP" Ids="PSmsEBts5InLN6oQZjC19H,GiUrw0lx3XQNzWFIgCb5oR" />
@@ -30192,6 +30446,14 @@
           <Link Id="NHNvvlWSmiKLEGRloGNMBG" Ids="OaTf3Rej9B1NA9Mk2kQNxB,KC9f59sho9NO0PFibqJwwR" IsFeedback="true" />
           <Link Id="KlBiSdIacypLhFanboMs38" Ids="KNMbhGfeN6FNnDrAF9qfb0,KC9f59sho9NO0PFibqJwwR" />
           <Link Id="PNoLfXFlgA7OA1U9R22CdW" Ids="KC9f59sho9NO0PFibqJwwR,I4YAzH2esqiMozMTnDYXPI,ARc3OjHs7CzPBRI8fSPR8P" />
+          <Patch Id="QTxVBHWf26UNYgqW8rq8Mw" Name="SetOutputColorSpace">
+            <Pin Id="AtCilpXe3LmPcsWc49Ytvk" MergeId="64366" Name="Output Color Space" Kind="InputPin" Visibility="Optional" />
+            <Pin Id="PxG4HTy7lAOPX1vFb60t6Y" MergeId="64367" Name="Backbuffer Format" Kind="InputPin" DefaultValue="R8G8B8A8_UNorm_SRgb" Visibility="Optional" />
+          </Patch>
+          <Link Id="E7pnVJPK0h7NTruS7NSQIV" Ids="AtCilpXe3LmPcsWc49Ytvk,VvR0KsTl5WOQOigygS4Pws" IsHidden="true" />
+          <Link Id="Cjoh18Lmat0M8IDBhQp7qP" Ids="PxG4HTy7lAOPX1vFb60t6Y,MwgNLs25K9FP7KfBpat9ox" IsHidden="true" />
+          <Link Id="DqwtAOGlVUqNzIujMfG9wI" Ids="VvR0KsTl5WOQOigygS4Pws,E9jCTHvorhKO00GEkgu45z" />
+          <Link Id="P4ptOYyqDvCMOfxvK4SKvb" Ids="MwgNLs25K9FP7KfBpat9ox,NiGpuFDdNiuLwN8K7PGNfZ" />
         </Patch>
       </Node>
       <!--
@@ -30450,7 +30712,7 @@
               <Pin Id="IcRV0woI68bPAoXW1R4Ihs" Name="Output" Kind="StateOutputPin" />
             </Node>
             <ControlPoint Id="UKTaUgWOOdVLjq9NWkiYZo" Bounds="890,626" />
-            <ControlPoint Id="SurEB42NM1DNmjWeVSdTCi" Bounds="768,-218" />
+            <ControlPoint Id="SurEB42NM1DNmjWeVSdTCi" Bounds="752,-302" />
             <Pad Id="Ml1nY1xILzOOOWuDet7Pvj" Bounds="953,375,175,19" ShowValueBox="true" isIOBox="true" Value="that doesn't occur too often">
               <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
@@ -30673,17 +30935,18 @@
             <Pad Id="UD8gOG2u4TWOfHUwjQniTJ" SlotId="T4QVG8EitL9PYMmIkpDdit" Bounds="380,812" />
             <Pad Id="HjlKEbTHkp2MqDmagbsjvS" SlotId="PAV2QLEHIawLiiMQjeCSBx" Bounds="49,1004" />
             <Overlay Id="U0VWKppbMlKO1tpNFLIDKg" Name="Update" Bounds="-65,663,657,426" />
-            <Node Bounds="821,-29,145,19" Id="SccbkpZLMnHQHA2h8BFgzN">
+            <Node Bounds="741,-20,284,19" Id="SccbkpZLMnHQHA2h8BFgzN">
               <p:NodeReference LastCategoryFullName="Stride.Windowing" LastDependency="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="GameWindowManager" />
               </p:NodeReference>
               <Pin Id="Q23VUf7wiH7Lksdd8TSaJx" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="Iszjff4UEYtNi7kAKaQdmc" Name="Bounds In Pixels" Kind="InputPin" />
-              <Pin Id="KN4dOSRlACeQU56E4zgyBQ" Name="Back Buffer Format" Kind="InputPin" />
               <Pin Id="LivoAB5rQk6LKGHMzqu6F6" Name="Multisample Count" Kind="InputPin" />
+              <Pin Id="KN4dOSRlACeQU56E4zgyBQ" Name="Back Buffer Format" Kind="InputPin" />
               <Pin Id="SDiA12YTMC7NsMHo1b0oMz" Name="Depth Buffer Format" Kind="InputPin" />
               <Pin Id="PT3zkJZcgLUL0ddMNVFMqc" Name="Graphics Profile" Kind="InputPin" />
+              <Pin Id="LWqEriOLR1ePWOZ6XA94Kh" Name="Presenter Color Space" Kind="InputPin" />
               <Pin Id="Gjsy3BUdG2lNtaXVMiOF1G" Name="Input Priority" Kind="InputPin" />
               <Pin Id="Kmxqv7AsWDzOFvZPoCMvLj" Name="Present Interval" Kind="InputPin" />
               <Pin Id="Ijvt2pnk9AqMBE5x1Y8R3G" Name="Output" Kind="OutputPin" />
@@ -30692,6 +30955,8 @@
               <Pin Id="CPiM9qGNWQTO5fxfG0PKIP" Name="Back Buffer" Kind="OutputPin" />
               <Pin Id="TeF5xbbG8WgP3WweJcrENT" Name="Depth Buffer" Kind="OutputPin" />
               <Pin Id="RcwjrG2zJ1FPuD8XNfUxfc" Name="Present Call Intercept" Kind="InputPin" />
+              <Pin Id="C8jivDCl1ZRQGNfGmjT9Ze" Name="Output Color Space" Kind="InputPin" />
+              <Pin Id="FnfstYyhv6tMb0EuvlwNcM" Name="Backbuffer Format" Kind="InputPin" />
             </Node>
             <ControlPoint Id="JWaZkXlUJPuQBGBryZcVCO" Bounds="-78,230" />
             <ControlPoint Id="LrehaedcjjPLkYyRRnQg2T" Bounds="883,69" />
@@ -30717,10 +30982,10 @@
               <Pin Id="Fbm2NI34INMOMCYvSwPSCL" Name="Title" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="DhJQBA7SLTjOrQeyR8Gf1q" Bounds="226,750" />
-            <ControlPoint Id="MHMulHwpQk2OrOCH16rwHB" Bounds="903,-64" />
-            <ControlPoint Id="GEozdBrsXpJMk4wlTULf4w" Bounds="863,-94" />
-            <ControlPoint Id="O5aSSY8jK93O7CDfOIfQKE" Bounds="913,40" />
-            <ControlPoint Id="Ow0y4l4ADaMNcS9GefpyGM" Bounds="943,10" />
+            <ControlPoint Id="MHMulHwpQk2OrOCH16rwHB" Bounds="848,-120" />
+            <ControlPoint Id="GEozdBrsXpJMk4wlTULf4w" Bounds="802,-160" />
+            <ControlPoint Id="O5aSSY8jK93O7CDfOIfQKE" Bounds="924,40" />
+            <ControlPoint Id="Ow0y4l4ADaMNcS9GefpyGM" Bounds="1022,40" />
             <Node Bounds="219,502,93,19" Id="Ks6TEq9bjGTOVLl7a8Jz48">
               <p:NodeReference LastCategoryFullName="Stride.Windowing" LastDependency="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -30935,7 +31200,7 @@
               <Pin Id="KYKX2enE4gSOBkWAWTgZV1" Name="Output" Kind="StateOutputPin" />
               <Pin Id="DnccpXrES6HLa9Yt0GhhXg" Name="Focused" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="BmBp8p8WkRwLHr3NbnoEHI" Bounds="943,-44" />
+            <ControlPoint Id="BmBp8p8WkRwLHr3NbnoEHI" Bounds="1010,-99" />
             <Pad Id="OMOt5v0gvSVLkAhs7FGTQU" SlotId="Jf4IxaFiXGzLGGonLcJzRw" Bounds="883,26" />
             <Pad Id="NNl1qfdf7zNOcLfKflQrgh" SlotId="Jf4IxaFiXGzLGGonLcJzRw" Bounds="408,520" />
             <ControlPoint Id="NeI6TrTgmyFL03KXYhzn7O" Bounds="364,-208" />
@@ -31109,7 +31374,7 @@
                 <Pin Id="S6Vr4iP3V3lMvsoXA43bys" Name="Graphics Outputs" Kind="InputPin" Bounds="1007,-655" />
               </Patch>
             </Node>
-            <Node Bounds="783,-146,89,19" Id="ESgLahGkRchOiS0hRMzpZx">
+            <Node Bounds="741,-220,89,19" Id="ESgLahGkRchOiS0hRMzpZx">
               <p:NodeReference LastCategoryFullName="Stride.RenderWindow" LastDependency="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetBoundsRight" />
@@ -31234,7 +31499,7 @@
             </Node>
             <ControlPoint Id="Dt08CHyNOHAQQOovvzy4zo" Bounds="153,1057" />
             <Pad Id="OI862sAjPluPTiWjiXcnvB" SlotId="PAV2QLEHIawLiiMQjeCSBx" Bounds="515,-201" />
-            <Node Bounds="842,-202,70,19" Id="QbNyoP5LQ0aL69zrc1p2lJ">
+            <Node Bounds="826,-286,70,19" Id="QbNyoP5LQ0aL69zrc1p2lJ">
               <p:NodeReference LastCategoryFullName="Stride.Windowing" LastDependency="VL.Stride.Graphics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="AdapterInfo" />
@@ -31439,7 +31704,7 @@
               <Pin Id="QTdf87G39jNLfL0Imc132L" Name="Value" Kind="InputPin" />
               <Pin Id="HAQ2OWI6puJNzvTE5wyzR5" Name="Value" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="OP8IZ5MrzxONExzIeI2LjN" Bounds="881,-80" />
+            <ControlPoint Id="OP8IZ5MrzxONExzIeI2LjN" Bounds="824,-140" />
             <Node Bounds="742,194,57,19" Id="ENxpumptD1BMRP1qGNO2tz">
               <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -31569,8 +31834,10 @@
               <Pin Id="O2Gk0YyCqS7ObWpIPYTfWm" Name="Current" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="Ko9uuE6xSYQOKehGYDUwtU" Bounds="149,-240" />
-            <ControlPoint Id="HLYYVJMAh9lO4OtRfpllBs" Bounds="1040,-47" />
-            <ControlPoint Id="SrMDSOJouEDN9MtWYnV359" Bounds="1014,-90" />
+            <ControlPoint Id="HLYYVJMAh9lO4OtRfpllBs" Bounds="1031,-79" />
+            <ControlPoint Id="SrMDSOJouEDN9MtWYnV359" Bounds="904,-80" />
+            <ControlPoint Id="HYv7y6KN3asLv1tiWBLXSj" Bounds="1051,-59" />
+            <ControlPoint Id="R8Cfs08eOqMM7lIur3Dovh" Bounds="1075,-39" />
           </Canvas>
           <Slot Id="PAV2QLEHIawLiiMQjeCSBx" Name="Game Window" />
           <Link Id="V7zVQDv7tilLMv638pLUGg" Ids="Aovd7gXzFIqPW6xwdW7oln,MUiMMxbgDwTMwpBxtCke2j" IsHidden="true" />
@@ -31718,6 +31985,7 @@
             <Fragment Id="TY9R43BBB4RN9ZbSLjpveX" Patch="RStOsMz4gHoN3igS9gs3PX" />
             <Fragment Id="Dxki9OHvXSUMUMtKkmXzuK" Patch="G1Kr1lam7kaLmLyJNKwfAf" />
             <Fragment Id="Pr3bktKGtFUMfIcGpUfUO6" Patch="M8O4yzgliPeO0sSuF6h9fg" Enabled="true" />
+            <Fragment Id="GzezCqpUfQ9N3lw79J8M4m" Patch="RcsomEkpX9tNy66FiD8vPY" Enabled="true" />
           </ProcessDefinition>
           <Link Id="MsiroA9GNILLt5N74XnrKK" Ids="OI862sAjPluPTiWjiXcnvB,Kxc0JPrhMdNONquxpqH63G" />
           <Link Id="IwK8HOUNRNFPQMDsAxOrAn" Ids="D9xZQrFgJLKOqsHxeLZoH7,Itw9qLp5wddQAYWLmdkBH5" />
@@ -31817,6 +32085,14 @@
           <Link Id="MnRxiBaldKQM73e2PT4D8B" Ids="HLYYVJMAh9lO4OtRfpllBs,RcwjrG2zJ1FPuD8XNfUxfc" />
           <Link Id="IlYQVKoEDw5LtOJBRkixMf" Ids="SrMDSOJouEDN9MtWYnV359,Gjsy3BUdG2lNtaXVMiOF1G" />
           <Link Id="CyPNOX3bQJiOqHOrAS11Bs" Ids="PAVIxxUArNQNDHN8eEuuJc,SrMDSOJouEDN9MtWYnV359" IsHidden="true" />
+          <Patch Id="RcsomEkpX9tNy66FiD8vPY" Name="SetOutputColorSpace">
+            <Pin Id="EvGIgpla16LNTtQT3fS738" MergeId="77394" Name="Output Color Space" Kind="InputPin" Visibility="Optional" />
+            <Pin Id="JPXBlntGMjXPVaIboHA00r" MergeId="77476" Name="Backbuffer Format" Kind="InputPin" DefaultValue="R8G8B8A8_UNorm_SRgb" Visibility="Optional" />
+          </Patch>
+          <Link Id="TuQOa5dkZ5NOwZatHZosJZ" Ids="EvGIgpla16LNTtQT3fS738,HYv7y6KN3asLv1tiWBLXSj" IsHidden="true" />
+          <Link Id="SyaXn8k4HUTQH4UuyiFos8" Ids="JPXBlntGMjXPVaIboHA00r,R8Cfs08eOqMM7lIur3Dovh" IsHidden="true" />
+          <Link Id="FNKXpdJBQFqLhOJzDMF5bP" Ids="HYv7y6KN3asLv1tiWBLXSj,C8jivDCl1ZRQGNfGmjT9Ze" />
+          <Link Id="MUmjdPmuyTOPqlojgAa5Dw" Ids="R8Cfs08eOqMM7lIur3Dovh,FnfstYyhv6tMb0EuvlwNcM" />
         </Patch>
       </Node>
       <!--

--- a/VL.Stride.Runtime/src/Games/GameWindowRenderer.cs
+++ b/VL.Stride.Runtime/src/Games/GameWindowRenderer.cs
@@ -122,6 +122,7 @@ namespace VL.Stride.Games
                     DepthStencilFormat = WindowManager.PreferredDepthStencilFormat,
                     PresentationInterval = PresentInterval.Immediate,
                     MultisampleCount = WindowManager.PreferredMultisampleCount,
+                    OutputColorSpace = WindowManager.PreferredPresenterColorSpace,
                 };
 
 #if STRIDE_GRAPHICS_API_DIRECT3D11 && STRIDE_PLATFORM_UWP

--- a/VL.Stride.Runtime/src/Games/GameWindowRendererManager.cs
+++ b/VL.Stride.Runtime/src/Games/GameWindowRendererManager.cs
@@ -43,6 +43,8 @@ namespace VL.Stride.Games
 
         private PixelFormat preferredBackBufferFormat;
 
+        private ColorSpaceType preferredPresenterColorSpace;
+
         private int preferredBackBufferHeight;
 
         private int preferredBackBufferWidth;
@@ -86,6 +88,7 @@ namespace VL.Stride.Games
 
             // Set defaults
             PreferredBackBufferFormat = PixelFormat.R8G8B8A8_UNorm;
+            PreferredPresenterColorSpace = ColorSpaceType.RgbFullG22NoneP709;
             PreferredDepthStencilFormat = PixelFormat.D24_UNorm_S8_UInt;
             PreferredBackBufferWidth = 1280;
             PreferredBackBufferHeight = 720;
@@ -265,6 +268,28 @@ namespace VL.Stride.Games
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or sets the preferred back buffer format.
+        /// </summary>
+        /// <value>The preferred back buffer format.</value>
+        public ColorSpaceType PreferredPresenterColorSpace
+        {
+            get
+            {
+                return preferredPresenterColorSpace;
+            }
+
+            set
+            {
+                if (preferredPresenterColorSpace != value)
+                {
+                    preferredPresenterColorSpace = value;
+                    deviceSettingsChanged = true;
+                }
+            }
+        }
+
 
         /// <summary>
         /// Gets or sets the height of the preferred back buffer.
@@ -728,6 +753,9 @@ namespace VL.Stride.Games
         {
             switch (format)
             {
+                case PixelFormat.R16G16B16A16_Float:
+                    return 64;
+
                 case PixelFormat.R8G8B8A8_UNorm:
                 case PixelFormat.R8G8B8A8_UNorm_SRgb:
                 case PixelFormat.B8G8R8A8_UNorm:

--- a/VL.Stride/help/Rendering/HowTo Render to HDR Displays.vl
+++ b/VL.Stride/help/Rendering/HowTo Render to HDR Displays.vl
@@ -1,0 +1,271 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="AW6QEGBVy9TLN6X2xTwqld" LanguageVersion="2025.7.0-0310-gb23441fc56" Version="0.128">
+  <NugetDependency Id="Q12ZLq5FI4yLNpx8AlfwwU" Location="VL.CoreLib" Version="2022.5.0-0761-gabcd235dd0" />
+  <Patch Id="DM6uY9CkmJjOmsaHO8WaEB">
+    <Canvas Id="ThW71eQraJPPmYt2bvfpn2" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="HvZJ2Y1S5XWOGbrNkXjFnZ">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <CategoryReference Kind="Category" Name="Primitive" />
+      </p:NodeReference>
+      <Patch Id="Pu1wbXnmmzvNMSkGcMjKd7">
+        <Canvas Id="QOLNYuQpzALLSnn8AZPuIX" CanvasType="Group">
+          <Node Bounds="593,540,245,19" Id="V7thtuNQPoJMoK7zWqnfxD">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="RenderWindow" />
+            </p:NodeReference>
+            <Pin Id="Dxkt9ankpslLeEKX9WcSyF" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Sxlioni0Ha7OBzV9QRyKiQ" Name="Bounds" Kind="InputPin" DefaultValue="1280.8, 145.6, 785.6, 432" IsHidden="true" />
+            <Pin Id="PaogysFWRmqPuIavhYEex5" Name="Bound to Document" Kind="InputPin" IsHidden="true" />
+            <Pin Id="TlTxbVbrIJAL46d1xdWmjj" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
+            <Pin Id="AEfOK2Fz6MDQCBCug0dyDJ" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
+            <Pin Id="CpeZT7E6j7eP2MEwHtgeIq" Name="Back Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="SRX9nwfPfZHLt7LeCrgIvo" Name="Depth Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Q48Mdi8Z9R9QcMXfbWnIQ0" Name="Multisample Count" Kind="InputPin" IsHidden="true" />
+            <Pin Id="UslKmXtk5AMPMaRqbnvP4l" Name="Input Priority" Kind="InputPin" IsHidden="true" />
+            <Pin Id="AiQiZhJ4ZcpMtakx8oC0Ux" Name="Input" Kind="InputPin" />
+            <Pin Id="S4DKBOgTBR2OhEbhBeliJO" Name="Render View" Kind="InputPin" />
+            <Pin Id="UV1DnFPwzm6MukXR1VNsvp" Name="Title" Kind="InputPin" />
+            <Pin Id="GwCMAm0RiTzOvHwI6CmtCk" Name="Clear Flags" Kind="InputPin" IsHidden="true" />
+            <Pin Id="N68RWq2UamxQZ7ZXuR799B" Name="Clear Color" Kind="InputPin" />
+            <Pin Id="EGQTMw6a1EmOb3CiUfTBxi" Name="Clear Depth" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Dtnc4DsC66IMX7rCmSetGl" Name="Clear Stencil" Kind="InputPin" IsHidden="true" />
+            <Pin Id="IZ5js0uuA5MQHsWv2b1lPi" Name="Clear" Kind="InputPin" />
+            <Pin Id="DwUlhmYJhjXPkovtOUpo7H" Name="Edit Mode" Kind="InputPin" />
+            <Pin Id="UIqsZph8KoeMNOtfUe5wpv" Name="Commands" Kind="InputPin" IsHidden="true" />
+            <Pin Id="MDhAHmO8KpzQAeweYba0aQ" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
+            <Pin Id="KME8LoNtDhbLcxIlWxttBs" Name="Enabled" Kind="InputPin" />
+            <Pin Id="BtCBL6httMHMzy3Q7PVlPC" Name="Present Interval" Kind="InputPin" />
+            <Pin Id="GmQRc9UShNRLdmeOsDH5du" Name="Output" Kind="OutputPin" />
+            <Pin Id="MhVgkFMXRrrOVQTJ9jmhgT" Name="Client Bounds" Kind="OutputPin" />
+            <Pin Id="IxOOREYcgBpQc9V18kGRWQ" Name="Input Source" Kind="OutputPin" />
+            <Pin Id="AkY9fOunijlQTw10a43FAz" Name="Back Buffer" Kind="OutputPin" />
+            <Pin Id="AN9JMWcPzKNOSgUVla3zOO" Name="Depth Buffer" Kind="OutputPin" />
+            <Pin Id="PawpjVu7AbaOxlW125cmbE" Name="Present Call Intercept" Kind="InputPin" IsHidden="true" />
+            <Pin Id="TorjMqLxnyhMtGeMpJzdpF" Name="Output Color Space" Kind="InputPin" />
+            <Pin Id="ShSns0Veiu9QWyN6kM2UDg" Name="Backbuffer Format" Kind="InputPin" />
+          </Node>
+          <Node Bounds="593,380,145,19" Id="PkJBrmAfUvTMLlDjgnY8BQ">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="FullscreenQuadRenderer" />
+            </p:NodeReference>
+            <Pin Id="QUhHZDyjem2OZGg7oBID8K" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="T41PZvigHZdPANRUeBwJ1A" Name="Transformation" Kind="InputPin" />
+            <Pin Id="IWWJbkyNFkLP9Bir7rklSx" Name="Texture" Kind="InputPin" />
+            <Pin Id="IopWJnEZftMPQuKPsZ9nft" Name="Sampler" Kind="InputPin" />
+            <Pin Id="O5mhHjjfkO7QOnU2meElmN" Name="Sample Mode" Kind="InputPin" />
+            <Pin Id="IZMldyoECaMQCPc4Mnwvrl" Name="Blend State" Kind="InputPin" />
+            <Pin Id="RHXJ7BCMAWPNwdzbBj6G4F" Name="Color" Kind="InputPin" />
+            <Pin Id="Tqotm9OQo9kMfDMNInN6yd" Name="Rasterizer State" Kind="InputPin" />
+            <Pin Id="Sf7BR3iVAYmLVF9gFiActr" Name="Depth Stencil State" Kind="InputPin" />
+            <Pin Id="FuwOsACO1LWOu6brJsacnc" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Pad Id="AraUYqUNIOnPdAY70iUW1i" Comment="Color" Bounds="185,220,136,15" ShowValueBox="true" isIOBox="true">
+            <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="RGBA" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Node Bounds="183,180,65,19" Id="Pk5QVO4Z4JALyrCKgBydqL">
+            <p:NodeReference LastCategoryFullName="Color.RGBA" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="RGBA (Join)" />
+            </p:NodeReference>
+            <Pin Id="FXm6ITEq31HPKm5oaVsylL" Name="Red" Kind="InputPin" />
+            <Pin Id="KmErBZmCbUUPEWaoizzUNd" Name="Green" Kind="InputPin" />
+            <Pin Id="LkSKOscGNztM2WAUiRZxR5" Name="Blue" Kind="InputPin" />
+            <Pin Id="HfItSbLsbD4Nege0D89iK8" Name="Alpha" Kind="InputPin" />
+            <Pin Id="VA5WVfqHMiOP3sB3KAadn3" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Pad Id="B2MYxEXXADOOEFl9Ba9uD6" Comment="Red" Bounds="185,121,35,15" ShowValueBox="true" isIOBox="true" Value="0.12">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="GuZ3BJtZX61MtxA205rO7U" Comment="Blue" Bounds="308,160,35,15" ShowValueBox="true" isIOBox="true" Value="0.61">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Node Bounds="83,540,245,19" Id="KPSU1HqUV0DMx9v7Wxo9fD">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="RenderWindow" />
+            </p:NodeReference>
+            <Pin Id="QyW1WuYRXbmPyGoDIKOLr9" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="OjcGOMRZUf0QWsEPkZd88E" Name="Bounds" Kind="InputPin" DefaultValue="1282.4, 605.6, 785.6, 432" IsHidden="true" />
+            <Pin Id="ScQhyrGr50pMN1SgMHpwi3" Name="Bound to Document" Kind="InputPin" IsHidden="true" />
+            <Pin Id="E746K9nakh1NrgkhnJTGHk" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
+            <Pin Id="JHDzi6aUsssNGX5j5mt6nT" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Gdx2Q8fcKrqNCuWjiJ1aXd" Name="Back Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="MAZOtZiOcUvLKAh4U57mXI" Name="Depth Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="SQN1dDS2B7nMQsQ0UJufct" Name="Multisample Count" Kind="InputPin" IsHidden="true" />
+            <Pin Id="OMHYfA8hjV1NVHe7TvL4Tk" Name="Input Priority" Kind="InputPin" IsHidden="true" />
+            <Pin Id="UJZWGPyPExYMR6dPwqpCTl" Name="Input" Kind="InputPin" />
+            <Pin Id="NL9piIc6XtRNxuTfklBY59" Name="Render View" Kind="InputPin" />
+            <Pin Id="In1IEouQTXELXaX692IArQ" Name="Title" Kind="InputPin" />
+            <Pin Id="QFJ71if4BjhQFOvjIlOwTE" Name="Clear Flags" Kind="InputPin" IsHidden="true" />
+            <Pin Id="DPryQT826sDNoOmqmKphtz" Name="Clear Color" Kind="InputPin" />
+            <Pin Id="RUX86nVmZhoPbyeZfjZvbf" Name="Clear Depth" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Fy2p3XwPGRrMpRvIgikonO" Name="Clear Stencil" Kind="InputPin" IsHidden="true" />
+            <Pin Id="JpXyNcnWaWOQZwkYr9dC6h" Name="Clear" Kind="InputPin" />
+            <Pin Id="T4wGepjUMEyQT22IQbgdlq" Name="Edit Mode" Kind="InputPin" />
+            <Pin Id="ViUGqfhOYwIMmYmvZfiLr4" Name="Commands" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Swfxfjjv2PyOWSEUZy11lV" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
+            <Pin Id="Mi8C5H4NkJOPIsu3rpSel5" Name="Enabled" Kind="InputPin" />
+            <Pin Id="DEDpEFxtwUvP3yMPSITrNE" Name="Present Interval" Kind="InputPin" />
+            <Pin Id="A7pZ1mpVjw6MYwXlBA0MPM" Name="Output" Kind="OutputPin" />
+            <Pin Id="HXzLs9amUbbLfq7tvDXPlW" Name="Client Bounds" Kind="OutputPin" />
+            <Pin Id="ALUynDthjbCLW3QSfmvXiU" Name="Input Source" Kind="OutputPin" />
+            <Pin Id="PD0gLpsrpjoPvhrp5FGaqL" Name="Back Buffer" Kind="OutputPin" />
+            <Pin Id="ThqMVHtTz1ULDXTgI5NLIe" Name="Depth Buffer" Kind="OutputPin" />
+            <Pin Id="JIphxlhiJdFNMsk4iMUQpz" Name="Present Call Intercept" Kind="InputPin" IsHidden="true" />
+            <Pin Id="AoaWQ7KpHJEPr8m4nbEumv" Name="Output Color Space" Kind="InputPin" />
+            <Pin Id="BCNvmoUH0epMDb9lEDIk6J" Name="Backbuffer Format" Kind="InputPin" />
+          </Node>
+          <Node Bounds="83,370,145,19" Id="QxElH2iJQ4ePePnT9Bqx3l">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="FullscreenQuadRenderer" />
+            </p:NodeReference>
+            <Pin Id="M38BdYGgYgIPNxvcXE2jug" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="EeZxMjlbcZ5MUpcsFMvxjE" Name="Transformation" Kind="InputPin" />
+            <Pin Id="EYFfr3jRmjzMT76SxKb9dw" Name="Texture" Kind="InputPin" />
+            <Pin Id="SZtzTpok2MEPLDLCAWtRPq" Name="Sampler" Kind="InputPin" />
+            <Pin Id="J7fdSFZdkwRNOf0zaEAJTD" Name="Sample Mode" Kind="InputPin" />
+            <Pin Id="TGCBpx0wIb4Pl3NSuBM2VY" Name="Blend State" Kind="InputPin" />
+            <Pin Id="QVyTcUPf8aXMcvQ01ZeB3g" Name="Color" Kind="InputPin" />
+            <Pin Id="IKR6kvJ0acIOabvbbnmhOM" Name="Rasterizer State" Kind="InputPin" />
+            <Pin Id="PChpqzYwGbGNQTXAIrPoJW" Name="Depth Stencil State" Kind="InputPin" />
+            <Pin Id="C9LEtZAspcjPzYg1Bfb7ug" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Pad Id="R8RgaG63rQQP1xoXzHkStx" Comment="Green" Bounds="205,150,54,15" ShowValueBox="true" isIOBox="true" Value="0.7">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Node Bounds="299,420,103,19" Id="HxCkm6kTqXiMwFVAyapN41">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="OutputColorSpaces" />
+            </p:NodeReference>
+            <Pin Id="F0K8EocoxYzLzAbIhRODvo" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="HMj91nQsROhOGGZxQ9B9T4" Name="Is HDR" Kind="InputPin" />
+            <Pin Id="VR51xYmQSFiQacKJJidseo" Name="Is HDR10" Kind="InputPin" />
+            <Pin Id="DyabG4bBvgqLN0VTV0aWLd" Name="Color Space" Kind="OutputPin" />
+            <Pin Id="HpnsLPVTFv4PWNCbhg1nsV" Name="Format" Kind="OutputPin" />
+          </Node>
+          <Pad Id="QEhndQFwy9pPKHxKxjQznr" Comment="Is HDR" Bounds="301,371,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="GsPZ68Gt49oPxWQpvdR85r" Comment="Is HDR10" Bounds="399,371,35,35" ShowValueBox="true" isIOBox="true" Value="False">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="RNu5hR7o2WSO9fVdpNtDs9" Bounds="517,477,462,27" ShowValueBox="true" isIOBox="true" Value="Enable optional Pins and assign a link to Create for intial/fixed settings">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="L2S2cUGhCaVLKmiJMn0Vhu" Bounds="167,477,280,25" ShowValueBox="true" isIOBox="true" Value="Enable optional pins to change at runtime.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Node Bounds="811,430,103,19" Id="GdblQFG0DO0PHXXMMW89o5">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="OutputColorSpaces" />
+            </p:NodeReference>
+            <Pin Id="NoI2Ce4UI8DLPWTivGOkJE" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="D9ytoRhw2e3Mu1pT0DJsCy" Name="Is HDR" Kind="InputPin" />
+            <Pin Id="TgWPVYNH7MbPFOtkOAuxrn" Name="Is HDR10" Kind="InputPin" />
+            <Pin Id="UWOtqGUDbSVP33RjHah6na" Name="Color Space" Kind="OutputPin" />
+            <Pin Id="CXHIUajJus4NAkboYeD4Sg" Name="Format" Kind="OutputPin" />
+          </Node>
+          <Pad Id="HwEYNLGZR8GNBO9hlkg3nC" Comment="Is HDR" Bounds="813,381,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="GqgkL4SITaIO12udBL8mvb" Comment="Is HDR10" Bounds="911,381,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Toggle</p:buttonmode>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="QcKdHEtrWXpQRtIgBUQPfF" Bounds="347,549,219,19" ShowValueBox="true" isIOBox="true" Value="Works the same for SceneWindow">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="Cicua9pIbj0PqxtjKcc2xw" Bounds="524,37,533,268" ShowValueBox="true" isIOBox="true" Value="Common Options:&#xD;&#xA;&#xD;&#xA;SDR with Gamma 2.2 (default):&#xD;&#xA;Use RgbFullG22NoneP709 with an 8-bit format like R8G8B8A8_UNorm_SRgb.&#xD;&#xA;&#xD;&#xA;Linear HDR scRGB (simple):&#xD;&#xA;Use RgbFullG10NoneP709 with R16G16B16A16_Float. This allows for linear rendering in a wider gamut, relying on the Windows Desktop Window Manager (DWM) for final conversion to the display.&#xD;&#xA;&#xD;&#xA;HDR10 / BT.2100 PQ (advanced):&#xD;&#xA;Use RgbFullG2084NoneP2020 with R10G10B10A2_UNorm. This requires the rendering pipeline to output colors matching the PQ transfer function and Rec.2020 primaries. It gets directly sent to the display.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+        </Canvas>
+        <Patch Id="A8DrXqCNeAbQJO93ATM4Gt" Name="Create" ParticipatingElements="ACnNMwz4lXyOYbQUyCz0rJ" />
+        <Patch Id="SvkOzgSJG8NMWC3RcYnvlk" Name="Update" />
+        <ProcessDefinition Id="FbpTECpslBLPskAbbV3rN3">
+          <Fragment Id="Rh8D5xSa2SjO0u69zbSsml" Patch="A8DrXqCNeAbQJO93ATM4Gt" Enabled="true" />
+          <Fragment Id="F4apWFNRg6TMQ9Eq8FHfHL" Patch="SvkOzgSJG8NMWC3RcYnvlk" Enabled="true" />
+        </ProcessDefinition>
+        <Link Id="KTwWqV2SQu3M22z2LxCtZw" Ids="FuwOsACO1LWOu6brJsacnc,AiQiZhJ4ZcpMtakx8oC0Ux" />
+        <Link Id="OyD6V1dc1URMiUaJg6SoeY" Ids="AraUYqUNIOnPdAY70iUW1i,RHXJ7BCMAWPNwdzbBj6G4F" />
+        <Link Id="VYytBM9SmAyLjryotYWk0w" Ids="VA5WVfqHMiOP3sB3KAadn3,AraUYqUNIOnPdAY70iUW1i" />
+        <Link Id="KnBIbjjYJy5PSZ0r5FwAT1" Ids="B2MYxEXXADOOEFl9Ba9uD6,FXm6ITEq31HPKm5oaVsylL" />
+        <Link Id="E0xCGXMj4yGMqNpSFUJubg" Ids="GuZ3BJtZX61MtxA205rO7U,LkSKOscGNztM2WAUiRZxR5" />
+        <Link Id="GMYAdpW4rgdNZ7wJBX5SGb" Ids="C9LEtZAspcjPzYg1Bfb7ug,UJZWGPyPExYMR6dPwqpCTl" />
+        <Link Id="GkdxTl03kCUPVNtEI6MJpk" Ids="AraUYqUNIOnPdAY70iUW1i,QVyTcUPf8aXMcvQ01ZeB3g" />
+        <Link Id="T3a68UG3B6RLevpGiLFhUy" Ids="R8RgaG63rQQP1xoXzHkStx,KmErBZmCbUUPEWaoizzUNd" />
+        <Link Id="RdTifquFh79NmjhzgErBdR" Ids="DyabG4bBvgqLN0VTV0aWLd,AoaWQ7KpHJEPr8m4nbEumv" />
+        <Link Id="TTdZcgClcBcLr0gkBaWVR2" Ids="HpnsLPVTFv4PWNCbhg1nsV,BCNvmoUH0epMDb9lEDIk6J" />
+        <Link Id="NLV0RqAC5BvNvmyM6eVIjC" Ids="QEhndQFwy9pPKHxKxjQznr,HMj91nQsROhOGGZxQ9B9T4" />
+        <Link Id="D71NYZsoAzTOAlYrKdx7f2" Ids="GsPZ68Gt49oPxWQpvdR85r,VR51xYmQSFiQacKJJidseo" />
+        <Link Id="NhaaTBidYQxQBh2cWF9Yu2" Ids="HwEYNLGZR8GNBO9hlkg3nC,D9ytoRhw2e3Mu1pT0DJsCy" />
+        <Link Id="DO1xsk8Me3jQLCRr70gLBP" Ids="GqgkL4SITaIO12udBL8mvb,TgWPVYNH7MbPFOtkOAuxrn" />
+        <Link Id="ACnNMwz4lXyOYbQUyCz0rJ" Ids="UWOtqGUDbSVP33RjHah6na,TorjMqLxnyhMtGeMpJzdpF" />
+        <Link Id="EtW6WzohoMkOFWB0c9U649" Ids="CXHIUajJus4NAkboYeD4Sg,ShSns0Veiu9QWyN6kM2UDg" />
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="HilxKJxEORmOUkJootO3XH" Location="VL.Stride" Version="2022.5.0-0761-gabcd235dd0" />
+  <NugetDependency Id="GE83EMkikKhN7CmMlrQMoy" Location="VL.Stride.TextureFX" Version="2023.5.3-0424-g377a9fa3b5" />
+</Document>


### PR DESCRIPTION
## Description

* New pins on `RenderWindow` and `SceneWindow` to set the output color space. 
* New convenience node `OutputColorSpaces` to get the most common 3 combinations of color space and backbuffer format.
* Help patch to show the new feature, see:
![image](https://github.com/user-attachments/assets/ed86d01b-aab7-4363-abb4-03c618e40bf8)

## Motivation and Context

Render wide color gamut for HDR displays and LED walls.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

