### PR TITLE
[Core] Fixes TryDisposeSequence not returning true if all elements where disposed

### DIFF
--- a/VL.CoreLib/src/Primitive/Disposable.cs
+++ b/VL.CoreLib/src/Primitive/Disposable.cs
@@ -58,6 +58,7 @@ namespace VL.Lib.Primitive
             success = false;
             if (input != null)
             {
+                success = true;
                 foreach (var item in input)
                 {
                     bool itemSuccess;


### PR DESCRIPTION
Fixes TextureQueue not removing all slices on Clear.

# PR Details

Initializes the success out parameter with `true` if the input sequence is not null. They get concatenated with an AND operator, so the initial value must be true, otherwise it can never become true.

## Motivation and Context

TextureQueue wasn't removing the slices when enabling "Clear".

![image](https://github.com/user-attachments/assets/f3a3d3c8-beb6-44cd-96a7-94d4c46c6e97)
<img width="420" alt="image" src="https://github.com/user-attachments/assets/67d94075-852d-496d-8aa8-a79ec27e54bf" />


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
