### PR TITLE
ObjectToJson property naming policy

### DIFF
--- a/VL.CoreLib/VL.Xml.vl
+++ b/VL.CoreLib/VL.Xml.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="Q2iWAXgl3GDPCvxD5IfFJH" LanguageVersion="2025.7.0-0285-g389d5317fc" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="Q2iWAXgl3GDPCvxD5IfFJH" LanguageVersion="2025.7.0-0413-g101b9a7a4c" Version="0.128">
   <Patch Id="ASFIym52stPN1PuCUAOytF">
     <Canvas Id="POMRF0wHzKKMGFQzoh2Gxa" DefaultCategory="System.XML" CanvasType="FullCategory">
       <Canvas Id="IMLnWDFQSGiN3Z5XnLqomY" Name="Obsolete" Position="401,141">
@@ -55,11 +55,9 @@
                       <Pin Id="UdjXibjo6gXNGq22I9ULEv" Name="On Completed" Kind="OutputPin" />
                     </Node>
                   </Patch>
-                  <Pin Id="NrltzYoJfR2NqWDFodfBTn" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="CCwFDmrwuDhP7ul8R7usWp" Name="Default Output 1" Kind="InputPin" />
                   <Pin Id="Lf5cfEUH7IoMkF2zvUsk7q" Name="Default Output 2" Kind="InputPin" />
                   <Pin Id="BzdSgp6aoc3O65qb5Mvrv4" Name="Default Output 3" Kind="InputPin" />
-                  <Pin Id="LtVkxxwHzbHNianIM1hWPD" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="U4RUwwcVuvQLwC3BKaeK1A" Name="Output 1" Kind="OutputPin" />
                   <Pin Id="QFKwsx9mdqmOddeqoxMDUn" Name="Output 2" Kind="OutputPin" />
                   <Pin Id="BLqh1qFyjjAPwLUlHxYfqw" Name="Output 3" Kind="OutputPin" />
@@ -165,11 +163,9 @@
                       <Pin Id="BIA1gcFMIl8NnnBC6W3BC6" Name="On Completed" Kind="OutputPin" />
                     </Node>
                   </Patch>
-                  <Pin Id="LUITJXqTz8PM9eRANNIMso" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="HX4AXB944HAPQaiacrR7qK" Name="Default Output 1" Kind="InputPin" />
                   <Pin Id="MnUiAkng6OTODkzFrsQsH5" Name="Default Output 2" Kind="InputPin" />
                   <Pin Id="PE4ZkPfPCI9M18jK48GX5m" Name="Default Output 3" Kind="InputPin" />
-                  <Pin Id="AneJm0o636xNLu7P3K7HVa" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="SvK6qn08gPsN4ujuxfXxQi" Name="Output 1" Kind="OutputPin" />
                   <Pin Id="I2LOqo0LC1DMW8sB7WChbO" Name="Output 2" Kind="OutputPin" />
                   <Pin Id="CNMnXLa5lYtOCo2Ahjarqo" Name="Output 3" Kind="OutputPin" />
@@ -282,10 +278,8 @@
                       <Pin Id="SJNXsHjNlJiMI7BdezIq0F" Name="In Progress" Kind="OutputPin" />
                     </Node>
                   </Patch>
-                  <Pin Id="RNEvuGDOQIWPROdMTxp6WI" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Q5Xj0vXEuO7OjQVfV1Xjcj" Name="Default Output 1" Kind="InputPin" />
                   <Pin Id="FDk1gdldItBPGgxLIva9eD" Name="Default Output 2" Kind="InputPin" />
-                  <Pin Id="EoCUswQqc6cPcMMVmHS2R1" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="BLctK1DkVWzMLU3kHhPM3k" Name="Output 1" Kind="OutputPin" />
                   <Pin Id="HOkKw03zA5hQNq4RLzJ0K9" Name="Output 2" Kind="OutputPin" />
                   <Pin Id="TTQdc6D1i5pQD8CwchALcT" Name="Success" Kind="OutputPin" />
@@ -405,10 +399,8 @@
                       <Pin Id="H0W3U7cqvpTL43OIVqPXWt" Name="In Progress" Kind="OutputPin" />
                     </Node>
                   </Patch>
-                  <Pin Id="LvwzufSJ7WVNZdT12srthe" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="UzqkmD3SpTCOr4QNOc0Ixc" Name="Default Output 1" Kind="InputPin" />
                   <Pin Id="Sj10DW6GHDBNYMfLWwBBX9" Name="Default Output 2" Kind="InputPin" />
-                  <Pin Id="BcAOURljyzHNvrNF6rwtLw" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="NMIhJVXMFQjOxqLeWp4UZT" Name="Output 1" Kind="OutputPin" />
                   <Pin Id="B8Yjwni1g8rOSs0oHtJIYP" Name="Output 2" Kind="OutputPin" />
                   <Pin Id="Cm8DaQs35aWOawYQC6TA5J" Name="Success" Kind="OutputPin" />
@@ -6236,7 +6228,7 @@
               <Pin Id="Q7gfUrcAdUUPlqIC1oXlLQ" Name="Result" Kind="OutputPin" />
             </Node>
             <Link Id="TBO7U6BQMufM0I9AlNpWSK" Ids="JlCqMXuepO3PbGmjiswxbP,UjyJJZC33elQMWKj4nFBMp" />
-            <Node Bounds="421,382,63,19" Id="TITObNhCDlmMGb12ISXqoU">
+            <Node Bounds="421,382,63,26" Id="TITObNhCDlmMGb12ISXqoU">
               <p:NodeReference LastCategoryFullName="System.Xml.Serialization.XmlSerializer" LastDependency="System.Xml.Serialization.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="XmlSerializer" />
@@ -6254,7 +6246,7 @@
               <Pin Id="JZFflptTMJLNyA116QBISA" Name="Input" Kind="InputPin" />
               <Pin Id="MtimRF0OZSaPcYTz9YHblH" Name="Result" Kind="OutputPin" />
             </Node>
-            <Node Bounds="421,437,66,19" Id="Pu8SNAGWXYmMcdPKmyjLjF">
+            <Node Bounds="421,437,66,26" Id="Pu8SNAGWXYmMcdPKmyjLjF">
               <p:NodeReference LastCategoryFullName="System.Xml.Serialization.XmlSerializer" LastDependency="System.Xml.Serialization.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Deserialize" />
@@ -6276,7 +6268,7 @@
               <Pin Id="Hu8CQkoNRrHPSBIRyIiyXO" Name="Result" Kind="OutputPin" />
               <Pin Id="S0pPTP0lG8yLyZ0Lv1Qu8n" Name="Success" Kind="OutputPin" />
             </Node>
-            <Node Bounds="502,383,62,19" Id="FSgxMGSR9cuMVSr3lOeoWk">
+            <Node Bounds="502,383,62,26" Id="FSgxMGSR9cuMVSr3lOeoWk">
               <p:NodeReference LastCategoryFullName="System.IO.StringReader" LastDependency="mscorlib.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="Create" />
@@ -6332,7 +6324,7 @@
                   <Patch Id="JMMkM6yIllfPc1GVTfOKjr" ManuallySortedPins="true">
                     <Patch Id="VA8qXjOazQsP6xrGBjefJu" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="Fu6XR3pfOv3LjkYaYu4Zy4" Name="Update" ManuallySortedPins="true" />
-                    <Node Bounds="865,509,59,19" Id="Bvz08VcVYrDOizfhUmKwVE">
+                    <Node Bounds="865,509,59,26" Id="Bvz08VcVYrDOizfhUmKwVE">
                       <p:NodeReference LastCategoryFullName="System.IO.StringWriter" LastDependency="mscorlib.dll">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <CategoryReference Kind="AssemblyCategory" Name="StringWriter" />
@@ -6351,7 +6343,7 @@
                       <Patch Id="KIv159SpKRKMqmG96nSXNk" ManuallySortedPins="true">
                         <Patch Id="C9DwlsDZRouPD18MFQ76eR" Name="Create" ManuallySortedPins="true" />
                         <Patch Id="NGvjefiJm4jQFWMPEOJyTW" Name="Update" ManuallySortedPins="true" />
-                        <Node Bounds="771,450,66,19" Id="VU9wt6YnQb6QQTvPBXLA6B">
+                        <Node Bounds="771,450,66,26" Id="VU9wt6YnQb6QQTvPBXLA6B">
                           <p:NodeReference LastCategoryFullName="System.Xml.Serialization.XmlSerializer" LastDependency="System.Xml.Serialization.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                             <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                             <CategoryReference Kind="AssemblyCategory" Name="XmlSerializer" NeedsToBeDirectParent="true" />
@@ -6371,7 +6363,7 @@
                     </Node>
                   </Patch>
                 </Node>
-                <Node Bounds="771,353,63,19" Id="HMG8ozEeRhPMjOsZjQVexv">
+                <Node Bounds="771,353,63,26" Id="HMG8ozEeRhPMjOsZjQVexv">
                   <p:NodeReference LastCategoryFullName="System.Xml.Serialization.XmlSerializer" LastDependency="System.Xml.Serialization.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="XmlSerializer" />
@@ -6381,7 +6373,7 @@
                   <Pin Id="CypfXMy6coYNzqmmHKsIFo" Name="Type" Kind="InputPin" />
                   <Pin Id="KZr5p23bKCELExQUQZ1ObF" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="750,307,54,19" Id="O7Gj3pSg2mANNZGOQQ2guN">
+                <Node Bounds="750,307,54,26" Id="O7Gj3pSg2mANNZGOQQ2guN">
                   <p:NodeReference LastCategoryFullName="System.Object" LastDependency="mscorlib.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="Object" />
@@ -6391,7 +6383,7 @@
                   <Pin Id="BrPIezN24l3P9JhkfW8AEZ" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="T7EZAUic4yOLg4eCsgpBT3" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="865,360,59,19" Id="AiVYGqpioUJL67f5T4OTX7">
+                <Node Bounds="865,360,59,26" Id="AiVYGqpioUJL67f5T4OTX7">
                   <p:NodeReference LastCategoryFullName="System.IO.StringWriter" LastDependency="mscorlib.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="StringWriter" />
@@ -6443,12 +6435,12 @@
     ************************ ObjectToJson ************************
 
 -->
-        <Node Name="ObjectToJson" Bounds="753,708,341,303" Id="PikbuPz8tIuQdHNuerMY22">
+        <Node Name="ObjectToJson" Bounds="780,708,525,369" Id="PikbuPz8tIuQdHNuerMY22">
           <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="L7bHdaQch2TNomUIeItoj2" IsGeneric="true">
-            <Node Bounds="805,794,207,175" Id="MPVqehE98XINvIjcPaVVK2">
+            <Node Bounds="803,787,490,248" Id="MPVqehE98XINvIjcPaVVK2">
               <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Primitive" />
@@ -6457,8 +6449,8 @@
               <Pin Id="NT6h0EvvvhPPOtiZpkbZYk" Name="Condition" Kind="InputPin" />
               <Patch Id="SB1bmnJWy3mPnlEf8szYSI" ManuallySortedPins="true">
                 <Patch Id="OwgQ5QrDIJcMAZ4lihwaEM" Name="Create" ManuallySortedPins="true" />
-                <Patch Id="C8SnAJMGmLaN84pUbd1bGS" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="907,835,92,26" Id="SL68Nj923OLQcHXncO2LVd">
+                <Patch Id="C8SnAJMGmLaN84pUbd1bGS" Name="Then" ParticipatingElements="DWTxAsrhs9uLlia29lXgf6" ManuallySortedPins="true" />
+                <Node Bounds="907,820,92,26" Id="SL68Nj923OLQcHXncO2LVd">
                   <p:NodeReference LastCategoryFullName="System.Text.Json.JsonSerializerOptions" LastDependency="System.Text.Json.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="JsonSerializerOptions" />
@@ -6466,7 +6458,7 @@
                   </p:NodeReference>
                   <Pin Id="LXlvPRaufWoOPwKHN5zTBD" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="907,875,93,26" Id="QgvPoNcbdtiLHiC2W4Q8Sr">
+                <Node Bounds="907,860,127,26" Id="QgvPoNcbdtiLHiC2W4Q8Sr">
                   <p:NodeReference LastCategoryFullName="System.Text.Json.JsonSerializerOptions" LastDependency="System.Text.Json.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="JsonSerializerOptions" />
@@ -6476,7 +6468,7 @@
                   <Pin Id="SVeYYTITRzfMZ4S0yzlY2j" Name="Value" Kind="InputPin" />
                   <Pin Id="KK14WPcaf6tQTkGnbaVpN8" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="848,924,66,19" Id="Nodcx22bN53NwZM9vfjT9L">
+                <Node Bounds="846,990,66,19" Id="Nodcx22bN53NwZM9vfjT9L">
                   <p:NodeReference LastCategoryFullName="System.Text.Json.JsonSerializer" LastDependency="System.Text.Json.dll" OverloadStrategy="UserSelectedPins">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="AssemblyCategory" Name="JsonSerializer" NeedsToBeDirectParent="true" />
@@ -6491,25 +6483,42 @@
                   <Pin Id="V7IDgaw6YB4LZVb6875RxN" Name="Options" Kind="InputPin" />
                   <Pin Id="Oza2kBDA8iOPqaspy6gVbs" Name="Result" Kind="OutputPin" />
                 </Node>
+                <Node Bounds="907,920,218,26" Id="M16nvQ1t5RhMFBM0iWWxI9">
+                  <p:NodeReference LastCategoryFullName="System.Text.Json.JsonSerializerOptions" LastDependency="System.Text.Json.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="JsonSerializerOptions" />
+                    <Choice Kind="OperationCallFlag" Name="SetPropertyNamingPolicy" />
+                  </p:NodeReference>
+                  <Pin Id="FZ8qBjoyJ7DM4Zke7WpKuP" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="CiLjcbtEtgFOtbMSaJPEhL" Name="Value" Kind="InputPin" />
+                  <Pin Id="V51JpeqlE4pLECI4S63X8P" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="1120,860,161,19" Id="Mw3E4u4Fzs8Lf0vqcqVWbn">
+                  <p:NodeReference LastCategoryFullName="VL.Lib.Xml.XmlNodes" LastDependency="VL.CoreLib.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="GetJsonNamingPolicyFromEnum" />
+                  </p:NodeReference>
+                  <Pin Id="QxL5AYolQh1Mv86oNkqsis" Name="Input" Kind="InputPin" />
+                  <Pin Id="ICMmMGXVCVnMl7PurjxlrG" Name="Result" Kind="OutputPin" />
+                </Node>
               </Patch>
-              <ControlPoint Id="PCVA4xBkkYTNReE1xPs5Wf" Bounds="819,963" Alignment="Bottom" />
-              <ControlPoint Id="IuNbhihAf2oNozIDuHwwdu" Bounds="819,800" Alignment="Top" />
-              <ControlPoint Id="D7xp040ujehN6NzucrIjLa" Bounds="850,963" Alignment="Bottom" />
-              <ControlPoint Id="LmeDXvMMkYjOXk2EqmqjJe" Bounds="868,800" Alignment="Top" />
+              <ControlPoint Id="PCVA4xBkkYTNReE1xPs5Wf" Bounds="817,1029" Alignment="Bottom" />
+              <ControlPoint Id="IuNbhihAf2oNozIDuHwwdu" Bounds="819,793" Alignment="Top" />
+              <ControlPoint Id="D7xp040ujehN6NzucrIjLa" Bounds="848,1029" Alignment="Bottom" />
+              <ControlPoint Id="LmeDXvMMkYjOXk2EqmqjJe" Bounds="868,793" Alignment="Top" />
             </Node>
             <ControlPoint Id="EgkpBbGSnWuO9pe8CWC9Ag" Bounds="848,726" />
-            <ControlPoint Id="ShJlTw6dPttPHXFf5Ef2MH" Bounds="1031,849" />
+            <ControlPoint Id="ShJlTw6dPttPHXFf5Ef2MH" Bounds="1031,771" />
             <Link Id="MZ0Ozcd8d4QOcxBdQKh5rh" Ids="C0jTDCi3quZMH8qngC4fqA,EgkpBbGSnWuO9pe8CWC9Ag" IsHidden="true" />
             <Link Id="DJoNXIsNSzOOpRbv0vlfAi" Ids="LXlvPRaufWoOPwKHN5zTBD,B6RpNMMf2WOOqE2fi18Ure" />
-            <Link Id="SixZbFR09iONBL8a9xKOKj" Ids="KK14WPcaf6tQTkGnbaVpN8,V7IDgaw6YB4LZVb6875RxN" />
             <Link Id="A9V1SB7IE5cPZeNdtFW0U5" Ids="ShJlTw6dPttPHXFf5Ef2MH,SVeYYTITRzfMZ4S0yzlY2j" />
             <Link Id="GhRlCUlyJP8NXjnOnA5uwm" Ids="SqWoBWY5frmNpkTZwFzjHC,ShJlTw6dPttPHXFf5Ef2MH" IsHidden="true" />
             <Pin Id="C0jTDCi3quZMH8qngC4fqA" Name="Input" Kind="InputPin" Bounds="461,220" />
             <Pin Id="SqWoBWY5frmNpkTZwFzjHC" Name="Indented" Kind="InputPin" Bounds="734,318" DefaultValue="True" />
-            <ControlPoint Id="ObZkpKuVjOcOOR2dGw8Pqh" Bounds="850,994" />
+            <ControlPoint Id="ObZkpKuVjOcOOR2dGw8Pqh" Bounds="848,1060" />
             <Pin Id="FAqQKLXELGwOMhm5ptxiOw" Name="Result" Kind="OutputPin" Bounds="1040,857" />
             <Link Id="HJyuRVQlthhMeZwazof2eB" Ids="ObZkpKuVjOcOOR2dGw8Pqh,FAqQKLXELGwOMhm5ptxiOw" IsHidden="true" />
-            <Node Bounds="765,755,65,19" Id="GMjUYY8KpViMG88mPR6xkI">
+            <Node Bounds="803,750,65,19" Id="GMjUYY8KpViMG88mPR6xkI">
               <p:NodeReference LastCategoryFullName="VL.Lib.Primitive.Object.ObjectHelpers" LastDependency="VL.CoreLib.dll">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="IsAssigned" />
@@ -6526,6 +6535,17 @@
             <Link Id="D0WmnvZTQp8LAloSfxyxnE" Ids="LmeDXvMMkYjOXk2EqmqjJe,D7xp040ujehN6NzucrIjLa" IsFeedback="true" />
             <Link Id="Q5WRGsqt5wTPkOm8KjJRCT" Ids="Oza2kBDA8iOPqaspy6gVbs,D7xp040ujehN6NzucrIjLa" />
             <Link Id="E4TlcHD7ZMGMAkGQp938fR" Ids="D7xp040ujehN6NzucrIjLa,ObZkpKuVjOcOOR2dGw8Pqh" />
+            <Link Id="Dn1QQgRh2vNMEZ9muDcQTK" Ids="KK14WPcaf6tQTkGnbaVpN8,FZ8qBjoyJ7DM4Zke7WpKuP" />
+            <Link Id="EDJd8NhVkSTM8LtbFVmEkI" Ids="V51JpeqlE4pLECI4S63X8P,V7IDgaw6YB4LZVb6875RxN" />
+            <Pin Id="OCHXrSlYKXFLtNUL6MAizq" Name="Property Naming Policy" Kind="InputPin">
+              <p:TypeAnnotation LastCategoryFullName="VL.Lib.Xml" LastDependency="VL.CoreLib.dll">
+                <Choice Kind="TypeFlag" Name="JsonPropertyNamingPolicy" />
+              </p:TypeAnnotation>
+            </Pin>
+            <ControlPoint Id="RaMQ206xLhJO6XWLTjBNDG" Bounds="1122,770" />
+            <Link Id="R4Y5YtJ2NqlQIfaziQBYlc" Ids="OCHXrSlYKXFLtNUL6MAizq,RaMQ206xLhJO6XWLTjBNDG" IsHidden="true" />
+            <Link Id="FI0B0DnGqA7MvZKHddReMX" Ids="RaMQ206xLhJO6XWLTjBNDG,QxL5AYolQh1Mv86oNkqsis" />
+            <Link Id="DWTxAsrhs9uLlia29lXgf6" Ids="ICMmMGXVCVnMl7PurjxlrG,CiLjcbtEtgFOtbMSaJPEhL" />
           </Patch>
         </Node>
       </Canvas>

--- a/VL.CoreLib/src/Xml/Xml.cs
+++ b/VL.CoreLib/src/Xml/Xml.cs
@@ -14,6 +14,7 @@ using System.Xml.Xsl;
 using VL.Core;
 using VL.Lib.Basics.Resources;
 using VL.Lib.Collections;
+using System.Text.Json;
 
 namespace VL.Lib.Xml
 {
@@ -24,6 +25,9 @@ namespace VL.Lib.Xml
         Schema
     }
 
+    /// <summary>
+    /// User-facing enum allowing to pick a naming policy for objects serialized with the ObjectToJson node
+    /// </summary>
     public enum JsonPropertyNamingPolicy
     {
         CamelCase,
@@ -339,6 +343,25 @@ namespace VL.Lib.Xml
                 xslt.Transform(input.CreateReader(ReaderOptions.None), null, writer);
                 return writer.ToString();
             }
+        }
+
+        /// <summary>
+        /// Returns a JsonNamingPolicy from a JsonPropertyNamingPolicy
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public static JsonNamingPolicy GetJsonNamingPolicyFromEnum(JsonPropertyNamingPolicy input)
+        {
+            return input switch
+            {
+                JsonPropertyNamingPolicy.CamelCase => JsonNamingPolicy.CamelCase,
+                JsonPropertyNamingPolicy.KebabCaseLower => JsonNamingPolicy.KebabCaseLower,
+                JsonPropertyNamingPolicy.KebabCaseUpper => JsonNamingPolicy.KebabCaseUpper,
+                JsonPropertyNamingPolicy.SnakeCaseLower => JsonNamingPolicy.SnakeCaseLower,
+                JsonPropertyNamingPolicy.SnakeCaseUpper => JsonNamingPolicy.SnakeCaseUpper,
+                _ => throw new ArgumentOutOfRangeException("input", input, "Could not create JsonNamingPolicy with provided value")
+            };
         }
     }
 }

--- a/VL.CoreLib/src/Xml/Xml.cs
+++ b/VL.CoreLib/src/Xml/Xml.cs
@@ -24,6 +24,15 @@ namespace VL.Lib.Xml
         Schema
     }
 
+    public enum JsonPropertyNamingPolicy
+    {
+        CamelCase,
+        KebabCaseLower,
+        KebabCaseUpper,
+        SnakeCaseLower,
+        SnakeCaseUpper
+    }
+
     public static class XmlNodes
     {
         /// <summary>


### PR DESCRIPTION
# PR Details

This pull request introduces an additional Naming Policy pin to the experimental `ObjectToJson` node, enabling users to specify the casing of properties for a serialized C# object.

## Description

- Introduces a static `JsonPropertyNamingPolicy` helper enum to allow users to select a naming policy from an enum instead of using static operations that return these policies (19b84f093eb372529d05ea99ad807234a848646d).
- Adds a static `GetJsonNamingPolicyFromEnum` function that returns the appropriate `JsonNamingPolicy` based on a `JsonPropertyNamingPolicy` (our helper enum) input (0bdf3567dcb9ca564ac55927a939b083a5e1db9e).
- Adds a `Property Naming Policy` input pin of type `JsonPropertyNamingPolicy` to `ObjectToJson`. Internally, it sets the `PropertyNamingPolicy` of the `JsonSerializeOption` using the aforementioned `GetJsonNamingPolicyFromEnum` function. (bb8e1f77746a24e36e7dcaff697e98d21ceb3963)

Before change:

<img width="300" alt="Yaagsm6ykJ" src="https://github.com/user-attachments/assets/ae817f67-128d-40fe-80ca-83fbb30a4de8" />

After change:

<img width="300" alt="lGGw5odkpb" src="https://github.com/user-attachments/assets/d40f861d-ada3-41e6-9209-51f0f33d87e7" />

I have a few issues with the current state of this PR though:

- I'm not sure if `JsonPropertyNamingPolicy` is the best pick for the helper enum name. I picked this one as it was the most meaningful for the end-user I could think of.
- Right now, `GetJsonNamingPolicyFromEnum` is a static operation living in the `XmlNodes` class. That obviously does not make much sense as this function deals with JSON, but I was not sure where to put it. Open to suggestions here!
- The default behavior (i.e without explicitly setting a naming policy) was returning a serialized object using `PascalCase` properties. Unfortunately, `JsonNamingPolicy` does not allow to pick `PascalCase`, as you can see on [the .NET doc](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonnamingpolicy?view=net-9.0). What if the user actually wants `PascalCase` then? I was thinking about making the input pin `Optional<JsonPropertyNamingPolicy>` and only applying `SetPropertyNamingPolicy` if `HasValue` returns true, what do you think?
- I'm adding a `.zip` file to this PR that shows the change in action. You can open this `.vl` document with this branch of `VL.StandardLibs` in your `--package-repositories`: [JsonNamingPolicyPrTest.zip](https://github.com/user-attachments/files/21316464/JsonNamingPolicyPrTest.zip)

## Related Issue

None.

## Motivation and Context

When serializing objects to send to a web API, incorrect property casing can cause the request to be rejected. This pull request addresses this issue by allowing users to choose a property naming policy, making sure the serialized object matches the API's expectations.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation
