### PR TITLE
WSAD Camera

### DIFF
--- a/VL.EditingFramework/VL.Cameras.vl
+++ b/VL.EditingFramework/VL.Cameras.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="USVpn2wMsrSLK5oj1XAsi5" LanguageVersion="2022.5.0-0685-ga251664bc1" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="USVpn2wMsrSLK5oj1XAsi5" LanguageVersion="2025.7.0" Version="0.128">
   <NugetDependency Id="DyQfiR2b61dORTEyJLJqPu" Location="VL.Core" Version="2021.4.11-1091-gcb990e3a36" />
   <NugetDependency Id="OswjX9o1eeSNlJehlXquQp" Location="VL.CoreLib" Version="2021.4.11-1091-gcb990e3a36" />
   <Patch Id="Q3wx7zXOTEpPxY2B2tAric">
@@ -25,6 +25,7 @@
                     <p:OuterCategoryReference Kind="Category" Name="Editors" NeedsToBeDirectParent="true" />
                   </CategoryReference>
                 </p:NodeReference>
+                <Pin Id="Cj5uh1n2v6aMowNFPwc3rV" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="FmqV2YrkBLJOM9jqhQR3cL" Name="Initial Interest" Kind="InputPin" />
                 <Pin Id="L4mVWXlylkYQUogAmYgKRs" Name="Initial Zoom" Kind="InputPin" />
                 <Pin Id="RhcvZlZ9DrOOd3FlcVZJCf" Name="Minimum Zoom" Kind="InputPin" />
@@ -54,6 +55,7 @@
                   <Choice Kind="ProcessAppFlag" Name="FlatCameraControls" />
                   <CategoryReference Kind="Category" Name="Editors" />
                 </p:NodeReference>
+                <Pin Id="MIc2SwdhUwLNShJgVvAITG" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="CiWCzm2BwuFLb99LSGJob5" Name="CameraControls2d" Kind="InputPin" />
                 <Pin Id="MTkSaWw45SNNlotuKxmQm2" Name="Mouse Device" Kind="InputPin" />
                 <Pin Id="IlsS1JgJXAaPyHt9d2YI8w" Name="Keyboard Device" Kind="InputPin" />
@@ -333,6 +335,7 @@
                     </CategoryReference>
                   </p:NodeReference>
                   <Pin Id="TUICCjsysiFLNVSPztr2Cj" Name="Input" Kind="InputPin" />
+                  <Pin Id="EGnDGcyehhYPqRn2VeXKeg" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="SkQQtb3TbEyMs4kuRzfWNX" Name="Pan Delta" Kind="OutputPin" />
                   <Pin Id="F0SxUCxDUHVOFWJPNlvp4Q" Name="Zoom Delta" Kind="OutputPin" />
                   <Pin Id="Rmh06Ln91skPNF8urXtFGe" Name="Zoom Target" Kind="OutputPin" />
@@ -344,6 +347,7 @@
                     <Choice Kind="ProcessNode" Name="TogEdge" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="OzeLatIvQfeMRKKiA0NSYm" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="JYG29cHqz8SMdKeFflU7R5" Name="Value" Kind="InputPin" />
                   <Pin Id="IDAvGw57jIQO1UcDgC2VJL" Name="Up Edge" Kind="OutputPin" />
                   <Pin Id="Pn068poKcXuN5yYqbU05wp" Name="Down Edge" Kind="OutputPin" />
@@ -353,6 +357,7 @@
                     <Choice Kind="ProcessNode" Name="Toggle" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="UjYQdGbUKCRPQkOugZt0ZC" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="HoJ91sndTRQOlH8Z1D3AWe" Name="Flip" Kind="ApplyPin" />
                   <Pin Id="F5g8bhiaIRUOE6DV73z7P4" Name="Reset" Kind="ApplyPin" />
                   <Pin Id="HU3xnCTN3wLLPqZjUUlvnY" Name="Value" Kind="OutputPin" />
@@ -909,6 +914,7 @@
                     <Choice Kind="ProcessNode" Name="MouseState" />
                     <CategoryReference Kind="Category" Name="Mouse" />
                   </p:NodeReference>
+                  <Pin Id="UmlgMLxO4NJPh7StzZETEZ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="MqfXxPFAziMOkzmxsaw1Cj" Name="Mouse Device" Kind="InputPin" />
                   <Pin Id="Od8kc2UhWzYOCK0Qyet0cZ" Name="Position In World" Kind="OutputPin" />
                   <Pin Id="LUE7sixiXsLQAeX2LaTohq" Name="Position In Projection" Kind="OutputPin" />
@@ -926,6 +932,7 @@
                     <Choice Kind="ProcessNode" Name="KeyboardState" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="QBtc0i1PHbMOqgx7BG3Vxm" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="QicA7gY2xgzN4kMcQQ7pmG" Name="Keyboard Device" Kind="InputPin" />
                   <Pin Id="LTIStQaladeQceFHxBs3Ag" Name="Pressed Keys" Kind="OutputPin" />
                 </Node>
@@ -934,6 +941,7 @@
                     <Choice Kind="ProcessNode" Name="FrameDifference" />
                     <CategoryReference Kind="Category" Name="FrameBased" />
                   </p:NodeReference>
+                  <Pin Id="AGPyjv1eJDtLEBPtabLwgT" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="MHLLI4kIlZoOJCnzlSdVyv" Name="Value" Kind="InputPin" />
                   <Pin Id="Ql2qeiSz48eLHPeQxkjP3r" Name="Result" Kind="OutputPin" />
                 </Node>
@@ -942,6 +950,7 @@
                     <Choice Kind="ProcessNode" Name="KeyMatch" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="TysD6gVLmwZQdiKlqVwHsm" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Ipujcmc3p9YLQRHqoy5tcD" Name="Keys" Kind="InputPin" />
                   <Pin Id="EQ0fBP15YKOO5K8IUO1bNP" Name="Key Name" Kind="InputPin" />
                   <Pin Id="Rc6S7fhpFjWOlrntnXXmHc" Name="Is Down" Kind="OutputPin" />
@@ -988,6 +997,7 @@
                     <Choice Kind="ProcessNode" Name="FrameDifference" />
                     <CategoryReference Kind="Category" Name="FrameBased" />
                   </p:NodeReference>
+                  <Pin Id="NtPI7eNPlBiQFr6Ulmd7jS" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="A2OlxkiWRJfMBg5PMdbPrG" Name="Value" Kind="InputPin" />
                   <Pin Id="KCREhopVKD5O1FfhbupU0H" Name="Result" Kind="OutputPin" />
                 </Node>
@@ -1005,6 +1015,7 @@
                     <Choice Kind="ProcessNode" Name="TimerFlop" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="Ja2wqe65wD9MknwQBOjTOA" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="TQQhJ9rz96UNamrtlRSsso" Name="Clock" Kind="InputPin" />
                   <Pin Id="T1sZoFEduBdO9Deixg8Qm2" Name="Set" Kind="InputPin" />
                   <Pin Id="GbCUS0Z0aH4OrGIG1qhvby" Name="Reset" Kind="InputPin" />
@@ -1017,6 +1028,7 @@
                     <Choice Kind="ProcessNode" Name="KeyMatch" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="KrOo5KTLCSRQEnZ8Z3bxUi" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="IkFZPJt5XLdMI4edWOQ7IL" Name="Keys" Kind="InputPin" />
                   <Pin Id="LavkbBv7N3LOugMLHKiAj0" Name="Key Name" Kind="InputPin" />
                   <Pin Id="B0ikO8hx9PmM4tU5i9aRai" Name="Is Down" Kind="OutputPin" />
@@ -1026,6 +1038,7 @@
                     <Choice Kind="ProcessNode" Name="TogEdge" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="FqJRE3SpRbGMEXSb4wmRJe" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="SBGodWCv96ZPBaMimwiwH7" Name="Value" Kind="InputPin" />
                   <Pin Id="JQCQToZjAlSMqlbo3YyStB" Name="Up Edge" Kind="OutputPin" />
                   <Pin Id="MOxwk4LndmtMe6FvoImM2L" Name="Down Edge" Kind="OutputPin" />
@@ -1072,6 +1085,8 @@
                     <Choice Kind="ProcessNode" Name="Changed" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="UY0O2qLQg7MOcU9RwEaYQO" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="FzpX8w0jf6WOpzxoUVp56S" Name="Changed On Create" Kind="InputPin" IsHidden="true" />
                   <Pin Id="I4DxtRWBBBJO4kiD7Z1msM" Name="Value" Kind="InputPin" />
                   <Pin Id="EEoINcwuIHpMsVdUJjpfPe" Name="Result" Kind="OutputPin" />
                   <Pin Id="SukqXFbinQLNUc4wztMM3P" Name="Unchanged" Kind="OutputPin" />
@@ -1170,6 +1185,7 @@
                     <p:OuterCategoryReference Kind="Category" Name="Editors" NeedsToBeDirectParent="true" />
                   </CategoryReference>
                 </p:NodeReference>
+                <Pin Id="FWCnRlo53XAQF9eJ7V6L67" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="MiBzbbEXUfUPFVvDHLrhpp" Name="Initial Interest" Kind="InputPin" />
                 <Pin Id="GGPtdm9iN27NZUBS0YPyf4" Name="Initial Longitude" Kind="InputPin" />
                 <Pin Id="Dy2CXpCjiQyNkOXnQq8Cux" Name="Initial Latitude" Kind="InputPin" />
@@ -1187,6 +1203,7 @@
                   <Choice Kind="ProcessNode" Name="SoftimageCameraControls" />
                   <CategoryReference Kind="Category" Name="Editors" />
                 </p:NodeReference>
+                <Pin Id="FTOYNo81MHVLNHf2E01cR2" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="ARdHoUFkQT4NklFDcCpXKH" Name="Camera Controls" Kind="InputPin" />
                 <Pin Id="ErbeLsauvhcN4DcrXH8Tad" Name="Mouse Device" Kind="InputPin" />
                 <Pin Id="LlmWsyvNpaXNijGutZvsqx" Name="Keyboard Device" Kind="InputPin" />
@@ -1281,6 +1298,7 @@
                     <p:OuterCategoryReference Kind="Category" Name="Editors" NeedsToBeDirectParent="true" />
                   </CategoryReference>
                 </p:NodeReference>
+                <Pin Id="DShq0ql1BDfORPygpzr0uR" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="Q2Zqlvdywo9NPnTb2Fjd3G" Name="Initial Interest" Kind="InputPin" />
                 <Pin Id="F15WZN99aNzMRCUzrCBFH0" Name="Initial Longitude" Kind="InputPin" />
                 <Pin Id="H9WC8VtNZt9OQzKsco1clw" Name="Initial Latitude" Kind="InputPin" />
@@ -1298,6 +1316,7 @@
                   <Choice Kind="ProcessNode" Name="MouseState" />
                   <CategoryReference Kind="Category" Name="Mouse" />
                 </p:NodeReference>
+                <Pin Id="AuQNn1o9QT6PraBDNNpbZZ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="AhccSd6kHodQEkUJSx8SL8" Name="Mouse Device" Kind="InputPin" />
                 <Pin Id="GaNMe1JFqBTPPKtQWezpVw" Name="Position In World" Kind="OutputPin" />
                 <Pin Id="FbjZ5J65VrVNannNLwkE7w" Name="Position In Projection" Kind="OutputPin" />
@@ -1315,6 +1334,7 @@
                   <Choice Kind="ProcessNode" Name="KeyMatch" />
                   <CategoryReference Kind="Category" Name="Keyboard" />
                 </p:NodeReference>
+                <Pin Id="GgERlw7KnOqO8UFEoRAJOy" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="OOg6wTocj3tPsZMsQENiF2" Name="Keys" Kind="InputPin" />
                 <Pin Id="JVwdFWlT8npO7BLUbWP3Gz" Name="Key Name" Kind="InputPin" />
                 <Pin Id="TU1E9snBhjbMjxDxxRgXI4" Name="Is Down" Kind="OutputPin" />
@@ -1324,6 +1344,7 @@
                   <Choice Kind="ProcessNode" Name="KeyboardState" />
                   <CategoryReference Kind="Category" Name="Keyboard" />
                 </p:NodeReference>
+                <Pin Id="KjOdAv7EOL8LzTLykGSw0D" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="JVElDdsYF8QK9uZbpebU8n" Name="Keyboard Device" Kind="InputPin" />
                 <Pin Id="F0c4K9sZiYVOApm02VyjiE" Name="Pressed Keys" Kind="OutputPin" />
               </Node>
@@ -1332,6 +1353,7 @@
                   <Choice Kind="ProcessNode" Name="KeyMatch" />
                   <CategoryReference Kind="Category" Name="Keyboard" />
                 </p:NodeReference>
+                <Pin Id="Mbqc8IKDJwBMMlkc7ycYES" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="I66QD0vwXNTL3QtaPOQS4R" Name="Keys" Kind="InputPin" />
                 <Pin Id="VdZ3yU2tNTGME36ugNgGT6" Name="Key Name" Kind="InputPin" />
                 <Pin Id="Mx5aVPVAB4FMPLMt42V1kD" Name="Is Down" Kind="OutputPin" />
@@ -1373,6 +1395,7 @@
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="OrbitCameraControls" />
                 </p:NodeReference>
+                <Pin Id="AeRgc44eCPKNHHQIeERfgO" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="C89587t6jOzPHQXwByrNTe" Name="Camera Controls" Kind="InputPin" />
                 <Pin Id="BgD7WYQmx8mN9lJ4iMqlr0" Name="Mouse Device" Kind="InputPin" />
                 <Pin Id="VeBCO3fipdjO9vsXcQMD8w" Name="Keyboard Device" Kind="InputPin" />
@@ -1441,7 +1464,7 @@
               <Slot Id="Juq7oqAWhE8MDwi0KTKtEX" Name="Interest" />
               <Slot Id="DnlvDp0hMDFMl0HdJ0oLPJ" Name="Initialize" />
               <Patch Id="ClyCkMqlVUoNvUn2qAEA8c" Name="Create" ParticipatingElements="EYy9v9a4utiLXIf1DHitBO" IsGeneric="true" />
-              <Patch Id="V8aV1mAkTltPAY5PYJoCJ2" Name="Update" ParticipatingElements="CNCJDmuwfk4M2OQAo9YWau,GHzePx3CE6nLwGHZgUfTHg,RaaKZi6ez0yLD3gi92Z5sF,EfKum0qJOLQK94yVAvaJzR,J0hgO4Q2NBILXRDzNqQHEg,QNRxQ9Vzt5nLVavT4J8Vww,MtpRfy8bvKyLchd30SxBzf,LyHKNGvhXnKNPc5iAVpR7u,G0Fs4wqRwamNSaDo9YdD1m,CeJ70R9Q5XcOBE99dE49hi,H8HYLp34X8TL7Zf5hsfIFa,EMxU6aJiPNeMsNhQ6EwsuA,TG9NQ75QorKMuKBTg63zto,KMWDPTQPnRqMffUnAIAItP,EIrct5yY1pFL7h3zMnrgNm,Jgex5GnkryqPB74BNhbEs6,ICJ45KN8o0bPLCXxXvorgI,A4Fl75YqnWONhsAI2Wi6So,VkZBkcIvGluO0qjETY6s5E,PDUkHeZbaqAOrkjQ36l9EM,KQxWf7X9xTAPBM3XuNB37u,L0nyJbSgcHjM05jWkCMum9,V7XLbamzy0fOg29y6TRUI1,U4LYXNbVyzENBj6QYNb3Kl,Iqs8GIqiG2LLWGbWbdTg09,GzTKeNBZ2qiPAm4G6jzuEo,H3qNA2QEIjPPqbmhKGlNb3,JjdjRcWi4gUOKwDiCXF3xJ,OpDhmiLmMHpQJwRaZzev5p,JAKsfuWlW0mLz8JIylN7vC,CvrNyHdfo8hLFmXFjZfz2c,JfYlgomkOqgLh2LVC8pMGT,VXh8VMJM177MaGRC9ezCDL,G1m5Aej0LX3OQuvFluRoiE,DYzpn1NBO4TOwCN58f3Vfs,ApqKxJ6jSy2OEpToAYxSYW,BPkvPC1FzFkPOmHrifAjOd,Q6QP19SClvbOvx1RTvTPB2,FfgH6WBEXDJMwGXUtRnzwu,KXZDYeTAqPQL2rsUgva7Cr,KeADejQOc4aLskeX6sY1nh,LLjpRwPO5lvPQWMFGwaahW,PAqnBr4bQ97PChcWXfwWmk,M1NpguTBYcxPvwKcvmYZy6,Ug4VxLqG2r3QS4cQl1hTR4,AcI0ddFiGR3ONXNQSgO1FW" IsGeneric="true">
+              <Patch Id="V8aV1mAkTltPAY5PYJoCJ2" Name="Update" ParticipatingElements="CNCJDmuwfk4M2OQAo9YWau,GHzePx3CE6nLwGHZgUfTHg,RaaKZi6ez0yLD3gi92Z5sF,EfKum0qJOLQK94yVAvaJzR,J0hgO4Q2NBILXRDzNqQHEg,QNRxQ9Vzt5nLVavT4J8Vww,MtpRfy8bvKyLchd30SxBzf,LyHKNGvhXnKNPc5iAVpR7u,G0Fs4wqRwamNSaDo9YdD1m,CeJ70R9Q5XcOBE99dE49hi,H8HYLp34X8TL7Zf5hsfIFa,EMxU6aJiPNeMsNhQ6EwsuA,KMWDPTQPnRqMffUnAIAItP,EIrct5yY1pFL7h3zMnrgNm,Jgex5GnkryqPB74BNhbEs6,ICJ45KN8o0bPLCXxXvorgI,A4Fl75YqnWONhsAI2Wi6So,VkZBkcIvGluO0qjETY6s5E,PDUkHeZbaqAOrkjQ36l9EM,KQxWf7X9xTAPBM3XuNB37u,L0nyJbSgcHjM05jWkCMum9,V7XLbamzy0fOg29y6TRUI1,U4LYXNbVyzENBj6QYNb3Kl,Iqs8GIqiG2LLWGbWbdTg09,GzTKeNBZ2qiPAm4G6jzuEo,H3qNA2QEIjPPqbmhKGlNb3,JjdjRcWi4gUOKwDiCXF3xJ,OpDhmiLmMHpQJwRaZzev5p,JAKsfuWlW0mLz8JIylN7vC,CvrNyHdfo8hLFmXFjZfz2c,JfYlgomkOqgLh2LVC8pMGT,VXh8VMJM177MaGRC9ezCDL,G1m5Aej0LX3OQuvFluRoiE,DYzpn1NBO4TOwCN58f3Vfs,ApqKxJ6jSy2OEpToAYxSYW,BPkvPC1FzFkPOmHrifAjOd,Q6QP19SClvbOvx1RTvTPB2,FfgH6WBEXDJMwGXUtRnzwu,KXZDYeTAqPQL2rsUgva7Cr,KeADejQOc4aLskeX6sY1nh,LLjpRwPO5lvPQWMFGwaahW,PAqnBr4bQ97PChcWXfwWmk,M1NpguTBYcxPvwKcvmYZy6,Ug4VxLqG2r3QS4cQl1hTR4,AcI0ddFiGR3ONXNQSgO1FW" IsGeneric="true">
                 <Pin Id="QzB4OgwiF88QPf4ZgCGAwO" Name="Initial Interest" Kind="InputPin" />
                 <Pin Id="M4WwboqtZD0QZVfFO4xC4j" Name="Initial Longitude" Kind="InputPin" />
                 <Pin Id="VDnRcymOs7WP4S7yafUB43" Name="Initial Latitude" Kind="InputPin" />
@@ -1469,17 +1492,17 @@
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="DG1GIeUrYkJNbBfNEqZAdW" Comment="Initialize" Bounds="-22,200" ShowValueBox="true" isIOBox="true" Value="True">
+                <Pad Id="DG1GIeUrYkJNbBfNEqZAdW" Comment="Initialize" Bounds="-22,200,35,35" ShowValueBox="true" isIOBox="true" Value="True">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="Dnp0YxX8fR9OtmME9r82dX" Comment="Initialize" Bounds="-24,310" ShowValueBox="true" isIOBox="true" Value="False">
+                <Pad Id="Dnp0YxX8fR9OtmME9r82dX" Comment="Initialize" Bounds="-24,310,35,35" ShowValueBox="true" isIOBox="true" Value="False">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Boolean" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="T847zBB3pdgL2gTa14fuVP" Comment="Min" Bounds="160,407" ShowValueBox="true" isIOBox="true" Value="-0.249899909">
+                <Pad Id="T847zBB3pdgL2gTa14fuVP" Comment="Min" Bounds="160,407,46,15" ShowValueBox="true" isIOBox="true" Value="-0.249899909">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -1488,7 +1511,7 @@
                     <p:precision p:Type="Int32">4</p:precision>
                   </p:ValueBoxSettings>
                 </Pad>
-                <Pad Id="H4zGKI5CXUQLX57hMqe4tJ" Comment="Max" Bounds="236,406" ShowValueBox="true" isIOBox="true" Value="0.249900028">
+                <Pad Id="H4zGKI5CXUQLX57hMqe4tJ" Comment="Max" Bounds="236,406,40,15" ShowValueBox="true" isIOBox="true" Value="0.249900028">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -1503,25 +1526,25 @@
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="CXaKQtPvHmiOxb8sxEGeHK" Bounds="214,212" ShowValueBox="true" isIOBox="true" Value="-1">
+                <Pad Id="CXaKQtPvHmiOxb8sxEGeHK" Bounds="214,212,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="F6xkoKEp24sLCwCRfqYwGc" Comment="Scalar" Bounds="708,589" ShowValueBox="true" isIOBox="true" Value="-1">
+                <Pad Id="F6xkoKEp24sLCwCRfqYwGc" Comment="Scalar" Bounds="708,589,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="E7sSI5WHQxdMo2QuCX3A6J" Bounds="367,156" ShowValueBox="true" isIOBox="true" Value="-1">
+                <Pad Id="E7sSI5WHQxdMo2QuCX3A6J" Bounds="367,156,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="Ah2HubJVE8kNTuryLTji2d" Comment="Scalar" Bounds="875,312" ShowValueBox="true" isIOBox="true" Value="-1">
+                <Pad Id="Ah2HubJVE8kNTuryLTji2d" Comment="Scalar" Bounds="875,312,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -1540,7 +1563,7 @@
                 <Pad Id="Lfjz4Ay4RuHP94AwPtzDSM" SlotId="DnlvDp0hMDFMl0HdJ0oLPJ" Bounds="881,194" />
                 <Pad Id="VZF3mxh15RENp0ZVItAUK3" SlotId="DnlvDp0hMDFMl0HdJ0oLPJ" Bounds="-27,349" />
                 <Pad Id="LYj6XgTntLsPcTYmKmaIHo" SlotId="DnlvDp0hMDFMl0HdJ0oLPJ" Bounds="-25,240" />
-                <Node Bounds="659,1022,35,13" Id="CNCJDmuwfk4M2OQAo9YWau">
+                <Node Bounds="659,1022,42,19" Id="CNCJDmuwfk4M2OQAo9YWau">
                   <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Invert" />
                     <CategoryReference Kind="Category" Name="Matrix" />
@@ -1548,7 +1571,7 @@
                   <Pin Id="G71QZxVX084OPk7aNshMZ1" Name="Input" Kind="InputPin" />
                   <Pin Id="DzhzeIOILjGOYzALoVw17K" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="590,843,65,13" Id="GHzePx3CE6nLwGHZgUfTHg">
+                <Node Bounds="590,843,68,19" Id="GHzePx3CE6nLwGHZgUfTHg">
                   <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Perspective (FOV)" />
                     <CategoryReference Kind="Category" Name="Matrix" />
@@ -1559,7 +1582,7 @@
                   <Pin Id="HrbRVoh4o0HMpyUgA5OSka" Name="Z Far" Kind="InputPin" />
                   <Pin Id="IKHEkRvUOkgPIokaNr8oFN" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="187,336,-9,19" Id="RaaKZi6ez0yLD3gi92Z5sF">
+                <Node Bounds="187,336,25,19" Id="RaaKZi6ez0yLD3gi92Z5sF">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="+" />
                   </p:NodeReference>
@@ -1567,7 +1590,7 @@
                   <Pin Id="NY3qhu2A4CIOInloStU0jB" Name="Input 2" Kind="InputPin" />
                   <Pin Id="Lik8s8TVjPRLZap2RvxX1S" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="324,336,-6,19" Id="EfKum0qJOLQK94yVAvaJzR">
+                <Node Bounds="324,336,25,19" Id="EfKum0qJOLQK94yVAvaJzR">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="+" />
                   </p:NodeReference>
@@ -1575,7 +1598,7 @@
                   <Pin Id="VHrlMSaJHGhOSF4HSfQE1t" Name="Input 2" Kind="InputPin" />
                   <Pin Id="CEvbxgy7jsTMfI48XDtOUM" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="439,336,-14,19" Id="J0hgO4Q2NBILXRDzNqQHEg">
+                <Node Bounds="439,336,25,19" Id="J0hgO4Q2NBILXRDzNqQHEg">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="+" />
                   </p:NodeReference>
@@ -1583,7 +1606,7 @@
                   <Pin Id="EtjHaJE1DsXMKGqe2VBu2V" Name="Input 2" Kind="InputPin" />
                   <Pin Id="FRu7D545U6TNgNgVRG811r" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="323,301,63,13" Id="QNRxQ9Vzt5nLVavT4J8Vww">
+                <Node Bounds="323,301,63,19" Id="QNRxQ9Vzt5nLVavT4J8Vww">
                   <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Switch (Boolean)" />
                     <FullNameCategoryReference ID="Control" />
@@ -1593,7 +1616,7 @@
                   <Pin Id="ROoiXuT8hKGMvIP2RaODxB" Name="Input 2" Kind="InputPin" />
                   <Pin Id="BKp5WLbmIc4OZCzQCHO9My" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="187,301,63,13" Id="MtpRfy8bvKyLchd30SxBzf">
+                <Node Bounds="187,301,63,19" Id="MtpRfy8bvKyLchd30SxBzf">
                   <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Switch (Boolean)" />
                     <FullNameCategoryReference ID="Control" />
@@ -1603,7 +1626,7 @@
                   <Pin Id="OSmAReC7t9CNBoWfxN7or3" Name="Input 2" Kind="InputPin" />
                   <Pin Id="JHSsQJLiwlKMQt60DRvw1t" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="439,301,63,13" Id="LyHKNGvhXnKNPc5iAVpR7u">
+                <Node Bounds="439,301,63,19" Id="LyHKNGvhXnKNPc5iAVpR7u">
                   <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Switch (Boolean)" />
                     <FullNameCategoryReference ID="Control" />
@@ -1613,7 +1636,7 @@
                   <Pin Id="U6PBVSA7hEqLkdjYDdVPJ1" Name="Input 2" Kind="InputPin" />
                   <Pin Id="DWVheGXZusALEYTgxSk0IK" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="572,301,63,13" Id="G0Fs4wqRwamNSaDo9YdD1m">
+                <Node Bounds="572,301,63,19" Id="G0Fs4wqRwamNSaDo9YdD1m">
                   <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Switch (Boolean)" />
                     <FullNameCategoryReference ID="Control" />
@@ -1623,7 +1646,7 @@
                   <Pin Id="NfW2xElYnN6MGLVHo35zbp" Name="Input 2" Kind="InputPin" />
                   <Pin Id="TvAvASu7QDENUgxfrcaEPF" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="572,336,-24,19" Id="CeJ70R9Q5XcOBE99dE49hi">
+                <Node Bounds="572,336,25,19" Id="CeJ70R9Q5XcOBE99dE49hi">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="+" />
                   </p:NodeReference>
@@ -1631,7 +1654,7 @@
                   <Pin Id="LB70qyRXoMrPg3lMqNRhvx" Name="Input 2" Kind="InputPin" />
                   <Pin Id="LYULLoX6WAXPSHA2IfnrRb" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="770,301,63,13" Id="H8HYLp34X8TL7Zf5hsfIFa">
+                <Node Bounds="770,301,63,19" Id="H8HYLp34X8TL7Zf5hsfIFa">
                   <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Switch (Boolean)" />
                     <FullNameCategoryReference ID="Control" />
@@ -1641,7 +1664,7 @@
                   <Pin Id="NwMW43L2cTkPn26rHJJWWV" Name="Input 2" Kind="InputPin" />
                   <Pin Id="J2Zb5wlHMuhMM2Ukxf9WPq" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="774,607,-26,19" Id="EMxU6aJiPNeMsNhQ6EwsuA">
+                <Node Bounds="774,607,25,19" Id="EMxU6aJiPNeMsNhQ6EwsuA">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="+" />
                   </p:NodeReference>
@@ -1649,16 +1672,7 @@
                   <Pin Id="JDwmFsEgVlBM3FSixM7b4w" Name="Input 2" Kind="InputPin" />
                   <Pin Id="UNhr6ksjymcOHZ8Im46c8E" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="826,374,57,13" Id="TG9NQ75QorKMuKBTg63zto">
-                  <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="CoreLibBasics.vl">
-                    <Choice Kind="OperationNode" Name="ToVector3" />
-                    <CategoryReference Kind="Category" Name="Vector2" />
-                  </p:NodeReference>
-                  <Pin Id="MaRobHRGrkmQNOuaoc1SS7" Name="Input" Kind="InputPin" />
-                  <Pin Id="ET1Hm80UBuAOJEY70DKiCd" Name="Z" Kind="InputPin" />
-                  <Pin Id="V5V3CVjxyGFPHjKJuRopem" Name="Result" Kind="OutputPin" />
-                </Node>
-                <Node Bounds="833,95,125,22" Id="KMWDPTQPnRqMffUnAIAItP">
+                <Node Bounds="833,95,125,26" Id="KMWDPTQPnRqMffUnAIAItP">
                   <p:NodeReference LastCategoryFullName="Editors.3D.CameraControls" LastDependency="VL.Cameras.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationNode" Name="Split" />
@@ -1668,6 +1682,7 @@
                     </CategoryReference>
                   </p:NodeReference>
                   <Pin Id="BV5PJSxIPPVLod12OHW1Hk" Name="Input" Kind="InputPin" />
+                  <Pin Id="Cdhijja8hXKOdBx4InvAqW" Name="Output" Kind="OutputPin" IsHidden="true" />
                   <Pin Id="IqoWQ7Ye86XNeAmXpv2dof" Name="Longitude Delta" Kind="OutputPin" />
                   <Pin Id="U9I7gYZzZWQOjfcXU4mi2o" Name="Latitude Delta" Kind="OutputPin" />
                   <Pin Id="LyMi8teSaRPOq1qq6qbZgr" Name="FOV Delta" Kind="OutputPin" />
@@ -1676,7 +1691,7 @@
                   <Pin Id="UnPeJqvHURjO0MKXuKFQuf" Name="Reset" Kind="OutputPin" />
                   <Pin Id="Cr3tL2cKAV8Qc7oSsjlFsN" Name="Idle" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="181,445,37,19" Id="EIrct5yY1pFL7h3zMnrgNm">
+                <Node Bounds="181,445,45,19" Id="EIrct5yY1pFL7h3zMnrgNm">
                   <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Clamp" />
                     <CategoryReference Kind="Category" Name="Ranges" />
@@ -1686,12 +1701,13 @@
                   <Pin Id="MEkJqv9EncYLVuRsdFgq9E" Name="Maximum" Kind="InputPin" />
                   <Pin Id="JqHbsWzUtNWLWVpV8L6Kmg" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="893,256,41,13" Id="JWQsAm25TI1NuwYqpL2jnC">
+                <Node Bounds="893,256,52,19" Id="JWQsAm25TI1NuwYqpL2jnC">
                   <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="Control" />
                     <Choice Kind="ProcessAppFlag" Name="FlipFlop" />
                   </p:NodeReference>
+                  <Pin Id="HzSUL8CwzniL3zjiT7nzeb" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Lczktq8OyE3PORrdjpykJn" Name="Set" Kind="InputPin" />
                   <Pin Id="FPphhMv9CMIPMvOtLygWYK" Name="Reset" Kind="ApplyPin" />
                   <Pin Id="Drvl9BbUAKrMV6nqJbfvbp" Name="State" Kind="OutputPin" />
@@ -1701,11 +1717,12 @@
                     <Choice Kind="ProcessNode" Name="TogEdge" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="MPIGiV23uUwPtRnC7hWB7I" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="QyN38dy8NYiPq7feJtJ4c8" Name="Value" Kind="InputPin" />
                   <Pin Id="NJ1WXet2O1YL4H0r0lef7i" Name="Up Edge" Kind="OutputPin" />
                   <Pin Id="FRvbXXPszjPLNhaxDFBojq" Name="Down Edge" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="893,223,65,13" Id="Jgex5GnkryqPB74BNhbEs6">
+                <Node Bounds="893,223,65,19" Id="Jgex5GnkryqPB74BNhbEs6">
                   <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="OR" />
                     <CategoryReference Kind="Category" Name="Boolean" />
@@ -1715,7 +1732,7 @@
                   <Pin Id="TK5ZEIRrfrvMFwTXpMeXYO" Name="Input 3" Kind="InputPin" />
                   <Pin Id="LmJMHr5Pu2FQRlUnnnCvSp" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="320,488,45,13" Id="ICJ45KN8o0bPLCXxXvorgI">
+                <Node Bounds="320,488,46,19" Id="ICJ45KN8o0bPLCXxXvorgI">
                   <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Vector (Join)" />
                     <CategoryReference Kind="Category" Name="Vector3" />
@@ -1725,7 +1742,7 @@
                   <Pin Id="VCYx6b2gPAJNYBDL15aESA" Name="Z" Kind="InputPin" />
                   <Pin Id="QXZ69c0DwnnMI5q30HJOKH" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="295,523,-2,19" Id="A4Fl75YqnWONhsAI2Wi6So">
+                <Node Bounds="295,523,45,19" Id="A4Fl75YqnWONhsAI2Wi6So">
                   <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Rotate" />
                     <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -1736,7 +1753,7 @@
                   <Pin Id="JEiZgvG5TPeP8p28O05YZt" Name="Rotation" Kind="InputPin" />
                   <Pin Id="GD4s7C3M65APjy1vD1ze7c" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="183,869,61,13" Id="VkZBkcIvGluO0qjETY6s5E">
+                <Node Bounds="183,869,67,19" Id="VkZBkcIvGluO0qjETY6s5E">
                   <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Translation" />
                     <CategoryReference Kind="Category" Name="Matrix" />
@@ -1744,7 +1761,7 @@
                   <Pin Id="Kz1hhYxy92EPf66bYxbleg" Name="Translation" Kind="InputPin" />
                   <Pin Id="HEco1jDwdufMIiKbgOigF6" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="464,827,45,13" Id="PDUkHeZbaqAOrkjQ36l9EM">
+                <Node Bounds="464,827,46,19" Id="PDUkHeZbaqAOrkjQ36l9EM">
                   <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Vector (Join)" />
                     <CategoryReference Kind="Category" Name="Vector3" />
@@ -1754,7 +1771,7 @@
                   <Pin Id="GDgDskzfteZON1cNiF27Ha" Name="Z" Kind="InputPin" />
                   <Pin Id="M7uv4x7wXefN6uosIMkSIK" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="295,792,35,13" Id="KQxWf7X9xTAPBM3XuNB37u">
+                <Node Bounds="295,792,42,19" Id="KQxWf7X9xTAPBM3XuNB37u">
                   <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Invert" />
                     <CategoryReference Kind="Category" Name="Matrix" />
@@ -1762,7 +1779,7 @@
                   <Pin Id="ClBPjicjVFbM5Dl9z2kNph" Name="Input" Kind="InputPin" />
                   <Pin Id="L8dZiwcCIvPLWkXpgQudVq" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="168,711,61,13" Id="L0nyJbSgcHjM05jWkCMum9">
+                <Node Bounds="168,711,67,19" Id="L0nyJbSgcHjM05jWkCMum9">
                   <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Translation" />
                     <CategoryReference Kind="Category" Name="Matrix" />
@@ -1770,7 +1787,7 @@
                   <Pin Id="BKHlcpXvSXaMo86TzW6Zlo" Name="Translation" Kind="InputPin" />
                   <Pin Id="JtCprzmUt5hOwaVKJJ575x" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="167,828,-5,19" Id="V7XLbamzy0fOg29y6TRUI1">
+                <Node Bounds="167,828,25,19" Id="V7XLbamzy0fOg29y6TRUI1">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="*" />
                   </p:NodeReference>
@@ -1778,7 +1795,7 @@
                   <Pin Id="CCYuaTaYsrqNw7jaOFLGj2" Name="Input 2" Kind="InputPin" />
                   <Pin Id="HEr8sQEBJH8PiSXkQxP4n3" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="167,897,-20,19" Id="U4LYXNbVyzENBj6QYNb3Kl">
+                <Node Bounds="167,897,25,19" Id="U4LYXNbVyzENBj6QYNb3Kl">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="*" />
                   </p:NodeReference>
@@ -1786,7 +1803,7 @@
                   <Pin Id="OaOvx7hdPCJNR6Eo3EH3JN" Name="Input 2" Kind="InputPin" />
                   <Pin Id="PK634YsZbJwQZVtPYKdK0L" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="826,421,45,13" Id="Iqs8GIqiG2LLWGbWbdTg09">
+                <Node Bounds="826,421,45,19" Id="Iqs8GIqiG2LLWGbWbdTg09">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="* (Scale)" />
                   </p:NodeReference>
@@ -1795,7 +1812,7 @@
                   <Pin Id="FCtsBeYYMDXP00CfZdRwIt" Name="Apply" Kind="ApplyPin" />
                   <Pin Id="Rynl0RYscmfOJw7AFmFsqG" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="826,570,57,13" Id="GzTKeNBZ2qiPAm4G6jzuEo">
+                <Node Bounds="826,570,64,19" Id="GzTKeNBZ2qiPAm4G6jzuEo">
                   <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Transform" />
                     <CategoryReference Kind="Category" Name="Vector3" />
@@ -1805,7 +1822,7 @@
                   <Pin Id="IHFNFBla6h9NUlbNJlYI4G" Name="Apply" Kind="ApplyPin" />
                   <Pin Id="IPh4bxL5c7BPRLh2BBky0T" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="474,1020,1,19" Id="H3qNA2QEIjPPqbmhKGlNb3">
+                <Node Bounds="474,1020,25,19" Id="H3qNA2QEIjPPqbmhKGlNb3">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="*" />
                   </p:NodeReference>
@@ -1813,7 +1830,7 @@
                   <Pin Id="QlQyO2qlCdBLX7T5Dcfaye" Name="Input 2" Kind="InputPin" />
                   <Pin Id="EsCMHjCBF8vNqC3x5byEXF" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="687,1082,57,13" Id="JjdjRcWi4gUOKwDiCXF3xJ">
+                <Node Bounds="687,1082,64,19" Id="JjdjRcWi4gUOKwDiCXF3xJ">
                   <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="Transform" />
                     <CategoryReference Kind="Category" Name="Vector3" />
@@ -1822,7 +1839,7 @@
                   <Pin Id="Ev6rk2j8ByUPqYVbftWU8v" Name="Transform" Kind="InputPin" />
                   <Pin Id="LiTeDVMl3frPn3WazbQwZh" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="200,243,-14,19" Id="OpDhmiLmMHpQJwRaZzev5p">
+                <Node Bounds="200,243,25,19" Id="OpDhmiLmMHpQJwRaZzev5p">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="*" />
                   </p:NodeReference>
@@ -1830,7 +1847,7 @@
                   <Pin Id="LMwVcbby0JCPTAXz3D9JiY" Name="Input 2" Kind="InputPin" />
                   <Pin Id="MX9q3BtEhvWMXdCzZX6t0i" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="693,635,-22,19" Id="JAKsfuWlW0mLz8JIylN7vC">
+                <Node Bounds="693,635,25,19" Id="JAKsfuWlW0mLz8JIylN7vC">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="* (Scale)" />
                   </p:NodeReference>
@@ -1838,7 +1855,7 @@
                   <Pin Id="TjJl3mJOJnNNFmw1yO0xsH" Name="Scalar" Kind="InputPin" />
                   <Pin Id="Nn7OBdqAXPQLYSNAbjnqZo" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="352,176,15,19" Id="CvrNyHdfo8hLFmXFjZfz2c">
+                <Node Bounds="352,176,25,19" Id="CvrNyHdfo8hLFmXFjZfz2c">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="OperationNode" Name="*" />
                   </p:NodeReference>
@@ -1846,10 +1863,11 @@
                   <Pin Id="TGQlFfo73QEOtwTJNs2kwA" Name="Input 2" Kind="InputPin" />
                   <Pin Id="PS76YrG81qlPVnfTlmOukb" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="857,343,-15,19" Id="JfYlgomkOqgLh2LVC8pMGT">
-                  <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="CoreLibBasics.vl">
+                <Node Bounds="857,343,25,19" Id="JfYlgomkOqgLh2LVC8pMGT">
+                  <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
                     <Choice Kind="OperationNode" Name="* (Scale)" />
-                    <CategoryReference Kind="Category" Name="Vector2" />
                   </p:NodeReference>
                   <Pin Id="M21eYEPK1uuNEp7Ahc8RYE" Name="Input" Kind="InputPin" />
                   <Pin Id="MfZOTmd25iIOjYmXF01v0A" Name="Scalar" Kind="InputPin" />
@@ -1874,6 +1892,7 @@
                       <p:OuterCategoryReference Kind="Category" Name="Editors" NeedsToBeDirectParent="true" />
                     </CategoryReference>
                   </p:NodeReference>
+                  <Pin Id="FvhhpBKLqwfPTMCJ7bg90X" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Exyu7jXTZ0ZN8vyaWgnFvm" Name="View Projection" Kind="InputPin" />
                   <Pin Id="IlpNBuYUXhVMTL73lpNBEQ" Name="View" Kind="InputPin" />
                   <Pin Id="I2vu9uk9E7VOD24JvpfXwW" Name="Projection" Kind="InputPin" />
@@ -1938,7 +1957,6 @@
               <Link Id="Szxu6D2wh9BNt1kXiszqzv" Ids="HEco1jDwdufMIiKbgOigF6,OaOvx7hdPCJNR6Eo3EH3JN" />
               <Link Id="LUvep2ehMXuOd4BanTTRiP" Ids="HEr8sQEBJH8PiSXkQxP4n3,MAGnZbjdwLyPJKrywQraB5" />
               <Link Id="QXkKxOJHuTYOpU4oNYqoHs" Ids="CEvbxgy7jsTMfI48XDtOUM,KJTOh21tsqGQZBTVFUclWW" />
-              <Link Id="DGjBcDeLi2DNLrjp7Hn9xk" Ids="V5V3CVjxyGFPHjKJuRopem,FSSQRESdigNMb9cu2h9NMp" />
               <Link Id="F7hcYrChJzMNihKXFYeWtv" Ids="LYULLoX6WAXPSHA2IfnrRb,UrrAEWKLpImMILY5pWqgRI" />
               <Link Id="Lj4ybXagvMfPk9HnR0l6C8" Ids="Rynl0RYscmfOJw7AFmFsqG,MmBAhxwLUmDPd5PwGUogl8" />
               <Link Id="IfCqnU65QDzORrpwoubF7J" Ids="GD4s7C3M65APjy1vD1ze7c,A0TaZp9W6M6O5oFeuV8YaU" />
@@ -1962,7 +1980,6 @@
               <Link Id="SVe8Qp2QklIL66bvGieGiA" Ids="PS76YrG81qlPVnfTlmOukb,ROoiXuT8hKGMvIP2RaODxB" />
               <Link Id="Ug4VxLqG2r3QS4cQl1hTR4" Ids="E7sSI5WHQxdMo2QuCX3A6J,TGQlFfo73QEOtwTJNs2kwA" />
               <Link Id="LejxiME7ASCK9fw85zhlm2" Ids="AdnJ6jU67BSPRuJKuk5eLV,M21eYEPK1uuNEp7Ahc8RYE" />
-              <Link Id="FJvOY2HDNKLQEliXk0ktjk" Ids="RSWfTZZwPxBPEDnpPQ6IyD,MaRobHRGrkmQNOuaoc1SS7" />
               <Link Id="AcI0ddFiGR3ONXNQSgO1FW" Ids="Ah2HubJVE8kNTuryLTji2d,MfZOTmd25iIOjYmXF01v0A" />
               <Link Id="HehQEEQ9qxpLOCIf7dPm8G" Ids="U4EWBc0SAkaPqCgfboo87N,JxDAVh4A8PdLPhUEUiKpOn" IsHidden="true" />
               <Link Id="P0tsJrXG9qJPk00NCxKzDQ" Ids="O4M1sMAcX9LMXGapx7DNF0,TK5ZEIRrfrvMFwTXpMeXYO" />
@@ -1990,6 +2007,7 @@
               <Link Id="TwoJlCPxKJIODJUk3MaIDf" Ids="Drvl9BbUAKrMV6nqJbfvbp,MMNNaBcaoDaM96sz2FVXM2" />
               <Link Id="P5tpmwcz3RgOrvXiuEudzm" Ids="Drvl9BbUAKrMV6nqJbfvbp,THnlegorzquLq8AfGvI1tO" />
               <Link Id="DNet1uyWoNOLqpGZqz2xyu" Ids="Drvl9BbUAKrMV6nqJbfvbp,Un4SnBUbEVTNhFYlr1aijF" />
+              <Link Id="U6mM6zO8LQUM7xhJmRUxpD" Ids="RSWfTZZwPxBPEDnpPQ6IyD,FSSQRESdigNMb9cu2h9NMp" />
             </Patch>
           </Node>
           <!--
@@ -2009,7 +2027,7 @@
               <Slot Id="AbMKOT2krA4MLd8gtw0Pb8" Name="Distance Delta" />
               <Slot Id="Mg8OmJKocZRM6i7uipROtM" Name="Reset" />
               <Slot Id="N7XliBYW10wPlqHR78wO5R" Name="Not Idle" />
-              <Canvas Id="MIgixhLWwegMUcnOld67ad" BordersChecked="false">
+              <Canvas Id="MIgixhLWwegMUcnOld67ad">
                 <Pad Id="KBOBYprtXiLOBaYbnxcm4m" SlotId="V8dWdLIU14jMGbNfEAm5Po" Bounds="383,519" />
                 <Pad Id="M4NJoOmpImYOOvoteRFRtH" SlotId="V8dWdLIU14jMGbNfEAm5Po" Bounds="398,826" />
                 <Pad Id="SkZb4lb167nLTLnveJ6Svj" SlotId="V8dWdLIU14jMGbNfEAm5Po" Bounds="373,943" />
@@ -2245,8 +2263,8 @@
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="Ad7om3iNVz8NOiuOhYb7eR" Name="Interest Delta" Kind="InputPin">
-                  <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="CoreLibBasics.vl">
-                    <Choice Kind="TypeFlag" Name="Vector2" />
+                  <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Vector3" />
                   </p:TypeAnnotation>
                 </Pin>
                 <Pin Id="ATD35wnWVBxNp9rmVwfHM3" Name="Distance Delta" Kind="InputPin">
@@ -2551,25 +2569,25 @@
                 <Pin Id="C7gUlOk8f5WNPn295jPDx8" Name="Camera Controls" Kind="OutputPin" />
               </Patch>
               <Canvas Id="S78Zz4BKwjJMcZkMKyTJsO">
-                <Pad Id="FyJ4msG0ps1LSifruJaJBI" Comment="FOV Delta Speed" Bounds="429,345" ShowValueBox="true" isIOBox="true" Value="0.015">
+                <Pad Id="FyJ4msG0ps1LSifruJaJBI" Comment="FOV Delta Speed" Bounds="429,345,35,15" ShowValueBox="true" isIOBox="true" Value="0.015">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="SsaADLCPsW7OwvLHd0r0ct" Comment="Ctrl + Mouse Wheel changes FOV" Bounds="755,252,29,14" ShowValueBox="true" isIOBox="true" Value="ControlKey">
+                <Pad Id="SsaADLCPsW7OwvLHd0r0ct" Comment="Ctrl + Mouse Wheel changes FOV" Bounds="755,252,29,15" ShowValueBox="true" isIOBox="true" Value="ControlKey">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="O9wa43EqDhpOSn3Oy4Ydtq" Comment="Time" Bounds="758,143" ShowValueBox="true" isIOBox="true" Value="0.5">
+                <Pad Id="O9wa43EqDhpOSn3Oy4Ydtq" Comment="Time" Bounds="758,143,35,15" ShowValueBox="true" isIOBox="true" Value="0.5">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="JSmLjEZpIlvMvC5ix3pUqL" Comment="Reset" Bounds="742,36,29,14" ShowValueBox="true" isIOBox="true" Value="R">
+                <Pad Id="JSmLjEZpIlvMvC5ix3pUqL" Comment="Reset" Bounds="742,36,29,15" ShowValueBox="true" isIOBox="true" Value="R">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -2630,6 +2648,7 @@
                     <Choice Kind="ProcessNode" Name="KeyMatch" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="F1Ly5vgXuMDNyklqJCR6ts" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="TV8IWzLnrpOMVrmGzmglPL" Name="Keys" Kind="InputPin" />
                   <Pin Id="LOgoPwf8x8tOAa3raRy6VJ" Name="Key Name" Kind="InputPin" />
                   <Pin Id="LQX6us5Or7xM4bIa0jtrS5" Name="Is Down" Kind="OutputPin" />
@@ -2657,6 +2676,7 @@
                     <Choice Kind="ProcessNode" Name="TogEdge" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="CC5sGGMU1CUPIb9M6mMwjc" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Pzsv17we6YYPr1g3N4hiqH" Name="Value" Kind="InputPin" />
                   <Pin Id="TFjqCBB2NiZN4H4FN3zRue" Name="Up Edge" Kind="OutputPin" />
                   <Pin Id="P86bJsLWzVqNhJISZjuCrK" Name="Down Edge" Kind="OutputPin" />
@@ -2666,6 +2686,7 @@
                     <Choice Kind="ProcessNode" Name="FrameDifference" />
                     <CategoryReference Kind="Category" Name="FrameBased" />
                   </p:NodeReference>
+                  <Pin Id="Es15uhx7c4xNyijADyKXgT" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="UHmGV27LgYcPhjimTTbKJE" Name="Value" Kind="InputPin" />
                   <Pin Id="HDJrdrOfdKaNUbnXzcO9bW" Name="Result" Kind="OutputPin" />
                 </Node>
@@ -2683,6 +2704,7 @@
                     <Choice Kind="ProcessNode" Name="TimerFlop" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="Krkc0rQro7SQRLi7nyqjXE" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Rrm5sDRUJvyN3vVgXYSvBh" Name="Clock" Kind="InputPin" />
                   <Pin Id="Pq5SEdOY8wyQc1jRti0suh" Name="Set" Kind="InputPin" />
                   <Pin Id="CqEv02oxzwpObKT4WK2Zr3" Name="Reset" Kind="InputPin" />
@@ -2695,6 +2717,7 @@
                     <Choice Kind="ProcessNode" Name="FrameDifference" />
                     <CategoryReference Kind="Category" Name="FrameBased" />
                   </p:NodeReference>
+                  <Pin Id="Oq2vSBOk0swOQ17ypeoPlO" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="AICNLuntEwVQFzt7jUU1Wl" Name="Value" Kind="InputPin" />
                   <Pin Id="TRPoar2z2KbPBDJnoUwQrJ" Name="Result" Kind="OutputPin" />
                 </Node>
@@ -2703,6 +2726,7 @@
                     <Choice Kind="ProcessNode" Name="KeyMatch" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="AS5boIvROEoOn0J2qg4d3I" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Fh73jfBlpWLPPXcXrT9Ydp" Name="Keys" Kind="InputPin" />
                   <Pin Id="JiD56ohf229M4DklifVRUm" Name="Key Name" Kind="InputPin" />
                   <Pin Id="EyfvyLKzzYDNL71zegLENu" Name="Is Down" Kind="OutputPin" />
@@ -2730,6 +2754,7 @@
                     <Choice Kind="ProcessNode" Name="KeyboardState" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="VdjieQpUVKUNgShOItDzvD" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="K0U2UiQnnAdNnn3bzWPRdf" Name="Keyboard Device" Kind="InputPin" />
                   <Pin Id="Suq4wq4I8R3QIJ3qxnWwr0" Name="Pressed Keys" Kind="OutputPin" />
                 </Node>
@@ -2738,6 +2763,7 @@
                     <Choice Kind="ProcessNode" Name="MouseState" />
                     <CategoryReference Kind="Category" Name="Mouse" />
                   </p:NodeReference>
+                  <Pin Id="UonlNfBWmrKOaNaBB2rI8x" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="KuaKET065BQPYul7Fvjpgd" Name="Mouse Device" Kind="InputPin" />
                   <Pin Id="ShY18Lxzeh2QMGGWUUjr8b" Name="Position In World" Kind="OutputPin" />
                   <Pin Id="TKLO4tQovKCPlvYENHsg0J" Name="Position In Projection" Kind="OutputPin" />
@@ -2755,25 +2781,25 @@
                 <ControlPoint Id="LlFk7Hrv62wPxqEhuYp3yc" Bounds="497,-48" />
                 <ControlPoint Id="BVWxMOroFENQNpG5y8d3xp" Bounds="863,-53" />
                 <ControlPoint Id="JWGT1buWUOHNbaUrQ2PN73" Bounds="118,660,462,20" />
-                <Pad Id="Mj0D14pCRTuMy18vhCNcYy" Comment="Distance Delta Speed" Bounds="392,317" ShowValueBox="true" isIOBox="true" Value="1.6">
+                <Pad Id="Mj0D14pCRTuMy18vhCNcYy" Comment="Distance Delta Speed" Bounds="392,317,35,15" ShowValueBox="true" isIOBox="true" Value="1.6">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="SwUywVIV7t2LH7Pj6Bdwv8" Comment="Longitude / Latitude Delta Speed " Bounds="277,283" ShowValueBox="true" isIOBox="true" Value="0.25">
+                <Pad Id="SwUywVIV7t2LH7Pj6Bdwv8" Comment="Longitude / Latitude Delta Speed " Bounds="277,283,35,15" ShowValueBox="true" isIOBox="true" Value="0.25">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="U4TmoDSLiWAPnaR56rMqWL" Comment="Interest Delta Speed" Bounds="514,368" ShowValueBox="true" isIOBox="true" Value="1">
+                <Pad Id="U4TmoDSLiWAPnaR56rMqWL" Comment="Interest Delta Speed" Bounds="514,368,35,15" ShowValueBox="true" isIOBox="true" Value="1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="DPkH5LjwjPRNaYPlCPOFKM" Bounds="383,254" ShowValueBox="true" isIOBox="true" Value="SPEEDS">
+                <Pad Id="DPkH5LjwjPRNaYPlCPOFKM" Bounds="383,254,50,19" ShowValueBox="true" isIOBox="true" Value="SPEEDS">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -2788,6 +2814,7 @@
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Filter" />
                   </p:NodeReference>
+                  <Pin Id="QMKgPPtfEjAN1HcqGthLf1" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="QM9o2WD7m4DOWFwsmgAU9e" Name="Initial Position" Kind="InputPin" />
                   <Pin Id="MmYDvyXjGHoMaDNkU7cC9J" Name="Clock" Kind="InputPin" />
                   <Pin Id="PzQWUTjFoc4QOsFnpS4fyD" Name="New Clock" Kind="InputPin" />
@@ -2808,6 +2835,7 @@
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Filter" />
                   </p:NodeReference>
+                  <Pin Id="DjiMRmEFk6ZOwST7Tm1dnU" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="L2T3i3QdYXdLgEUVydYJYp" Name="Initial Position" Kind="InputPin" />
                   <Pin Id="ArWdz3vw1v7QZ7COWdw5WV" Name="Clock" Kind="InputPin" />
                   <Pin Id="OqcDoYwpj73PGzaBs6koWE" Name="New Clock" Kind="InputPin" />
@@ -2828,6 +2856,7 @@
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Filter" />
                   </p:NodeReference>
+                  <Pin Id="URQYIOOKOZrPRzirtqBuyM" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="OfOiP6boW54QGOiyK8njUj" Name="Initial Position" Kind="InputPin" />
                   <Pin Id="GkiGZgKpE0ANFgekoiWE3n" Name="Clock" Kind="InputPin" />
                   <Pin Id="VhDI69U25D1LqrbRHG5PtY" Name="New Clock" Kind="InputPin" />
@@ -2848,6 +2877,7 @@
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Filter" />
                   </p:NodeReference>
+                  <Pin Id="Ic1EzHSYqN9PPiGWmAwKmt" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="VdOvRh8YIKfMGWCF0hdzGB" Name="Initial Position" Kind="InputPin" />
                   <Pin Id="Lx0IQufUx9yP76g99406c9" Name="Clock" Kind="InputPin" />
                   <Pin Id="HXR6aFCY9dGPXrrhE0pKiN" Name="New Clock" Kind="InputPin" />
@@ -2868,6 +2898,7 @@
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Filter" />
                   </p:NodeReference>
+                  <Pin Id="ABjzvlN71UFN9hLDhZ03NZ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="AuVvlXXB8IiLdrEClW7veM" Name="Initial Position" Kind="InputPin" />
                   <Pin Id="EIpodu0Ig26PctyIGOcAZM" Name="Clock" Kind="InputPin" />
                   <Pin Id="NHpGAiSMMvyLnnHODUSmWA" Name="New Clock" Kind="InputPin" />
@@ -2975,43 +3006,43 @@
                 <Pin Id="Hczk0qLYT27MntFvfHrtUb" Name="Camera Controls" Kind="OutputPin" />
               </Patch>
               <Canvas Id="V4YE68HHJ1bLshURX20Ml2">
-                <Pad Id="FmKMu7TH567QTYRBFUEtRT" Comment="Reset" Bounds="615,240,29,14" ShowValueBox="true" isIOBox="true" Value="R">
+                <Pad Id="FmKMu7TH567QTYRBFUEtRT" Comment="Reset" Bounds="615,240,29,15" ShowValueBox="true" isIOBox="true" Value="R">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="H5AozzvWbNSPyJRnGZaInv" Comment="Key Name" Bounds="877,240,29,14" ShowValueBox="true" isIOBox="true" Value="Z">
+                <Pad Id="H5AozzvWbNSPyJRnGZaInv" Comment="Key Name" Bounds="877,240,29,15" ShowValueBox="true" isIOBox="true" Value="Z">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="T7jqm3OjsmAPwREcoMH9Gh" Comment="Key Name" Bounds="754,240,29,14" ShowValueBox="true" isIOBox="true" Value="O">
+                <Pad Id="T7jqm3OjsmAPwREcoMH9Gh" Comment="Key Name" Bounds="754,240,29,15" ShowValueBox="true" isIOBox="true" Value="O">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="RTzx2ElnplUPWNiDyP0CMU" Comment="Key Name" Bounds="1010,240,29,14" ShowValueBox="true" isIOBox="true" Value="P">
+                <Pad Id="RTzx2ElnplUPWNiDyP0CMU" Comment="Key Name" Bounds="1010,240,29,15" ShowValueBox="true" isIOBox="true" Value="P">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="Uo6alaXXQutNMobmQV8DoX" Comment="Time" Bounds="612,311" ShowValueBox="true" isIOBox="true" Value="0.5">
+                <Pad Id="Uo6alaXXQutNMobmQV8DoX" Comment="Time" Bounds="612,311,35,15" ShowValueBox="true" isIOBox="true" Value="0.5">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="H5DBl3pAsqDPBDdGS63JdA" Comment="Distance Delta Speed Slow " Bounds="398,543" ShowValueBox="true" isIOBox="true" Value="1">
+                <Pad Id="H5DBl3pAsqDPBDdGS63JdA" Comment="Distance Delta Speed Slow " Bounds="398,543,35,15" ShowValueBox="true" isIOBox="true" Value="1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="KAjrwoFFM7nQbJntaOJ0x9" Comment="Distance Delta Speed Fast" Bounds="418,597" ShowValueBox="true" isIOBox="true" Value="5">
+                <Pad Id="KAjrwoFFM7nQbJntaOJ0x9" Comment="Distance Delta Speed Fast" Bounds="418,597,35,15" ShowValueBox="true" isIOBox="true" Value="5">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -3030,6 +3061,7 @@
                     <Choice Kind="ProcessNode" Name="MouseState" />
                     <CategoryReference Kind="Category" Name="Mouse" />
                   </p:NodeReference>
+                  <Pin Id="JSKEWAFDjUnNGCRwCdXF59" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="VTebeREul1pMghTUkGd5w1" Name="Mouse Device" Kind="InputPin" />
                   <Pin Id="Ng6NCcGpDK7QQBCiNxO47f" Name="Position In World" Kind="OutputPin" />
                   <Pin Id="DlTPAyc25ZDNybNtKlweck" Name="Position In Projection" Kind="OutputPin" />
@@ -3047,6 +3079,7 @@
                     <Choice Kind="ProcessNode" Name="KeyboardState" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="NwXB15zTAhKP6WERKLnlti" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="HEwOedeNO8rPZBK00tuMgV" Name="Keyboard Device" Kind="InputPin" />
                   <Pin Id="EazuUUIKrQGLT3c6Bs64ak" Name="Pressed Keys" Kind="OutputPin" />
                 </Node>
@@ -3073,6 +3106,7 @@
                     <Choice Kind="ProcessNode" Name="KeyMatch" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="GgGDlNwnCR6LGtMAwx3icu" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="GpHseJP0xDWMb7OFX5kpq5" Name="Keys" Kind="InputPin" />
                   <Pin Id="Kfw4DFclZqCPf6FUQr0PoA" Name="Key Name" Kind="InputPin" />
                   <Pin Id="GotBQG7vxKiOQe3QcrH0nD" Name="Is Down" Kind="OutputPin" />
@@ -3082,6 +3116,7 @@
                     <Choice Kind="ProcessNode" Name="KeyMatch" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="SQ5BqEmYXsnON5cyAGhDGQ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="CE0c8uIoyQlMeeKTvPBw9x" Name="Keys" Kind="InputPin" />
                   <Pin Id="VSOkIIbQhvwNlLRnIs2tXH" Name="Key Name" Kind="InputPin" />
                   <Pin Id="DpaZY0WGWHHNPaRXZaUNRA" Name="Is Down" Kind="OutputPin" />
@@ -3091,6 +3126,7 @@
                     <Choice Kind="ProcessNode" Name="KeyMatch" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="CW9ho4svLmiNayrqSQ6UrF" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="BsuqP3ohyZhQHMCv7Gy4aJ" Name="Keys" Kind="InputPin" />
                   <Pin Id="OYeRULQVF81LLn33Fhm59G" Name="Key Name" Kind="InputPin" />
                   <Pin Id="QZBSzjF5LViPZVke2RnhmS" Name="Is Down" Kind="OutputPin" />
@@ -3100,6 +3136,7 @@
                     <Choice Kind="ProcessNode" Name="KeyMatch" />
                     <CategoryReference Kind="Category" Name="Keyboard" />
                   </p:NodeReference>
+                  <Pin Id="Iq4mlJI8mcmLrgbLT4GIi3" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="R6SFOZF64EPPOwZsPW82JE" Name="Keys" Kind="InputPin" />
                   <Pin Id="VK7kGAZ1GsmL5dxOaSnqhy" Name="Key Name" Kind="InputPin" />
                   <Pin Id="TptFgnjPFokLyI4wC9xx4b" Name="Is Down" Kind="OutputPin" />
@@ -3118,6 +3155,7 @@
                     <Choice Kind="ProcessNode" Name="FrameDifference" />
                     <CategoryReference Kind="Category" Name="FrameBased" />
                   </p:NodeReference>
+                  <Pin Id="RBForTPnDAjMbOrR0fuZ08" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="Uoqnc2C4zWKPQIkC21mLhN" Name="Value" Kind="InputPin" />
                   <Pin Id="HNW0CbtA3KVLivfjeXzmXJ" Name="Result" Kind="OutputPin" />
                 </Node>
@@ -3126,6 +3164,7 @@
                     <Choice Kind="ProcessNode" Name="TimerFlop" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="Kni0K3FktX0OxPxIU3tzqV" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="KDfbfNN8WehLkYcTA4uAJL" Name="Clock" Kind="InputPin" />
                   <Pin Id="OxM7PZ0jm7jLHIECeBJ8QP" Name="Set" Kind="InputPin" />
                   <Pin Id="KNGaiCfUBTVN1RiloeXrOv" Name="Reset" Kind="InputPin" />
@@ -3192,6 +3231,7 @@
                     <Choice Kind="ProcessNode" Name="TogEdge" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="LDNJPdBMYv4P0c4uacnHTi" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="GED4jBW0naDNDP8H4zR9pY" Name="Value" Kind="InputPin" />
                   <Pin Id="VXxfQuXKeYcQCD5Ne60SuB" Name="Up Edge" Kind="OutputPin" />
                   <Pin Id="EkNRi0X4tSIN1NcA61f0CP" Name="Down Edge" Kind="OutputPin" />
@@ -3237,6 +3277,7 @@
                     <Choice Kind="ProcessNode" Name="FlipFlop" />
                     <CategoryReference Kind="Category" Name="Control" />
                   </p:NodeReference>
+                  <Pin Id="CVRhqfm5ipSOEsxmqCKmNG" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="EsyUSKk0cILLijgRZQYCEh" Name="Set" Kind="ApplyPin" />
                   <Pin Id="TlOCptXWdvNPSly8NBPOF6" Name="Reset" Kind="ApplyPin" />
                   <Pin Id="TQuI9u6lBFaLIhoeCTgGix" Name="State" Kind="OutputPin" />
@@ -3329,26 +3370,26 @@
                 <ControlPoint Id="U9VKspVJ97fM263978F29s" Bounds="551,118" />
                 <ControlPoint Id="NNyfSRFetmmLFpmh8UdBXZ" Bounds="718,116" />
                 <ControlPoint Id="QZQ8z2hj0jLLbvAWyq7xpn" Bounds="131,832" />
-                <Pad Id="EAORjq9eEqsQcsSUBsjerc" Comment="Longitude / Latitude Delta Speed " Bounds="250,446" ShowValueBox="true" isIOBox="true" Value="0.25">
+                <Pad Id="EAORjq9eEqsQcsSUBsjerc" Comment="Longitude / Latitude Delta Speed " Bounds="250,446,35,15" ShowValueBox="true" isIOBox="true" Value="0.25">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="VVAXyGMXjeyLxT90LKyX0W" Comment="FOV Delta Speed" Bounds="305,470" ShowValueBox="true" isIOBox="true" Value="0.01">
+                <Pad Id="VVAXyGMXjeyLxT90LKyX0W" Comment="FOV Delta Speed" Bounds="305,470,35,15" ShowValueBox="true" isIOBox="true" Value="0.01">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="U6FKNhjT9nuQKPvhnBxV9v" Comment="Y" Bounds="263,529" ShowValueBox="true" isIOBox="true" />
-                <Pad Id="CoiyDgGcnJ7PV3MCn2hXvx" Comment="Interest Delta Speed" Bounds="355,497" ShowValueBox="true" isIOBox="true" Value="1">
+                <Pad Id="U6FKNhjT9nuQKPvhnBxV9v" Comment="Y" Bounds="263,529,35,15" ShowValueBox="true" isIOBox="true" />
+                <Pad Id="CoiyDgGcnJ7PV3MCn2hXvx" Comment="Interest Delta Speed" Bounds="355,497,35,15" ShowValueBox="true" isIOBox="true" Value="1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="GoVN7pE5txhMxsrVzvGlcl" Bounds="313,409" ShowValueBox="true" isIOBox="true" Value="SPEEDS">
+                <Pad Id="GoVN7pE5txhMxsrVzvGlcl" Bounds="313,409,50,19" ShowValueBox="true" isIOBox="true" Value="SPEEDS">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -3440,6 +3481,541 @@
               <Link Id="BNP9LpQ9ni4OICdS0xRZqq" Ids="U6FKNhjT9nuQKPvhnBxV9v,VXkmFIAX49bMa5O0htNR9Y" />
               <Link Id="CgJlsc4FG9VLjjgd71I35x" Ids="U6FKNhjT9nuQKPvhnBxV9v,Hd5vz67fjdDMWtfVBQ1H1b" />
               <Link Id="Pd6Zn4DnefSOoGOHqukolq" Ids="CoiyDgGcnJ7PV3MCn2hXvx,DNftLbh7zivPGEAvfD1h0b" />
+            </Patch>
+          </Node>
+          <!--
+
+    ************************ WSADCamera ************************
+
+-->
+          <Node Name="WSADCamera" Bounds="141,430" Id="BuoFW8VCEzbPYf8lnLRQ9l">
+            <p:NodeReference>
+              <Choice Kind="ContainerDefinition" Name="Process" />
+              <FullNameCategoryReference ID="Primitive" />
+            </p:NodeReference>
+            <Patch Id="FsVMVMBVnWyNcKUjcSJ2Al">
+              <Slot Id="JYIIvGaAqIXMsSKEMvMWha" Name="Latitude" />
+              <Slot Id="Qr2nnvznZKkPJD3xR4adCS" Name="Longitude" />
+              <Slot Id="TH3K1c6gwM4O1aKkEWpz0j" Name="FOV" />
+              <Slot Id="RfApeqKcduyQKdCgM4fITq" Name="Distance" />
+              <Slot Id="TTxSh8wwHUSNKakhc8NYo9" Name="Interest" />
+              <Slot Id="SAyfUco8MSiNPLlc43uMNK" Name="Initialize" />
+              <Patch Id="V3j4eT9biK7M6LVbqxIGPs" Name="Create" ParticipatingElements="EG3zV9w6d7zPV3xrMCcJOv" IsGeneric="true" />
+              <Patch Id="F9wfUeHMjgnOCQyCSU25z9" Name="Update" ParticipatingElements="KtyoMqwgWVUOEsrSCur5xl,P5KAO2CCYhZPJpBwy8n2JQ,J2pAgVeExBgNbuIGC6mYTD,SPZSHkuUXvMP16ESb25uRm,RshbVjF7oDUP3JySRfOg7t,TZnEgxMHvEtPXoB2jKzIfj,ONH2chcrvysMxsbmJwHU8i,UzaQSd3VXRlPgVHVoB06sS,OvySGQKNQy7OZiqgoXvJFo,KX5iJ8al32ZQUFxQfrOkYU,QInmX1t8CFBLkSJl2TbPoa,RJzCsl5f7aYMqWtoyqW1Tl,GITpzmgl1Q6OVcup58Yqbu,PLye7obW3G2NcIMRnDawQC,SwslzYuO20pLBHgy9bwR9m,QVqtPA5E0b4LO8DH2YmsBD,IKUpHj5OGdjOlabeoKngmI,HeILYtsjQKWNEpRu9CFhqJ,JeV6uYueNbfOLK56QqZxoY,FnRtaIhkj41MrqoSI5nEgQ,HmJDjRNXL1TQQ207R8P1Vp,VSWeTj30TwvP1xU91dGw9z,E1D84MKO5TYPjue97WC34M,SBlo1ULsO1lLjyp2kIlhBL,F3s1AkhikHHOiOqQyv6AUr,BbmsXIQnA0hL1Uz5PgQuEK,ITUaJTSKIzXNnY2oBg15ta,KHBMdLVKlYHOn4Hd7DdMg4,SGnXvMHU9b3MqCTYw8T3VS,KxUDLK1fLgFNRFX8JyA9Lp,A1QnVuTOgU3LqfoZegZZCT,T8gyNUUGs0rOrDfrlnnNYW,BAQHzq20W2dNl3XwtJPrty,EKzzy7mTZrZLBX2PNn8WAh,Hq911cJ82jMPaletEKoGZj,CdFCDbefuqWNrpCeyeZPIf,Q0Ry4hu8GFfNFMAHJue5Ge,LW05c3tgC1AQEYj47ulxGr,L0bKgPCFyzOOKZI0bBdWfg,LkLI0iJRu4zPuAzis0b1si,LaIWZmaJt83PE0OSVeoC7u,EmPo1Q0EkaTNX7wUYILgwm" IsGeneric="true">
+                <Pin Id="AEw5t3hK1ssNCfPfNLoP81" Name="Initial Interest" Kind="InputPin" />
+                <Pin Id="LodXXqzJo0nLxeubkb6YPV" Name="Initial Longitude" Kind="InputPin" />
+                <Pin Id="OtjyHzJ0HL4NFqH9VKi4fg" Name="Initial Latitude" Kind="InputPin" />
+                <Pin Id="VkdzTBByVBaMeFGGrdvh2d" Name="Initial Distance" Kind="InputPin" />
+                <Pin Id="NuDvdlizrIDM5JzrDJQSde" Name="Initial FOV" Kind="InputPin" />
+                <Pin Id="TdYlorf99ROQG8TfriVFFT" Name="Near Plane" Kind="InputPin" DefaultValue="0.01">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="AH8HbJhIvfVPXkzytDTIMl" Name="Far Plane" Kind="InputPin" DefaultValue="100">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="BktQmus7bVlLstCyN5GJJu" Name="CameraControls3d" Kind="InputPin" />
+                <Pin Id="OY47lk5ULUbPngMp5b59V6" Name="Renderer Hovered" Kind="InputPin" />
+                <Pin Id="FFH7DYPze2oN0Hof15YMQI" Name="Reset" Kind="InputPin" />
+                <Pin Id="TDAHHkUeGZLLC8SuDXmsVi" Name="CameraState3d" Kind="OutputPin" />
+              </Patch>
+              <Canvas Id="HlUi84Yanc0LKtm6mZ9R0i">
+                <Pad Id="S79p23S4NfMMvf77iEZDYP" Comment="Aspect" Bounds="512,670,51,15" ShowValueBox="true" isIOBox="true" Value="1">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="LbwMulyRwAPL1vkxuBp69a" Comment="Initialize" Bounds="10,56,35,35" ShowValueBox="true" isIOBox="true" Value="True">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Boolean" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="ASxqgWKoUqmOrQK2JCmiHS" Comment="Initialize" Bounds="8,175,35,35" ShowValueBox="true" isIOBox="true" Value="False">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Boolean" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="GEkcEzz5ib1NZNw9vGoXqA" Comment="Min" Bounds="209,415,46,15" ShowValueBox="true" isIOBox="true" Value="-0.249899909">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                  <p:ValueBoxSettings>
+                    <p:precision p:Type="Int32">4</p:precision>
+                  </p:ValueBoxSettings>
+                </Pad>
+                <Pad Id="VkGAjEg3mZeL3fu44jJSd4" Comment="Max" Bounds="229,435,40,15" ShowValueBox="true" isIOBox="true" Value="0.249900028">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                  <p:ValueBoxSettings>
+                    <p:precision p:Type="Int32">4</p:precision>
+                  </p:ValueBoxSettings>
+                </Pad>
+                <Pad Id="N663mhUnobyMTPLnHCXMDT" Comment="Active Viewport" Bounds="672,1051,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Integer32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="EOkZHFS6VERM2lChpcs4ar" Bounds="214,212,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="KJHANuDHgBSNVMB74qBAU8" Comment="Scalar" Bounds="675,580,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="VAFORA7qoMfMUI355uFVko" Bounds="367,156,35,15" ShowValueBox="true" isIOBox="true" Value="-1">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="Fwi0a81HVw4MDYrjcOXnnV" SlotId="JYIIvGaAqIXMsSKEMvMWha" Bounds="124,255" />
+                <Pad Id="FQW0X9kArh2Ph0qOJVVTXP" SlotId="JYIIvGaAqIXMsSKEMvMWha" Bounds="189,505" />
+                <Pad Id="HSB1VzwCtmKM4PbtLBFNKD" SlotId="Qr2nnvznZKkPJD3xR4adCS" Bounds="354,261" />
+                <Pad Id="Fyzmj3HnCl0OAH16DBdtZa" SlotId="Qr2nnvznZKkPJD3xR4adCS" Bounds="325,370" />
+                <Pad Id="KY0qycPe7BhNrqTa7LcZI8" SlotId="TH3K1c6gwM4O1aKkEWpz0j" Bounds="470,260" />
+                <Pad Id="GN9Lh0SEmBrQVsSTlMXa8f" SlotId="TH3K1c6gwM4O1aKkEWpz0j" Bounds="441,370" />
+                <Pad Id="P8ULwvp0HO4M1JwjuP8z9E" SlotId="RfApeqKcduyQKdCgM4fITq" Bounds="603,260" />
+                <Pad Id="E9IbQZlzXspMSM3SgJfHf8" SlotId="RfApeqKcduyQKdCgM4fITq" Bounds="574,370" />
+                <Pad Id="CxPKwY3Z4PgOYPi92rfcof" SlotId="TTxSh8wwHUSNKakhc8NYo9" Bounds="785,260" />
+                <Pad Id="SxOvuJvrpNHNv9gbujZaYV" SlotId="TTxSh8wwHUSNKakhc8NYo9" Bounds="802,611" />
+                <Pad Id="VzEPGgGOGuYLxXpQQhzzxQ" SlotId="SAyfUco8MSiNPLlc43uMNK" Bounds="881,194" />
+                <Pad Id="M5XkFOXvouFMuAU80fv9Vw" SlotId="SAyfUco8MSiNPLlc43uMNK" Bounds="8,214" />
+                <Pad Id="GWooRnoEFORLBLyyZMMVRP" SlotId="SAyfUco8MSiNPLlc43uMNK" Bounds="10,105" />
+                <Node Bounds="539,1000,42,19" Id="KtyoMqwgWVUOEsrSCur5xl">
+                  <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Invert" />
+                    <CategoryReference Kind="Category" Name="Matrix" />
+                  </p:NodeReference>
+                  <Pin Id="Jwf5CBpCJ4vMPPlNqBNOwb" Name="Input" Kind="InputPin" />
+                  <Pin Id="Hx76whoHb4iPifVlWjMlKK" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="494,700,68,19" Id="P5KAO2CCYhZPJpBwy8n2JQ">
+                  <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Perspective (FOV)" />
+                    <CategoryReference Kind="Category" Name="Matrix" />
+                  </p:NodeReference>
+                  <Pin Id="JJRXiEWDcMgLs1oe0Pln4c" Name="FOV" Kind="InputPin" />
+                  <Pin Id="RyWDkU3vx8EM3OtyIoziQ0" Name="Aspect" Kind="InputPin" />
+                  <Pin Id="Lny3ofNjL0uLGVzDHKHbh4" Name="Z Near" Kind="InputPin" />
+                  <Pin Id="VrZnIXZme0yQdtO1Mw8j0p" Name="Z Far" Kind="InputPin" />
+                  <Pin Id="RE6cgAwrwDlPfcKNrZHzbw" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="187,341,25,19" Id="J2pAgVeExBgNbuIGC6mYTD">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="Gg2T22NBAd3OsDp07of6xo" Name="Input" Kind="InputPin" />
+                  <Pin Id="IBUgZc9fzDjM6uTHBm7Dmk" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="FnLrpxBdh5tP5kArbV3FT4" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="323,330,63,19" Id="SPZSHkuUXvMP16ESb25uRm">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="BMNPYJ3ZtSqO1QJjJJz6Nk" Name="Input" Kind="InputPin" />
+                  <Pin Id="LNnHaLEnRu4PrqCxX5BCpm" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="PHCNya6RYleOnM0ivmln6a" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="439,336,63,19" Id="RshbVjF7oDUP3JySRfOg7t">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="SjgZ2kaoP6iM6qf8Q15PEz" Name="Input" Kind="InputPin" />
+                  <Pin Id="T6GcCHmE5WpO2nHtav1YMP" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="OjRHNFyp4KHNwBuICfKxAH" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="323,301,63,19" Id="TZnEgxMHvEtPXoB2jKzIfj">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Switch (Boolean)" />
+                    <FullNameCategoryReference ID="Control" />
+                  </p:NodeReference>
+                  <Pin Id="HRQCfIfufCMMtCiA7h8hUH" Name="Condition" Kind="InputPin" />
+                  <Pin Id="C1apbYmoN8wNFtGeXsbDiD" Name="Input" Kind="InputPin" />
+                  <Pin Id="FibQP4pWwDvLZS1Ml6x5V7" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="OlTmI10yXkeOG8IuLMgl4j" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="187,301,63,19" Id="ONH2chcrvysMxsbmJwHU8i">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Switch (Boolean)" />
+                    <FullNameCategoryReference ID="Control" />
+                  </p:NodeReference>
+                  <Pin Id="VnZNRY18JtLPSf6IGYv8aa" Name="Condition" Kind="InputPin" />
+                  <Pin Id="U2fLs8MhJByM83kuobbn65" Name="Input" Kind="InputPin" />
+                  <Pin Id="SDcJ8tAPDUBLU7rFTNcdxI" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="CExefdH1n83NkGVE6gOow3" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="439,301,63,19" Id="UzaQSd3VXRlPgVHVoB06sS">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Switch (Boolean)" />
+                    <FullNameCategoryReference ID="Control" />
+                  </p:NodeReference>
+                  <Pin Id="FjQfklJBUW1Lva1jAkGGlN" Name="Condition" Kind="InputPin" />
+                  <Pin Id="LB6Cxj4yYVENN2v474kdeU" Name="Input" Kind="InputPin" />
+                  <Pin Id="U6PI19JmrnvLqoZa0cjns4" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="HfbJUK3p9gnOlg1zXG73Os" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="572,301,63,19" Id="OvySGQKNQy7OZiqgoXvJFo">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Switch (Boolean)" />
+                    <FullNameCategoryReference ID="Control" />
+                  </p:NodeReference>
+                  <Pin Id="JnPBPsTvAw1NHKySQ8nkz4" Name="Condition" Kind="InputPin" />
+                  <Pin Id="D7cZxKdSCCGQaPcTnxfCHR" Name="Input" Kind="InputPin" />
+                  <Pin Id="OsSzzXaro1tQPDkucxhWgk" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="DVWtyaGHHJdOjJr6Dy1TQp" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="572,336,63,19" Id="KX5iJ8al32ZQUFxQfrOkYU">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="CltGjzSZdQ0Ld1x5UYIAf7" Name="Input" Kind="InputPin" />
+                  <Pin Id="AApkq63yDU9LGdT1J7kNYq" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="FQ9soXQ72AsMjGYDnzQZNr" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="754,310,63,19" Id="QInmX1t8CFBLkSJl2TbPoa">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Switch (Boolean)" />
+                    <FullNameCategoryReference ID="Control" />
+                  </p:NodeReference>
+                  <Pin Id="VA0u6YMWycsMeQ4HY0w6tM" Name="Condition" Kind="InputPin" />
+                  <Pin Id="IxnqdwnjJW0Ls5tsCBYoRA" Name="Input" Kind="InputPin" />
+                  <Pin Id="SjKyj1e3h7xNfx6Zf64pwv" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="RIFidNa7m64OpmGgeXo4ht" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="754,560,25,19" Id="RJzCsl5f7aYMqWtoyqW1Tl">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="PlxIYBw5xvRMQYBPQRYH5X" Name="Input" Kind="InputPin" />
+                  <Pin Id="HHvzXAYgGB3NdsVfpXOT7g" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="RoSfji7pCw4LmRT9LP1U51" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="833,95,125,26" Id="GITpzmgl1Q6OVcup58Yqbu">
+                  <p:NodeReference LastCategoryFullName="Editors.3D.CameraControls" LastDependency="VL.Cameras.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationNode" Name="Split" />
+                    <CategoryReference Kind="Category" Name="CameraControls" />
+                    <CategoryReference Kind="RecordType" Name="CameraControls" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" Name="3D" NeedsToBeDirectParent="true" />
+                    </CategoryReference>
+                  </p:NodeReference>
+                  <Pin Id="JPyvQALgvimL1upzjYcpp0" Name="Input" Kind="InputPin" />
+                  <Pin Id="FFR5lLD9TaPNeQGD1Rljxs" Name="Output" Kind="OutputPin" IsHidden="true" />
+                  <Pin Id="SfVEa11UT7pQGxVmfjhYDe" Name="Longitude Delta" Kind="OutputPin" />
+                  <Pin Id="C8ceyANdIPfNZJbRfJ1Ana" Name="Latitude Delta" Kind="OutputPin" />
+                  <Pin Id="F2KhdJGVWjeNC5BtNftG4T" Name="FOV Delta" Kind="OutputPin" />
+                  <Pin Id="FmfajwoW405NbxOXzO1FmT" Name="Interest Delta" Kind="OutputPin" />
+                  <Pin Id="K6nOLxgX67xOLEN5gjqHaN" Name="Distance Delta" Kind="OutputPin" />
+                  <Pin Id="HmbCVmhE4g2PvSMXAiugYp" Name="Reset" Kind="OutputPin" />
+                  <Pin Id="URxumeNwDVbNkaqEvDrlNu" Name="Idle" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="187,450,45,19" Id="PLye7obW3G2NcIMRnDawQC">
+                  <p:NodeReference LastCategoryFullName="Math.Ranges" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Clamp" />
+                    <CategoryReference Kind="Category" Name="Ranges" />
+                  </p:NodeReference>
+                  <Pin Id="Sr04pZCzGOqODrAdGwWRHA" Name="Input" Kind="InputPin" />
+                  <Pin Id="EpJHNtSw3bkMtYZ2rghTWC" Name="Minimum" Kind="InputPin" />
+                  <Pin Id="UH3vGnkgMC4Pn2y6Trp28V" Name="Maximum" Kind="InputPin" />
+                  <Pin Id="LzydBQFnpkOK9rtuYqNpIm" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="893,256,52,19" Id="FrgyT7ssHrDOmdH39w1XC6">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Control" />
+                    <Choice Kind="ProcessAppFlag" Name="FlipFlop" />
+                  </p:NodeReference>
+                  <Pin Id="KaxZD3rSdWFNeOfR4rQZTB" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="C1OTJnkHdUOQBQoCP6jBEq" Name="Set" Kind="InputPin" />
+                  <Pin Id="P9czqqxzijOM8P2BoHIZdW" Name="Reset" Kind="ApplyPin" />
+                  <Pin Id="Al0oy24zFS2O3XXXWLm8LB" Name="State" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="978,224,56,19" Id="PqOuDaerJZTO7RpjkErUvz">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="ProcessNode" Name="TogEdge" />
+                    <CategoryReference Kind="Category" Name="Control" />
+                  </p:NodeReference>
+                  <Pin Id="U63xRLNlGlxNTafN85c5Xo" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="KbBQkVN3OKvLCqEb2Klnu0" Name="Value" Kind="InputPin" />
+                  <Pin Id="LJuMLwGwc6xM8GlTuK7x4Y" Name="Up Edge" Kind="OutputPin" />
+                  <Pin Id="GzAQ6YZIPmEPfxPzRFSqbA" Name="Down Edge" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="893,223,65,19" Id="SwslzYuO20pLBHgy9bwR9m">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="OR" />
+                    <CategoryReference Kind="Category" Name="Boolean" />
+                  </p:NodeReference>
+                  <Pin Id="SXAhuamoOuKL7ZEEcZYZiN" Name="Input" Kind="InputPin" />
+                  <Pin Id="L0vcBVivtuqLyeZrsT3IZO" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="SL1xYBq50ZxOVAn8ZLHf43" Name="Input 3" Kind="InputPin" />
+                  <Pin Id="FyIcmE5wWgiNHjhKCiASqr" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="320,488,46,19" Id="QVqtPA5E0b4LO8DH2YmsBD">
+                  <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Vector (Join)" />
+                    <CategoryReference Kind="Category" Name="Vector3" />
+                  </p:NodeReference>
+                  <Pin Id="RXNS0rkNcmmNFOwE3gWY6F" Name="X" Kind="InputPin" />
+                  <Pin Id="Td8S7AEMxQIM6hxcH6hkej" Name="Y" Kind="InputPin" />
+                  <Pin Id="VFgHmNS3JihQZpix2X3ZCJ" Name="Z" Kind="InputPin" />
+                  <Pin Id="HelBVvKQ4ODL6Dxz1T9pfG" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="295,523,45,19" Id="IKUpHj5OGdjOlabeoKngmI">
+                  <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Rotate" />
+                    <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" Name="3D" NeedsToBeDirectParent="true" />
+                    </CategoryReference>
+                  </p:NodeReference>
+                  <Pin Id="R8ahLO3GOqcLq7df5jSkUW" Name="Input" Kind="InputPin" />
+                  <Pin Id="KfnZssswZKyMdiVvlkSnD1" Name="Rotation" Kind="InputPin" />
+                  <Pin Id="BxsJRioqV69OpE9IvOHHRp" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="187,800,67,19" Id="HeILYtsjQKWNEpRu9CFhqJ">
+                  <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Translation" />
+                    <CategoryReference Kind="Category" Name="Matrix" />
+                  </p:NodeReference>
+                  <Pin Id="HGnfuKHQJm7N9sAOx6Sus2" Name="Translation" Kind="InputPin" />
+                  <Pin Id="Oz5c7gMq2ZyO0FAtBvIfxN" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="187,770,46,19" Id="JeV6uYueNbfOLK56QqZxoY">
+                  <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Vector (Join)" />
+                    <CategoryReference Kind="Category" Name="Vector3" />
+                  </p:NodeReference>
+                  <Pin Id="BXoPCxDFIypPpaGGjBIisG" Name="X" Kind="InputPin" />
+                  <Pin Id="IJJdLuPfjmSNCSlzOGSxdw" Name="Y" Kind="InputPin" />
+                  <Pin Id="TpjTi7N3KF1LQNZbBrn5JR" Name="Z" Kind="InputPin" />
+                  <Pin Id="PiqxiwvDYdDMl21xW154XY" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="295,700,42,19" Id="FnRtaIhkj41MrqoSI5nEgQ">
+                  <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Invert" />
+                    <CategoryReference Kind="Category" Name="Matrix" />
+                  </p:NodeReference>
+                  <Pin Id="S89t2fuVYCMPSaITKpj5eT" Name="Input" Kind="InputPin" />
+                  <Pin Id="LNJdLtsCEL5OMPLEeViHeL" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="168,641,67,19" Id="HmJDjRNXL1TQQ207R8P1Vp">
+                  <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Translation" />
+                    <CategoryReference Kind="Category" Name="Matrix" />
+                  </p:NodeReference>
+                  <Pin Id="Lhg2nBNETLHMIpn16WsAGu" Name="Translation" Kind="InputPin" />
+                  <Pin Id="PKyzJK2l3j7LvB9ygeEySv" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="167,730,25,19" Id="VSWeTj30TwvP1xU91dGw9z">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="V7GQ22BGN7mPBacdImIBu8" Name="Input" Kind="InputPin" />
+                  <Pin Id="P9qgYCqwZdAM34PdpJ1PEV" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="JpDyJCaqKLjN7yTuAhsLFy" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="167,827,25,19" Id="E1D84MKO5TYPjue97WC34M">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="E6zcuhbyJr0QTD8FfvkN6H" Name="Input" Kind="InputPin" />
+                  <Pin Id="ArjhzdIwqUlMt8vYlVX8TF" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="SgXNmbXrzTxOz6Z5c8s0DQ" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="774,520,64,19" Id="SBlo1ULsO1lLjyp2kIlhBL">
+                  <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Transform" />
+                    <CategoryReference Kind="Category" Name="Vector3" />
+                  </p:NodeReference>
+                  <Pin Id="D9rlXP3wGHsLkm0JtK69cT" Name="Input" Kind="InputPin" />
+                  <Pin Id="TgA8NF73W7OL7691Fj8kyU" Name="Transform" Kind="InputPin" />
+                  <Pin Id="DCCXU8plHkRMqicwKNiHFs" Name="Apply" Kind="ApplyPin" />
+                  <Pin Id="AeUg18jJdAsNBPyppxhFpe" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="474,910,25,19" Id="F3s1AkhikHHOiOqQyv6AUr">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="Jdj6qglJ8gINaEnuCWUG38" Name="Input" Kind="InputPin" />
+                  <Pin Id="O2OwnJ9JMD3OzKZ94zmvlM" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Rdkr6mIXK2KQW09YKYsw38" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="561,1040,64,19" Id="BbmsXIQnA0hL1Uz5PgQuEK">
+                  <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="Transform" />
+                    <CategoryReference Kind="Category" Name="Vector3" />
+                  </p:NodeReference>
+                  <Pin Id="JhJkycdhjk0MlonIpqRQg2" Name="Input" Kind="InputPin" />
+                  <Pin Id="UrxqeN5lRC5PzWc9IJed56" Name="Transform" Kind="InputPin" />
+                  <Pin Id="Ay4CPyNuS2HNXV0peT35AY" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="200,243,25,19" Id="ITUaJTSKIzXNnY2oBg15ta">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="DaTlOhrpgSrLxFBtgJA1cD" Name="Input" Kind="InputPin" />
+                  <Pin Id="AG2UeW1IvPfQNtzznBWmiC" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="BQjTP6n7MOYPRhJKnjq8NM" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="653,610,25,19" Id="KHBMdLVKlYHOn4Hd7DdMg4">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="* (Scale)" />
+                  </p:NodeReference>
+                  <Pin Id="CoPT0QA51TbMihDXsfG3aY" Name="Input" Kind="InputPin" />
+                  <Pin Id="RQkGOtBKiM2MLQlK1a2JkM" Name="Scalar" Kind="InputPin" />
+                  <Pin Id="DZAn2k0HD0iMEL0FSlGq7U" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="352,176,25,19" Id="SGnXvMHU9b3MqCTYw8T3VS">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
+                    <Choice Kind="OperationNode" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="JeLzd8JDz42QEB2SZDXViO" Name="Input" Kind="InputPin" />
+                  <Pin Id="KSr3Ihxz9GNPeeTKltJrE3" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Mah7nJN12RIQPNs0ZieIZk" Name="Output" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="BEgxLZG0rsWPQ6t6WtSOck" Bounds="139,48" />
+                <ControlPoint Id="R0CHqzZsoLvOvxan8ggnGM" Bounds="231,48" />
+                <ControlPoint Id="HEFfDH3k2PhOTRqcLA09Kh" Bounds="332,48" />
+                <ControlPoint Id="Rp1C4Aj3kNhNWSeamnNMtv" Bounds="426,48" />
+                <ControlPoint Id="DYPlN6Yf8BUO4Ym0mMsmYU" Bounds="517,48" />
+                <ControlPoint Id="OK1HYqHlYOBM4DjpYnskLm" Bounds="628,48" />
+                <ControlPoint Id="LznrNZotKadMAwBMwhjfH4" Bounds="737,48" />
+                <ControlPoint Id="GMf8DsYt7UnOp7KXqJ8BtH" Bounds="835,50" />
+                <ControlPoint Id="MVMGiJmZcozNFuSVlmty2J" Bounds="476,1151" />
+                <ControlPoint Id="MLCGtNpN1PKNCwjVH7462y" Bounds="1092,48" />
+                <ControlPoint Id="DENDZV8cor8N9Svd2FbSwz" Bounds="1216,48" />
+                <Node Bounds="474,1090,245,19" Id="KBTJQorO8S4NoBQ5xXDtzU">
+                  <p:NodeReference LastCategoryFullName="Editors.3D" LastDependency="VL.Cameras.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="CameraState" />
+                    <CategoryReference Kind="Category" Name="3D" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" Name="Editors" NeedsToBeDirectParent="true" />
+                    </CategoryReference>
+                  </p:NodeReference>
+                  <Pin Id="LfXOkReJuIjOJPve1Vsfn6" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="IRpv0sMGKjXMPHUnqYvh34" Name="View Projection" Kind="InputPin" />
+                  <Pin Id="AgmVnUaIEQxPNioqzHViyl" Name="View" Kind="InputPin" />
+                  <Pin Id="QADv0RY4fsJNZzdbt9tv2Z" Name="Projection" Kind="InputPin" />
+                  <Pin Id="Ogw4z8T4JnGQY98rkc00SJ" Name="Inverse View" Kind="InputPin" />
+                  <Pin Id="IdCqCNHchzALFjeafRMbKA" Name="Position" Kind="InputPin" />
+                  <Pin Id="GSXUYQJhMzzMGZ4tU5ZYoR" Name="Interest" Kind="InputPin" />
+                  <Pin Id="MPhJX41mJwoO55lwP5kqlR" Name="FOV" Kind="InputPin" />
+                  <Pin Id="T25tIA0QYr9MXOneRjIOz9" Name="Distance" Kind="InputPin" />
+                  <Pin Id="UNsMV6baHJhO1ot6coPIBh" Name="Four Rooms" Kind="InputPin" />
+                  <Pin Id="R9TdFc1lcOTLRmBVLlFaNX" Name="Active Viewport" Kind="InputPin" />
+                  <Pin Id="MkoRKutRrhTP8BldQXjaqJ" Name="Renderer Hovered" Kind="InputPin" />
+                  <Pin Id="F2aHN5sbxEANg72152tLp0" Name="Idle" Kind="InputPin" />
+                  <Pin Id="Sadxel4kMeQMty43W2kxJZ" Name="Output" Kind="StateOutputPin" />
+                </Node>
+              </Canvas>
+              <Link Id="Fh2ik3NWPX1MnZ8yG3otHu" Ids="AEw5t3hK1ssNCfPfNLoP81,BEgxLZG0rsWPQ6t6WtSOck" IsHidden="true" />
+              <Link Id="GBVAAPkz0n7PZM4bTunTxx" Ids="LodXXqzJo0nLxeubkb6YPV,R0CHqzZsoLvOvxan8ggnGM" IsHidden="true" />
+              <Link Id="TKLAcurvux5MV9s8nXCH6x" Ids="OtjyHzJ0HL4NFqH9VKi4fg,HEFfDH3k2PhOTRqcLA09Kh" IsHidden="true" />
+              <Link Id="O5umY4Yn8phPGCO9XmEu3z" Ids="VkdzTBByVBaMeFGGrdvh2d,Rp1C4Aj3kNhNWSeamnNMtv" IsHidden="true" />
+              <Link Id="TxsN0lksk5pLaTcE6CgjDc" Ids="NuDvdlizrIDM5JzrDJQSde,DYPlN6Yf8BUO4Ym0mMsmYU" IsHidden="true" />
+              <Link Id="Lz82axRyFqkQREMomwpaWR" Ids="TdYlorf99ROQG8TfriVFFT,OK1HYqHlYOBM4DjpYnskLm" IsHidden="true" />
+              <Link Id="JnZNaxPYtWpOf3aA9bmhal" Ids="AH8HbJhIvfVPXkzytDTIMl,LznrNZotKadMAwBMwhjfH4" IsHidden="true" />
+              <Link Id="PU3RS7b4qtxM8zgZAX3sar" Ids="BktQmus7bVlLstCyN5GJJu,GMf8DsYt7UnOp7KXqJ8BtH" IsHidden="true" />
+              <Link Id="Ge6Q46q5Q3cP2SfdtklRpQ" Ids="MVMGiJmZcozNFuSVlmty2J,TDAHHkUeGZLLC8SuDXmsVi" IsHidden="true" />
+              <Link Id="KxUDLK1fLgFNRFX8JyA9Lp" Ids="S79p23S4NfMMvf77iEZDYP,RyWDkU3vx8EM3OtyIoziQ0" />
+              <Link Id="A1QnVuTOgU3LqfoZegZZCT" Ids="HSB1VzwCtmKM4PbtLBFNKD,C1apbYmoN8wNFtGeXsbDiD" />
+              <Link Id="T8gyNUUGs0rOrDfrlnnNYW" Ids="Fwi0a81HVw4MDYrjcOXnnV,U2fLs8MhJByM83kuobbn65" />
+              <Link Id="PREeyJaMXiSQJcGexDWOv7" Ids="HEFfDH3k2PhOTRqcLA09Kh,SDcJ8tAPDUBLU7rFTNcdxI" />
+              <Link Id="IpdbRjwRfg1NwKg7Yhw8yQ" Ids="Rp1C4Aj3kNhNWSeamnNMtv,OsSzzXaro1tQPDkucxhWgk" />
+              <Link Id="BAQHzq20W2dNl3XwtJPrty" Ids="KY0qycPe7BhNrqTa7LcZI8,LB6Cxj4yYVENN2v474kdeU" />
+              <Link Id="P5h52vr7iHdMg7vVDITjyU" Ids="DYPlN6Yf8BUO4Ym0mMsmYU,U6PI19JmrnvLqoZa0cjns4" />
+              <Link Id="EKzzy7mTZrZLBX2PNn8WAh" Ids="P8ULwvp0HO4M1JwjuP8z9E,D7cZxKdSCCGQaPcTnxfCHR" />
+              <Link Id="Hq911cJ82jMPaletEKoGZj" Ids="CxPKwY3Z4PgOYPi92rfcof,IxnqdwnjJW0Ls5tsCBYoRA" />
+              <Link Id="DYnvXecvZZUP0SQARSDl8E" Ids="OK1HYqHlYOBM4DjpYnskLm,Lny3ofNjL0uLGVzDHKHbh4" />
+              <Link Id="RqwvD5BvHi4NlBoiacCfKJ" Ids="LznrNZotKadMAwBMwhjfH4,VrZnIXZme0yQdtO1Mw8j0p" />
+              <Link Id="Oj09BXgxGovMuNuehRdLDe" Ids="PHCNya6RYleOnM0ivmln6a,Fyzmj3HnCl0OAH16DBdtZa" />
+              <Link Id="M355uRgBF7YPDXFF9vOlSM" Ids="OjRHNFyp4KHNwBuICfKxAH,GN9Lh0SEmBrQVsSTlMXa8f" />
+              <Link Id="Aj0kwj4O3XkPa3Dh1lzivH" Ids="FQ9soXQ72AsMjGYDnzQZNr,E9IbQZlzXspMSM3SgJfHf8" />
+              <Link Id="MaaenHpmjOZMNwrCWoij5W" Ids="RoSfji7pCw4LmRT9LP1U51,SxOvuJvrpNHNv9gbujZaYV" />
+              <Link Id="L1lPnRrJQnQNoqDo4pSoa7" Ids="OlTmI10yXkeOG8IuLMgl4j,BMNPYJ3ZtSqO1QJjJJz6Nk" />
+              <Link Id="P0EKfLLuOOPNCwn7wVBEKw" Ids="CExefdH1n83NkGVE6gOow3,Gg2T22NBAd3OsDp07of6xo" />
+              <Link Id="DoXrliouu5sLvSLd78par0" Ids="HfbJUK3p9gnOlg1zXG73Os,SjgZ2kaoP6iM6qf8Q15PEz" />
+              <Link Id="QOWTtHxhaIJO7ByHabO7fY" Ids="DVWtyaGHHJdOjJr6Dy1TQp,CltGjzSZdQ0Ld1x5UYIAf7" />
+              <Link Id="EG3zV9w6d7zPV3xrMCcJOv" Ids="LbwMulyRwAPL1vkxuBp69a,GWooRnoEFORLBLyyZMMVRP" />
+              <Link Id="CdFCDbefuqWNrpCeyeZPIf" Ids="ASxqgWKoUqmOrQK2JCmiHS,M5XkFOXvouFMuAU80fv9Vw" />
+              <Link Id="P03GGmIe2REOqMBSBE92Yi" Ids="GMf8DsYt7UnOp7KXqJ8BtH,JPyvQALgvimL1upzjYcpp0" />
+              <Link Id="AAAUZCmlL5OMaTvFctf4tC" Ids="F2KhdJGVWjeNC5BtNftG4T,T6GcCHmE5WpO2nHtav1YMP" />
+              <Link Id="EfJslYoQ5I5LHrWTJXYkJR" Ids="K6nOLxgX67xOLEN5gjqHaN,AApkq63yDU9LGdT1J7kNYq" />
+              <Link Id="RlI5g3YRSzRPstl8ZMzlsf" Ids="FnLrpxBdh5tP5kArbV3FT4,Sr04pZCzGOqODrAdGwWRHA" />
+              <Link Id="GV8lAGGouj9P29eZxQBxwn" Ids="LzydBQFnpkOK9rtuYqNpIm,FQW0X9kArh2Ph0qOJVVTXP" />
+              <Link Id="I4f6SU4BvxvLd6JIYEYU2m" Ids="URxumeNwDVbNkaqEvDrlNu,KbBQkVN3OKvLCqEb2Klnu0" />
+              <Link Id="FNRD2GaEfhHPNBS728yuNk" Ids="GzAQ6YZIPmEPfxPzRFSqbA,P9czqqxzijOM8P2BoHIZdW" />
+              <Link Id="Q0Ry4hu8GFfNFMAHJue5Ge" Ids="VzEPGgGOGuYLxXpQQhzzxQ,SXAhuamoOuKL7ZEEcZYZiN" />
+              <Link Id="K0eH52H3bhgPz7Sah5laPU" Ids="HmbCVmhE4g2PvSMXAiugYp,L0vcBVivtuqLyeZrsT3IZO" />
+              <Link Id="Va0jZdfqnkvN3KSpPuZ4e8" Ids="HelBVvKQ4ODL6Dxz1T9pfG,KfnZssswZKyMdiVvlkSnD1" />
+              <Link Id="MQRjfyCnnXwLedVQvpRIOo" Ids="PiqxiwvDYdDMl21xW154XY,HGnfuKHQJm7N9sAOx6Sus2" />
+              <Link Id="G7Adkov711LLHFWgk6jOwl" Ids="BxsJRioqV69OpE9IvOHHRp,S89t2fuVYCMPSaITKpj5eT" />
+              <Link Id="HptjHgsbi8POt5fa5XIYSZ" Ids="FQ9soXQ72AsMjGYDnzQZNr,TpjTi7N3KF1LQNZbBrn5JR" />
+              <Link Id="KNZUM1BylsmMqMvSxYX1YE" Ids="LzydBQFnpkOK9rtuYqNpIm,RXNS0rkNcmmNFOwE3gWY6F" />
+              <Link Id="LBBY2nH3zIsMT8SfgZKy5c" Ids="PKyzJK2l3j7LvB9ygeEySv,V7GQ22BGN7mPBacdImIBu8" />
+              <Link Id="Ql5uvAe1xrkLEVbsdPzYLN" Ids="LNJdLtsCEL5OMPLEeViHeL,P9qgYCqwZdAM34PdpJ1PEV" />
+              <Link Id="FaVEqAvF1lvPkKEBdzMvNQ" Ids="Oz5c7gMq2ZyO0FAtBvIfxN,ArjhzdIwqUlMt8vYlVX8TF" />
+              <Link Id="Nb4BBOo1VVLNkHiKTEYNjH" Ids="JpDyJCaqKLjN7yTuAhsLFy,E6zcuhbyJr0QTD8FfvkN6H" />
+              <Link Id="FOCFlbzfUBlOPP13x47fdw" Ids="PHCNya6RYleOnM0ivmln6a,Td8S7AEMxQIM6hxcH6hkej" />
+              <Link Id="BITU8q6RwfzO1JHTX5fpin" Ids="BxsJRioqV69OpE9IvOHHRp,TgA8NF73W7OL7691Fj8kyU" />
+              <Link Id="IuP4cvX508mPrWu65JRsLY" Ids="AeUg18jJdAsNBPyppxhFpe,HHvzXAYgGB3NdsVfpXOT7g" />
+              <Link Id="TtCLvjFrKVyNkQXXsfeBcE" Ids="RE6cgAwrwDlPfcKNrZHzbw,O2OwnJ9JMD3OzKZ94zmvlM" />
+              <Link Id="HpheE3D98g3Ml0MlMhayOl" Ids="SgXNmbXrzTxOz6Z5c8s0DQ,Jdj6qglJ8gINaEnuCWUG38" />
+              <Link Id="UvcdaVQWQiiMk7RuBj3LPH" Ids="SgXNmbXrzTxOz6Z5c8s0DQ,Jwf5CBpCJ4vMPPlNqBNOwb" />
+              <Link Id="E5V7SSck5QiOUoqRv5X8zY" Ids="Hx76whoHb4iPifVlWjMlKK,UrxqeN5lRC5PzWc9IJed56" />
+              <Link Id="FN0jBeFPvLPPB7UwL2JaBq" Ids="BEgxLZG0rsWPQ6t6WtSOck,SjKyj1e3h7xNfx6Zf64pwv" />
+              <Link Id="LW05c3tgC1AQEYj47ulxGr" Ids="EOkZHFS6VERM2lChpcs4ar,AG2UeW1IvPfQNtzznBWmiC" />
+              <Link Id="PDM3CdHun22LYe2aWek0yA" Ids="SfVEa11UT7pQGxVmfjhYDe,LNnHaLEnRu4PrqCxX5BCpm" />
+              <Link Id="U4kigDc0SNYOuMiEcWJ6MR" Ids="C8ceyANdIPfNZJbRfJ1Ana,DaTlOhrpgSrLxFBtgJA1cD" />
+              <Link Id="CLqFRRiMmV8MCJMadQt9LV" Ids="BQjTP6n7MOYPRhJKnjq8NM,IBUgZc9fzDjM6uTHBm7Dmk" />
+              <Link Id="L0bKgPCFyzOOKZI0bBdWfg" Ids="GEkcEzz5ib1NZNw9vGoXqA,EpJHNtSw3bkMtYZ2rghTWC" />
+              <Link Id="LkLI0iJRu4zPuAzis0b1si" Ids="VkGAjEg3mZeL3fu44jJSd4,UH3vGnkgMC4Pn2y6Trp28V" />
+              <Link Id="LaIWZmaJt83PE0OSVeoC7u" Ids="KJHANuDHgBSNVMB74qBAU8,RQkGOtBKiM2MLQlK1a2JkM" />
+              <Link Id="Su4xeGFyTYnNHjj6mi7Snh" Ids="RoSfji7pCw4LmRT9LP1U51,CoPT0QA51TbMihDXsfG3aY" />
+              <Link Id="HPb9T35iOI8NovPQzwibdG" Ids="DZAn2k0HD0iMEL0FSlGq7U,Lhg2nBNETLHMIpn16WsAGu" />
+              <Link Id="J45IdWbmg9DO0lyln0hSXr" Ids="RIFidNa7m64OpmGgeXo4ht,PlxIYBw5xvRMQYBPQRYH5X" />
+              <Link Id="R4xMryVU4dxLLQfTkdtLcS" Ids="R0CHqzZsoLvOvxan8ggnGM,JeLzd8JDz42QEB2SZDXViO" />
+              <Link Id="TBsONE5lmCSMvYT1xXqkEe" Ids="Mah7nJN12RIQPNs0ZieIZk,FibQP4pWwDvLZS1Ml6x5V7" />
+              <Link Id="EmPo1Q0EkaTNX7wUYILgwm" Ids="VAFORA7qoMfMUI355uFVko,KSr3Ihxz9GNPeeTKltJrE3" />
+              <Link Id="N2bDSmaVEYyLCOyuk3ZHd7" Ids="OY47lk5ULUbPngMp5b59V6,MLCGtNpN1PKNCwjVH7462y" IsHidden="true" />
+              <Link Id="IBjkVpcmH3wN45vAaRhLq2" Ids="DENDZV8cor8N9Svd2FbSwz,SL1xYBq50ZxOVAn8ZLHf43" />
+              <Link Id="OKPw18MBJTSOQwQddIUcGZ" Ids="FFH7DYPze2oN0Hof15YMQI,DENDZV8cor8N9Svd2FbSwz" IsHidden="true" />
+              <ProcessDefinition Id="PK0cIEJMzPtP4uyTm1aZZN">
+                <Fragment Id="T8dyX1GmVjqLThCbM6kcc6" Patch="V3j4eT9biK7M6LVbqxIGPs" Enabled="true" />
+                <Fragment Id="FLZ17mtpnGoOOadk09QFDa" Patch="F9wfUeHMjgnOCQyCSU25z9" Enabled="true" />
+              </ProcessDefinition>
+              <Link Id="KYPohUWcjGOPFhkHvginYK" Ids="OjRHNFyp4KHNwBuICfKxAH,JJRXiEWDcMgLs1oe0Pln4c" />
+              <Link Id="MDxTMAsKd5aLPrzUdoBxF7" Ids="Rdkr6mIXK2KQW09YKYsw38,IRpv0sMGKjXMPHUnqYvh34" />
+              <Link Id="NiEbqsD2WgxOJPUEegzVSd" Ids="SgXNmbXrzTxOz6Z5c8s0DQ,AgmVnUaIEQxPNioqzHViyl" />
+              <Link Id="AaoK4BIOJqKMOJ6j7UYzXr" Ids="RE6cgAwrwDlPfcKNrZHzbw,QADv0RY4fsJNZzdbt9tv2Z" />
+              <Link Id="MOnQX20hxFYLf3p5ykbKt0" Ids="Hx76whoHb4iPifVlWjMlKK,Ogw4z8T4JnGQY98rkc00SJ" />
+              <Link Id="OOijZ37ewggLGRJAwPlEmS" Ids="Ay4CPyNuS2HNXV0peT35AY,IdCqCNHchzALFjeafRMbKA" />
+              <Link Id="Fd8RjqLbpX7QUNJUZXO7qC" Ids="RoSfji7pCw4LmRT9LP1U51,GSXUYQJhMzzMGZ4tU5ZYoR" />
+              <Link Id="SVdJ3yjV8P0OiirDcZLBYP" Ids="OjRHNFyp4KHNwBuICfKxAH,MPhJX41mJwoO55lwP5kqlR" />
+              <Link Id="CMC8JJWY3wFNuoYZ5z2k2b" Ids="FQ9soXQ72AsMjGYDnzQZNr,T25tIA0QYr9MXOneRjIOz9" />
+              <Link Id="EU5g6opusIJPJ4VccscQzX" Ids="N663mhUnobyMTPLnHCXMDT,R9TdFc1lcOTLRmBVLlFaNX" />
+              <Link Id="GezbRizbPl4PDUETCR9tc8" Ids="MLCGtNpN1PKNCwjVH7462y,MkoRKutRrhTP8BldQXjaqJ" />
+              <Link Id="UOssf4ajIcSLmn7ejGmrzl" Ids="URxumeNwDVbNkaqEvDrlNu,F2aHN5sbxEANg72152tLp0" />
+              <Link Id="GVLglJwxrpTMwzfFJz9NAY" Ids="Sadxel4kMeQMty43W2kxJZ,MVMGiJmZcozNFuSVlmty2J" />
+              <Link Id="PlgWG1PYQg9NJM6VHo7fjx" Ids="FyIcmE5wWgiNHjhKCiASqr,C1OTJnkHdUOQBQoCP6jBEq" />
+              <Link Id="BmoWnYwydCjQVAbw2bMdFh" Ids="Al0oy24zFS2O3XXXWLm8LB,VA0u6YMWycsMeQ4HY0w6tM" />
+              <Link Id="HrQaXiPuBqYMoWDJY11aiw" Ids="Al0oy24zFS2O3XXXWLm8LB,JnPBPsTvAw1NHKySQ8nkz4" />
+              <Link Id="E0SX5lIXoDGPfAxxoHY7m4" Ids="Al0oy24zFS2O3XXXWLm8LB,FjQfklJBUW1Lva1jAkGGlN" />
+              <Link Id="EtHW2rpc2jfP5YaAnY3szv" Ids="Al0oy24zFS2O3XXXWLm8LB,HRQCfIfufCMMtCiA7h8hUH" />
+              <Link Id="RZzwiCHqIXwNShzgyQjRya" Ids="Al0oy24zFS2O3XXXWLm8LB,VnZNRY18JtLPSf6IGYv8aa" />
+              <Link Id="Vpq3YeK7TOLPBfPJ3h3ydY" Ids="FmfajwoW405NbxOXzO1FmT,D9rlXP3wGHsLkm0JtK69cT" />
             </Patch>
           </Node>
         </Canvas>

--- a/VL.Stride.Runtime/VL.Stride.Engine.vl
+++ b/VL.Stride.Runtime/VL.Stride.Engine.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="UFzEbZy7D3GNY8xnLUU17p" LanguageVersion="2025.7.0-0536-gd790066209" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="UFzEbZy7D3GNY8xnLUU17p" LanguageVersion="2025.7.0" Version="0.128">
   <NugetDependency Id="EKAeSpl0TUSO67sl9VuE19" Location="VL.CoreLib" Version="2021.4.12-1361-g53776bfdff" />
   <Patch Id="M3fVx2jjvOSLPGL4EJGFf9">
     <Canvas Id="JugVUmEZoitO7m1cCzT7W3" DefaultCategory="Stride" CanvasType="FullCategory">
@@ -543,9 +543,10 @@
                   <Pin Id="MWjSe7AfV46PyWqQdVXmku" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="650,483,45,19" Id="RD5pnNiAYyQNKW7CyEyQsr">
-                  <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                  <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
                     <Choice Kind="OperationNode" Name="* (Scale)" />
-                    <CategoryReference Kind="Category" Name="Vector2" />
                   </p:NodeReference>
                   <Pin Id="UChiWS5Q8lSLYuW4VRTfXt" Name="Input" Kind="InputPin" />
                   <Pin Id="CJP9238VqrDPMjaiVBN6Wh" Name="Scalar" Kind="InputPin" />
@@ -868,7 +869,7 @@
                     <p:precision p:Type="Int32">4</p:precision>
                   </p:ValueBoxSettings>
                 </Pad>
-                <Pad Id="IBD9ZCX8iXfPUjUSre0lQ6" Comment="Position" Bounds="533,844,35,28" ShowValueBox="true" isIOBox="true" />
+                <Pad Id="IBD9ZCX8iXfPUjUSre0lQ6" Comment="Position" Bounds="533,844,35,43" ShowValueBox="true" isIOBox="true" />
                 <Pad Id="AMccUVtQPuwO6dfE85RgcH" Comment="Position" Bounds="399,902,35,15" ShowValueBox="true" isIOBox="true" />
                 <Pad Id="KhAoGoohQtuMuVbrXKCao3" Comment="Position" Bounds="240,895,35,15" ShowValueBox="true" isIOBox="true" />
                 <Pad Id="FjO0RanfzYxNyrbwLSwBPC" Comment="Y" Bounds="600,993,35,15" ShowValueBox="true" isIOBox="true" />
@@ -981,6 +982,16 @@
                   <Pin Id="RtUNEkBqJ7SMXpThQV0ZFP" Name="Keyboard Device" Kind="OutputPin" />
                   <Pin Id="J7kVgYnTExENO0dN1RBKRa" Name="Pointer Device" Kind="OutputPin" />
                 </Node>
+                <Node Bounds="650,150,63,19" Id="F9ZdB40FQl7M4oDMwpCp6B">
+                  <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="4043309057" Name="Vector2" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="ToVector3" />
+                  </p:NodeReference>
+                  <Pin Id="LXVzhKBlFofMnbhcYJJH60" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="VIb8Ujnhlr9LImCTUTIIs3" Name="Z" Kind="InputPin" />
+                  <Pin Id="P7SH10XKCL0MSUVG9haFxu" Name="Result" Kind="OutputPin" />
+                </Node>
               </Canvas>
               <ProcessDefinition Id="IQoGwSxOq6tMSjk9ANhn2W">
                 <Fragment Id="DAZuYq8myl3PDY10hgziMd" Patch="GO2wzXnIEhvLDWZiR9Sl6h" Enabled="true" />
@@ -1053,7 +1064,6 @@
               <Link Id="K5Rxe0KR1YNPGlW1QmMUgT" Ids="LtcG6NPTFIHOMW9Z7d6uIc,FjO0RanfzYxNyrbwLSwBPC" />
               <Link Id="G8pw2ngbCvXPbz30Q6dqcw" Ids="Sg2LDA3dLu1QdXywRTPdPc,SnwqvAAaD68LjRqqYxH4P1" />
               <Link Id="IATdxypLgMsMfMhmHGIfDg" Ids="RfcPvjkXTvtOpsN4KBRN1v,Ibdw5lxQsvAQUouEybMJnP" />
-              <Link Id="PGFKfJw3HZ8OpyTj0btIis" Ids="RfcPvjkXTvtOpsN4KBRN1v,UChiWS5Q8lSLYuW4VRTfXt" />
               <Link Id="Cdcs16yt4beLl5B8QsDEiY" Ids="U75wPBnoN2xQLBqKDrx3Hy,Bz8QH0cCosVPeggL1vtgZ7" />
               <Link Id="QahaXmqIRK6Ni9Z2Dx2prW" Ids="Lvs54USmIZnLZQCnhjhGPo,A3dLNdV5nIQMjv7iMWu18J" />
               <Link Id="Sd9eQxBuRaxOJKOj1OKO8K" Ids="U75wPBnoN2xQLBqKDrx3Hy,FJQBMkORAMCOKnSt8hEc33" />
@@ -1079,6 +1089,8 @@
                 <Pin Id="RgkAxdhdvLWNYa6NiJ5EAt" Name="Window Input Source" Kind="InputPin" />
                 <Pin Id="DjyQph9s4opLJiWIbYdAd5" Name="Camera Controls" Kind="OutputPin" />
               </Patch>
+              <Link Id="J3kV86UMkniQHItGU5gGYq" Ids="RfcPvjkXTvtOpsN4KBRN1v,LXVzhKBlFofMnbhcYJJH60" />
+              <Link Id="TaHVDSQJKBqOp0AEnrXiBN" Ids="P7SH10XKCL0MSUVG9haFxu,UChiWS5Q8lSLYuW4VRTfXt" />
             </Patch>
           </Node>
           <!--
@@ -2059,6 +2071,1052 @@
               <Link Id="AIfcCJe25cNNnrGqtYU3bp" Ids="B453lVGzD28OmjDmZIcrr5,FbTB7EAmnU9MU7uhhzzysY" IsFeedback="true" />
               <Link Id="HLPfDSVJgseO2cZxcE3fnI" Ids="Cl1pnxxV35cMDk0wxk4BdN,FbTB7EAmnU9MU7uhhzzysY" />
               <Link Id="QUyDE6il2VjOZfrXyYiQQt" Ids="FbTB7EAmnU9MU7uhhzzysY,Ge1rwZapngxO72a5kpVjsQ" />
+            </Patch>
+          </Node>
+          <!--
+
+    ************************ WSADCameraControls ************************
+
+-->
+          <Node Name="WSADCameraControls" Bounds="320,420" Id="AkBA3F9wUSxQDNaUpBWhnO">
+            <p:NodeReference>
+              <Choice Kind="ContainerDefinition" Name="Process" />
+              <FullNameCategoryReference ID="Primitive" />
+            </p:NodeReference>
+            <Patch Id="CLMJeT89mmJQbgQWlVdTC8">
+              <Canvas Id="AxOIxlod9ptMTCyH1NlZGG">
+                <Pad Id="SbfnqnG3pouPHUww7uyvl0" Comment="FOV Delta Speed" Bounds="679,840,35,15" ShowValueBox="true" isIOBox="true" Value="0.01">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="PFhtGtmc5OfNHkTeAIPqYg" Comment="Time" Bounds="1131,873,32,18" ShowValueBox="true" isIOBox="true" Value="0.5">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="136,1098,1238,26" Id="EKpPZ66SLGRL9ghwSGYH6N">
+                  <p:NodeReference LastCategoryFullName="Editors.3D.CameraControls" LastDependency="VL.EditingFramework.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="RecordType" Name="CameraControls" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" Name="3D" NeedsToBeDirectParent="true" />
+                    </CategoryReference>
+                    <Choice Kind="OperationNode" Name="Combine" />
+                  </p:NodeReference>
+                  <Pin Id="PX157mJzA5ELtAUMl7nwG9" Name="Input" Kind="InputPin" />
+                  <Pin Id="LG9ic4bXYlAOXPwlFqk2IP" Name="Longitude Delta" Kind="InputPin" />
+                  <Pin Id="R5WEcOyOr0XMYIO3Fy6xAg" Name="Latitude Delta" Kind="InputPin" />
+                  <Pin Id="BCANFPxPu19OVuyYrBRllX" Name="FOV Delta" Kind="InputPin" />
+                  <Pin Id="S4t3CBoX3wiPgz4d3qmOCu" Name="Interest Delta" Kind="InputPin" />
+                  <Pin Id="HnBOJvTeoc9OlQDTD4VOFa" Name="Distance Delta" Kind="InputPin" />
+                  <Pin Id="JvdxJkSuxbLQdc8nWHFbnu" Name="Reset" Kind="InputPin" />
+                  <Pin Id="PKdh6QJqmadMp4KvYpC3NI" Name="Idle" Kind="InputPin" />
+                  <Pin Id="UdkX39gcNu2MGsGKWYNIuU" Name="Apply" Kind="ApplyPin" />
+                  <Pin Id="IdHHmaBP9EGPUJA5dfICIt" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1215,886,52,19" Id="BVLSV2EMazkLDtZIoRrrAa">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="OperationNode" Name="OR" />
+                    <CategoryReference Kind="Category" Name="Boolean" />
+                  </p:NodeReference>
+                  <Pin Id="Ed35c0TF7icNoooIz8i3BO" Name="Input" Kind="InputPin" />
+                  <Pin Id="FDCCVRhdzNIMUEkTtfu0UN" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="L5T4184PrLjPl9tY6EvnUU" Name="Input 3" Kind="InputPin" />
+                  <Pin Id="AHzxmCTkkYcOYBluf9h4fV" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1215,927,37,19" Id="Qj230eJAQf9MzEEksXvAZi">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="OperationNode" Name="NOT" />
+                    <CategoryReference Kind="Category" Name="Boolean" />
+                  </p:NodeReference>
+                  <Pin Id="BZ3VyM0pqApOOYhP7fw5ZC" Name="Input" Kind="InputPin" />
+                  <Pin Id="L9sIHx2PVOOMUXiTgpNuAY" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="812,906,45,19" Id="LNJvpyrb7xrNrvi1ELqtJb">
+                  <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationNode" Name="* (Scale)" />
+                  </p:NodeReference>
+                  <Pin Id="FFdovZzq7w3P03MfEtpTKU" Name="Input" Kind="InputPin" />
+                  <Pin Id="HS9I9i3sAViOSIAzxEfEoL" Name="Scalar" Kind="InputPin" />
+                  <Pin Id="Je6dwH58CxUOF7PMRM0UZu" Name="Scalar 2" Kind="InputPin" />
+                  <Pin Id="Q4MSsBlffv0ODC7AMjch14" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="658,906,45,19" Id="Ld1f1rZoaZkPtg0uijCHSJ">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="OperationNode" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="SQNS6J4Ecx7PgeVpslCMZN" Name="Input" Kind="InputPin" />
+                  <Pin Id="VFXjWX0ldKvPz5eRk5M9CN" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="F8AM8cwbTuuLnqLbudpNCD" Name="Input 3" Kind="InputPin" />
+                  <Pin Id="GfnBEeMFq60LHntCY4fJUR" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="967,906,45,19" Id="I9jZhSHuvpcNfaG6rmoCUD">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="OperationNode" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="HLjC8o8jXiPNFUi58c7m9L" Name="Input" Kind="InputPin" />
+                  <Pin Id="LQjXnncc9AbMITAvEmXmMn" Name="Input 2" Kind="InputPin" DefaultValue="0" />
+                  <Pin Id="Tjg6R10a8NnLfVVBlcCcMD" Name="Input 3" Kind="InputPin" />
+                  <Pin Id="ODp7U9oARTKPqEGlxx173T" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1061,926,66,19" Id="F1n5nS0uaAXN4e32TLoUMT">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ProcessNode" Name="TogEdge" />
+                    <CategoryReference Kind="Category" Name="Control" />
+                  </p:NodeReference>
+                  <Pin Id="CN8HcCQoofrNXcaxg8xm66" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="STuSKtZO1e0NQcpFVlb126" Name="Value" Kind="InputPin" />
+                  <Pin Id="LsnuFrGqdQJQFk0X9RAgcI" Name="Up Edge" Kind="OutputPin" />
+                  <Pin Id="Bi1FaPU8Se8OzQBZ7HIrvX" Name="Down Edge" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="351,926,45,19" Id="FbsBeOhTcZXMI3rGqGVxpO">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="OperationNode" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="SFmTGb3DloFLdDweFGzLSd" Name="Input" Kind="InputPin" />
+                  <Pin Id="VYNddToP6pNOc5yeQGeO4n" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="BaB3y69BGTRMBYANGEvbSI" Name="Input 3" Kind="InputPin" />
+                  <Pin Id="H4JuIPwczynM0HJCFQKGje" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1061,896,72,19" Id="MjWszVIDhA9NaO5PXUIRIN">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ProcessNode" Name="TimerFlop" />
+                    <CategoryReference Kind="Category" Name="Control" />
+                  </p:NodeReference>
+                  <Pin Id="SOpK2GfJ2MnMeYw6NW4F4I" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="VMLuQEzvIo5QPyiQ1ETzOX" Name="Clock" Kind="InputPin" />
+                  <Pin Id="QHI186DTvLGMhzQnOvNRU1" Name="Set" Kind="InputPin" />
+                  <Pin Id="NppDIv1wHDALJv44qSh4Zw" Name="Reset" Kind="InputPin" />
+                  <Pin Id="BMfRUW0h6SKQXIOQXXOYQ4" Name="Time" Kind="InputPin" />
+                  <Pin Id="KLcbiBUHTIgNRmdFs7rI6s" Name="Value" Kind="OutputPin" />
+                  <Pin Id="Io5Am16NnbNNt48JN8zCAs" Name="Running" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="288,716,68,19" Id="VPITbw5GPvELCXrfIOA4QK">
+                  <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="OperationNode" Name="Vector (Split)" />
+                    <CategoryReference Kind="Category" Name="Vector2" />
+                  </p:NodeReference>
+                  <Pin Id="TwIh3iMnLCeNWOcRJ4x9CN" Name="Input" Kind="InputPin" />
+                  <Pin Id="Egu6kwaHJfyPr7NI4HSSju" Name="X" Kind="OutputPin" />
+                  <Pin Id="Lxdy0CFKltGNBzxBqwD6nb" Name="Y" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="288,926,45,19" Id="NRjsP2kPtcAOyqap3TPLgA">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="OperationNode" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="UnQitK0mHpmPmfk7Tdus2r" Name="Input" Kind="InputPin" />
+                  <Pin Id="CGdjq6S2F50PV4XlAUPfjc" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Jzf4HNn2JRtPruv4nFx3G7" Name="Input 3" Kind="InputPin" />
+                  <Pin Id="CCczD9jYXHqN0p0hPgft35" Name="Output" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="DcvMjjEmhqnMpMZj3ZpWYj" Bounds="134,468" />
+                <ControlPoint Id="BLPb0NxZTcINk0X54ys7kl" Bounds="1371,996" />
+                <ControlPoint Id="Bk8Jv4lhvUkNVBTqhfqbdS" Bounds="138,1166,462,20" />
+                <Pad Id="HibBUhJqfuIPlImL0Xa6kL" Comment="Distance Delta Speed" Bounds="1009,817,35,15" ShowValueBox="true" isIOBox="true" Value="20">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="U53ivF6Yc9TMxdHMLDh1A1" Comment="Longitude / Latitude Delta Speed " Bounds="330,827,35,15" ShowValueBox="true" isIOBox="true" Value="1">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="OGenmaOqCD0LOCFu3ClkdX" Comment="Interest Delta Speed" Bounds="854,863,35,15" ShowValueBox="true" isIOBox="true">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="MRyyGSDpZoIPWr2d1MKAdd" Bounds="404,752,58,19" ShowValueBox="true" isIOBox="true" Value="SPEEDS">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                    <CategoryReference Kind="Category" Name="Primitive" />
+                  </p:TypeAnnotation>
+                  <p:ValueBoxSettings>
+                    <p:fontsize p:Type="Int32">9</p:fontsize>
+                    <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                  </p:ValueBoxSettings>
+                </Pad>
+                <Node Bounds="277,1056,145,19" Id="RxYO2DOtsQcLBma2mfJkWW">
+                  <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="Filter" />
+                  </p:NodeReference>
+                  <Pin Id="BM7pCzzufrDPgkvxBx1Qcd" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="TYIjhEETaEDLyHvTHt9U7Y" Name="Initial Position" Kind="InputPin" />
+                  <Pin Id="K0gLN3reK7uMr1kSxaPpAG" Name="Clock" Kind="InputPin" />
+                  <Pin Id="TzIOLNrUCtvPsgRrKbwIcm" Name="New Clock" Kind="InputPin" />
+                  <Pin Id="KHQ8tJeQpZdNvE7Z9JjVO3" Name="Goto Position" Kind="InputPin" />
+                  <Pin Id="Lu2QtuyE3DrQBfDxQ51Aaf" Name="Filter Time" Kind="InputPin" />
+                  <Pin Id="HoJCKcKtFc2PwQJQX6DpBp" Name="Transition" Kind="InputPin" DefaultValue="Expo">
+                    <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="TweenerTransition" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="Co0uTNYRwacObiqPyxjM4I" Name="Mode" Kind="InputPin" />
+                  <Pin Id="DNJKHQtXQdtLT4WOztjYxN" Name="Reset" Kind="ApplyPin" />
+                  <Pin Id="VhOIIBUVwETQb6Q6mmaJHs" Name="Position" Kind="OutputPin" />
+                  <Pin Id="K9iyVVk076XLGlO42SmyG5" Name="Progress" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="435,1056,145,19" Id="LGQjdwX3Lv7MoAWpxAr7W4">
+                  <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="Filter" />
+                  </p:NodeReference>
+                  <Pin Id="K5FdwGDweaTPMxiRrCaPii" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="EWkkqajqlfZO5NQnE4EzCX" Name="Initial Position" Kind="InputPin" />
+                  <Pin Id="TAbVgcxrKm3NRM92DtZTVY" Name="Clock" Kind="InputPin" />
+                  <Pin Id="Hz6cfanr7TqOD33jL3xDjA" Name="New Clock" Kind="InputPin" />
+                  <Pin Id="Sv8aaI3ANM4LjpNfzbq7qk" Name="Goto Position" Kind="InputPin" />
+                  <Pin Id="HFsRa513SjIPJViF7dmx6s" Name="Filter Time" Kind="InputPin" />
+                  <Pin Id="U6Muw3nUCiUPDFF2mQHfoh" Name="Transition" Kind="InputPin" DefaultValue="Expo">
+                    <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="TweenerTransition" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="EiVkaHsMVgsPKhCuJhCUqq" Name="Mode" Kind="InputPin" />
+                  <Pin Id="IJ0t3FB1A2lQE0MUirxYDn" Name="Reset" Kind="ApplyPin" />
+                  <Pin Id="QBM82I3EokeNtT5RXrxSXQ" Name="Position" Kind="OutputPin" />
+                  <Pin Id="VB6NHy3Pt8TN6gdFVCI3Hf" Name="Progress" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="598,1056,145,19" Id="RJLgLmH23wLOcMVfAiFagT">
+                  <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="Filter" />
+                  </p:NodeReference>
+                  <Pin Id="PeDg1t6yu1EPHm69I1CoOv" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="JXEegV9BcTTNv8wUKfhoQ0" Name="Initial Position" Kind="InputPin" />
+                  <Pin Id="LDT5M852SEoNfYdLVcZGBP" Name="Clock" Kind="InputPin" />
+                  <Pin Id="QW7bam4dHFfMnZXOXKc7OX" Name="New Clock" Kind="InputPin" />
+                  <Pin Id="B6FWf29AW6PME3LmyUPAQd" Name="Goto Position" Kind="InputPin" />
+                  <Pin Id="P7Paq3UMoZTOOJf44e0BKK" Name="Filter Time" Kind="InputPin" />
+                  <Pin Id="V1H9BkHZhosLR42lXt0vdi" Name="Transition" Kind="InputPin" DefaultValue="Expo">
+                    <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="TweenerTransition" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="DIGL6ObRH0qMqRmeQ5Ak1M" Name="Mode" Kind="InputPin" />
+                  <Pin Id="Pz5urlCLF29MrAgOhXtFSh" Name="Reset" Kind="ApplyPin" />
+                  <Pin Id="ClxjG2Lk5z9MbqkchqBD1R" Name="Position" Kind="OutputPin" />
+                  <Pin Id="Tsn6yYyNc4JPAqiKdxCQpu" Name="Progress" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="907,1056,145,19" Id="Ns37zLsDrprONEZR45g0HD">
+                  <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="Filter" />
+                  </p:NodeReference>
+                  <Pin Id="CFInyeQU39EOhc4Vas37i6" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="EAIfaMudAgQPUNEfFGCePv" Name="Initial Position" Kind="InputPin" />
+                  <Pin Id="Vda3Zl29GGhNcjgzGbzygu" Name="Clock" Kind="InputPin" />
+                  <Pin Id="Aw8tlLBZ9CvLK4pP5YoAlJ" Name="New Clock" Kind="InputPin" />
+                  <Pin Id="OQT4efZqAekO6i5kb8DH9V" Name="Goto Position" Kind="InputPin" />
+                  <Pin Id="AYfWmC2ZWtvQGeKjM1tMeK" Name="Filter Time" Kind="InputPin" />
+                  <Pin Id="TiRMmF7jNniNjtHZYCpN2a" Name="Transition" Kind="InputPin" DefaultValue="Expo">
+                    <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="TweenerTransition" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="JynwGAxP92lO93wkXhfQSe" Name="Mode" Kind="InputPin" />
+                  <Pin Id="B0Oxb6yNTJcLhMZ8ob25Mo" Name="Reset" Kind="ApplyPin" />
+                  <Pin Id="BZ0btSwBYvKLvVt2dvygBt" Name="Position" Kind="OutputPin" />
+                  <Pin Id="DJDKOCw606CQG2Ep8jWgqn" Name="Progress" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="752,1056,145,19" Id="INldY8rt6IuPcUGuI4RfSw">
+                  <p:NodeReference LastCategoryFullName="Animation" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="Filter" />
+                  </p:NodeReference>
+                  <Pin Id="INMFqgcIrAbL77xku6wBpK" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="OUQSBx9Eu0pOuWDlctpx44" Name="Initial Position" Kind="InputPin" />
+                  <Pin Id="DXEwGdcHAgYLvFdmJLiuMH" Name="Clock" Kind="InputPin" />
+                  <Pin Id="K9smLZwinZTNcVa85DjS2m" Name="New Clock" Kind="InputPin" />
+                  <Pin Id="DOf74aF95LKNssbHMJbohq" Name="Goto Position" Kind="InputPin" />
+                  <Pin Id="VvgH64cwvJjOz4kqtTFh8v" Name="Filter Time" Kind="InputPin" />
+                  <Pin Id="EBdk4h6rsF7Nvr0eW3H4C1" Name="Transition" Kind="InputPin" DefaultValue="Expo">
+                    <p:TypeAnnotation LastCategoryFullName="Math.Tweener" LastDependency="VL.CoreLib.vl">
+                      <Choice Kind="TypeFlag" Name="TweenerTransition" />
+                    </p:TypeAnnotation>
+                  </Pin>
+                  <Pin Id="O99Aj5l8O1xQduUeTDBvQx" Name="Mode" Kind="InputPin" />
+                  <Pin Id="UcTh1PLqBlPQUVUzMEKz3L" Name="Reset" Kind="ApplyPin" />
+                  <Pin Id="Kf9odCYpyNgLrUcqdnV5AT" Name="Position" Kind="OutputPin" />
+                  <Pin Id="Fd8wgj0eCy0L8NNWko0x37" Name="Progress" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="T58kw9kWQRBQLy5ahfJ8dB" Bounds="451,926" />
+                <Node Bounds="695,226,128,26" Id="MaP1O4JZ3r1Nkx7vTqiPx6">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsButtonDown" />
+                  </p:NodeReference>
+                  <Pin Id="Jfj8tvS4g1tLH5ieXWJzGo" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="KZv3Mjb2VokNG9lhH24MUa" Name="Mouse Button" Kind="InputPin" />
+                  <Pin Id="DLlPRc5gPyfLnW9LgGddB2" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="Dx9eJounU6CPfzkobZLdJZ" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="695,306,128,26" Id="UIy6cTD9nXsPJ5a3zFjJyc">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsButtonDown" />
+                  </p:NodeReference>
+                  <Pin Id="TviM2112IPCOkg7d9IwlX8" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="QnckOgVZ9mWPOnRbrt3swD" Name="Mouse Button" Kind="InputPin" />
+                  <Pin Id="MLh12DSPjagK98x7CkyRWl" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="BsC4v49fXeUPjWG958GSKI" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="695,396,138,26" Id="Pjduk6N4SuEOeVr4QWGesL">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsButtonDown" />
+                  </p:NodeReference>
+                  <Pin Id="Vjc5ApfniGvQZexmRiIzBZ" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="LwmGlmrCqB7NQKWZqI13OW" Name="Mouse Button" Kind="InputPin" />
+                  <Pin Id="I1X5OsTIJwWOEbzOz85vOG" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="Fu70tiuvgFvOb3Bd9lnxxs" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="QPciIjfPUUILMRfnM9WJuo" Comment="Mouse Button" Bounds="820,281,85,19" ShowValueBox="true" isIOBox="true" Value="Middle">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
+                    <Choice Kind="TypeFlag" Name="MouseButton" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="EfC2tXGFygiNs0NjtrwHPo" Comment="Mouse Button" Bounds="830,361,85,19" ShowValueBox="true" isIOBox="true" Value="Right">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
+                    <Choice Kind="TypeFlag" Name="MouseButton" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="435,426,112,26" Id="CIL99EIcnkMNJ08RovOMwS">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.InputManager" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="MouseWheelDelta" />
+                  </p:NodeReference>
+                  <Pin Id="EZdzNuAvqt1MVD0jPGucXP" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="DYJsxnzVfQHNcJSjZM0t8r" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="S9HOIa7KgXaO0o4encKFQx" Name="Mouse Wheel Delta" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1328,596,75,26" Id="HSWUDya5dB4NATfGU1u6YF">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="JqFaObWwNx1MGdcnsXcb9g" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="HMHW0gBJflVMOX7QFBLD79" Name="Key" Kind="InputPin" />
+                  <Pin Id="PBHFd0Wh2UFOpIB5dSfJLr" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="FbcZQiNdNtMMJnOalTbYD0" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1328,696,75,26" Id="NgnuiZlPabkQAR5NQ9luFk">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="Q4DsMny8pFVNii2Mp0VWYu" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="Bw3t9Q8NgLLMoS8FC34jXa" Name="Key" Kind="InputPin" />
+                  <Pin Id="SIOwa06mkJcQAALfk300yd" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="VJvckSU7vBmOGHUIZMkjI1" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1438,696,75,26" Id="HEWqdhsdzGULLWGlALYk3X">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="Gj94CTzidjTLTuITm7Ug06" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="CAYEgqHc6MvPdpfIcxpfb9" Name="Key" Kind="InputPin" />
+                  <Pin Id="JUSAjQt0msfQAhcMFA4mHa" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="L4aMfxvW4KhPfn6drCudrV" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1398,746,115,19" Id="UASRVLQygUgPe2t7z4Q4RA">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="OR" />
+                    <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="VSX7NRHuBXMMmysoVE91o6" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="M312X3rBRKKLaOOccQFFDk" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="HuthUuGlOdOOVFzKjJ0Ed5" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Pad Id="Q0TUxBcummFQIp3i0dwUT2" Comment="Item" Bounds="1510,676,127,19" ShowValueBox="true" isIOBox="true" Value="RightCtrl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="DfluqSVsQ9XPc961B95JBF" Comment="Item" Bounds="1400,656,127,19" ShowValueBox="true" isIOBox="true" Value="LeftCtrl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="SYQSAyceUajOOYDyOLyW6L" Comment="Item" Bounds="1400,580,127,19" ShowValueBox="true" isIOBox="true" Value="R">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="FjRbawjPkxbLdKUqbwHXo5" Comment="Mouse Wheel Delta" Bounds="544,485,29,18" ShowValueBox="true" isIOBox="true" />
+                <Pad Id="Qxj540M5vGgMJLoAkZa7Vy" Comment="Position" Bounds="897,1147,58,15" ShowValueBox="true" isIOBox="true">
+                  <p:ValueBoxSettings>
+                    <p:precision p:Type="Int32">4</p:precision>
+                  </p:ValueBoxSettings>
+                </Pad>
+                <Pad Id="OiibOUBPnbJLzsNdGNutA1" Comment="Position" Bounds="438,1147,35,15" ShowValueBox="true" isIOBox="true" />
+                <Pad Id="Csxb4SA4SjFL12DVvO7Q2A" Comment="Position" Bounds="279,1147,35,15" ShowValueBox="true" isIOBox="true" />
+                <Pad Id="M8W6izI3X5vMouSa0akS98" Comment="Y" Bounds="337,777,35,15" ShowValueBox="true" isIOBox="true" />
+                <Pad Id="VO43lp6Q6wALZaoWWkm0NF" Comment="" Bounds="290,974,35,15" ShowValueBox="true" isIOBox="true" />
+                <Node Bounds="288,496,98,19" Id="UDCiQcJ4UXSNVqdftBVHXG">
+                  <p:NodeReference LastCategoryFullName="Stride.Cameras.OrbitCameraControls" LastDependency="VL.Stride.Engine.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="ToVector2FlipX" />
+                  </p:NodeReference>
+                  <Pin Id="OUUOisCDZw3ODy9L07BDwm" Name="Input" Kind="InputPin" />
+                  <Pin Id="QqTwSThVzYhMiPzLul4e6v" Name="Output" Kind="OutputPin" />
+                </Node>
+                <!--
+
+    ************************ ToVector2FlipX (Internal) ************************
+
+-->
+                <Node Name="ToVector2FlipX (Internal)" Bounds="132,150,119,243" Id="Hb9a6I24BZSQZgyKJkT967">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+                    <Choice Kind="OperationDefinition" Name="Operation" />
+                  </p:NodeReference>
+                  <Patch Id="QbqaEjsm3NaMY0E3694dKr">
+                    <Node Bounds="144,247,44,26" Id="PU2vwHTLeaPM8du8MOIbit">
+                      <p:NodeReference LastCategoryFullName="Stride.Core.Mathematics.Vector2" LastDependency="Stride.Core.Mathematics.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="X" />
+                        <CategoryReference Kind="AssemblyCategory" Name="Vector2" NeedsToBeDirectParent="true">
+                          <p:OuterCategoryReference Kind="AssemblyCategory" Name="Mathematics" NeedsToBeDirectParent="true" />
+                        </CategoryReference>
+                      </p:NodeReference>
+                      <Pin Id="SLJFJnBrcFDLmvvS3eKFfX" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="HztGYzEXRgeO76ZSVZVN86" Name="Output" Kind="OutputPin" IsHidden="true" />
+                      <Pin Id="I3w03lHQ1WROBdWH018vlP" Name="X" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="195,246,44,26" Id="R7pqjXjJ3wJMOn5oS3x84F">
+                      <p:NodeReference LastCategoryFullName="Stride.Core.Mathematics.Vector2" LastDependency="Stride.Core.Mathematics.dll">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="Y" />
+                        <CategoryReference Kind="AssemblyCategory" Name="Vector2" NeedsToBeDirectParent="true">
+                          <p:OuterCategoryReference Kind="AssemblyCategory" Name="Mathematics" NeedsToBeDirectParent="true" />
+                        </CategoryReference>
+                      </p:NodeReference>
+                      <Pin Id="I3hm1mXBRdRQJILeBg5rPR" Name="Input" Kind="StateInputPin" />
+                      <Pin Id="LF9XH8EVz2KOo12fvGakqW" Name="Output" Kind="OutputPin" IsHidden="true" />
+                      <Pin Id="Ep7wsFWQjnFMTTWvjKRTQz" Name="Y" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="144,336,47,19" Id="A2pMU8IWW8XNO8a4TEv1Z6">
+                      <p:NodeReference LastCategoryFullName="2D.Vector2" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
+                        <CategoryReference Kind="Vector2Type" Name="Vector2" NeedsToBeDirectParent="true" />
+                      </p:NodeReference>
+                      <Pin Id="Czx0kPek2z6OGs8KOOrzGb" Name="X" Kind="InputPin" />
+                      <Pin Id="EdrYqURHNqINgKO8V9Yu0J" Name="Y" Kind="InputPin" />
+                      <Pin Id="BeG2hFLYAXqM96tUCRsKQW" Name="Output" Kind="StateOutputPin" />
+                    </Node>
+                    <Link Id="B9bsZUKWg6HOqLE7gIZ0fL" Ids="I3w03lHQ1WROBdWH018vlP,OO2RTfrpLNtLfXq1QQShGo" />
+                    <Link Id="HrjkyhIWMDnNzz6XkJocHC" Ids="Ep7wsFWQjnFMTTWvjKRTQz,EdrYqURHNqINgKO8V9Yu0J" />
+                    <ControlPoint Id="VkA3fkOpSn2MzUpUJYurMp" Bounds="146,376" />
+                    <Link Id="RqGzDZm7URyMpkfYguWxba" Ids="BeG2hFLYAXqM96tUCRsKQW,VkA3fkOpSn2MzUpUJYurMp" />
+                    <Link Id="B7bfXIvqTVKNpuBCdcLJ8L" Ids="VkA3fkOpSn2MzUpUJYurMp,E8kgKS1oRDBMFEHWoGoNpe" IsHidden="true" />
+                    <ControlPoint Id="J7LySIoEkLzNQBURUM0czd" Bounds="146,168" />
+                    <Link Id="G23V8ze4IpBLt1X8P1fwcV" Ids="J7LySIoEkLzNQBURUM0czd,SLJFJnBrcFDLmvvS3eKFfX" />
+                    <Link Id="Qp48Ow5HYMtLnF22hSMx9h" Ids="UBSJLIaGdlsNLbHsf1StSo,J7LySIoEkLzNQBURUM0czd" IsHidden="true" />
+                    <Link Id="VP7CjLv07C1N4gxHDwDvXy" Ids="J7LySIoEkLzNQBURUM0czd,I3hm1mXBRdRQJILeBg5rPR" />
+                    <Node Bounds="144,294,22,19" Id="TBox4AnVr7PNyiUkRZIDqj">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="- (Negate)" />
+                      </p:NodeReference>
+                      <Pin Id="OO2RTfrpLNtLfXq1QQShGo" Name="Input" Kind="InputPin" />
+                      <Pin Id="UPR6Vulah0uNaIuOEco6vI" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Link Id="GZaOdII5DJVNFTeFZCOofh" Ids="UPR6Vulah0uNaIuOEco6vI,Czx0kPek2z6OGs8KOOrzGb" />
+                    <Pin Id="UBSJLIaGdlsNLbHsf1StSo" Name="Input" Kind="InputPin" Bounds="331,1022" />
+                    <Pin Id="E8kgKS1oRDBMFEHWoGoNpe" Name="Output" Kind="OutputPin" Bounds="477,1174" />
+                  </Patch>
+                </Node>
+                <Node Bounds="435,259,85,19" Id="MFEYGAE61SvNzbm0OsPXd3">
+                  <p:NodeReference LastCategoryFullName="Stride.Input" LastDependency="VL.Stride.Input.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="InputManager" />
+                  </p:NodeReference>
+                  <Pin Id="NAPqaGT9Zs7M7pYg64AZ1f" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="PNiGnJnpMFYLv0LcwHjlEg" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="435,336,70,26" Id="LwNUxwZ7GqTNf6u0hxKpyv">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.InputManager" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="MouseDelta" />
+                  </p:NodeReference>
+                  <Pin Id="MgNeGLJZof6N7jXgTFvoXH" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="DzTOMoBfWklLHHQgYLmJmv" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="FHC7S9YdKZULl4q7Whnn4V" Name="Mouse Delta" Kind="OutputPin" />
+                </Node>
+                <Pad Id="TKSCSZ1ZWhKPoiBF15yjTb" Comment="Mouse Delta" Bounds="502,390,35,28" ShowValueBox="true" isIOBox="true" />
+                <ControlPoint Id="RaCWubsw2dPQQ8tXRFnAwy" Bounds="697,56" />
+                <Pad Id="JR8baz05UghPLrTWJzIysH" Comment="Position" Bounds="557,1147,35,15" ShowValueBox="true" isIOBox="true" />
+                <Node Bounds="695,146,339,19" Id="TAspvHgenynLraywPTAfFB">
+                  <p:NodeReference LastCategoryFullName="Stride.Input" LastDependency="VL.Stride.Input.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="GetDevices" />
+                    <CategoryReference Kind="Category" Name="Input" NeedsToBeDirectParent="true">
+                      <p:OuterCategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
+                    </CategoryReference>
+                  </p:NodeReference>
+                  <Pin Id="ORLKLnM8UiANV7d5a3kPee" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="La2ShL1FhwZPBJMmpP1mcm" Name="Input" Kind="InputPin" />
+                  <Pin Id="Nh4bPo1nVjoND3QBobPJme" Name="Mouse Device" Kind="OutputPin" />
+                  <Pin Id="O0hZSf9oB8EMPsSVKpZYmT" Name="Keyboard Device" Kind="OutputPin" />
+                  <Pin Id="UisJKwlR8rePcAKeG5JFLo" Name="Pointer Device" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1144,206,75,26" Id="IeD2hH9rFeSMjr8Dy160hK">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="B6ZiqcT4Xe7MnFHJvnrq4o" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="PZsWVCobiIqLcAAYEokcFm" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="HIFPHOOjyVjM6T46X4ykFj" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="MDrmToyf2W1MKLDfh1OKYn" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="HxiGBJqky9fPvjkg27liKt" Comment="Key" Bounds="1216,196,120,15" ShowValueBox="true" isIOBox="true" Value="W">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1166,246,75,26" Id="BgbF8rMxXbDNgPKojkxSLA">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="FbPQypWCz5FO8cZV0XH254" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="TZme2ME4LCdMRx2R3Vi6Y3" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="CDYeCJAD9Y7Pt3E92sqvbL" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="PBo6KvgThj6P3eYpKfINT6" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="MqPnjIzEVjlLVvktMwkNJW" Comment="Key" Bounds="1238,236,120,15" ShowValueBox="true" isIOBox="true" Value="S">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1196,286,75,26" Id="SFrVYoWmAKnM457qikx6NW">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="G5pz85QLFNCMT6v0pThi4v" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="T4GJm7XW1IrNkluTzGYvob" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="L7WbnSuSTPMMxV5K651Hch" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="IsLphb3etfuLG4pMZwRo9Z" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="TeInYXX5Bc0OkmslVPRUUu" Comment="Key" Bounds="1268,276,120,15" ShowValueBox="true" isIOBox="true" Value="A">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1224,326,75,26" Id="ORjyxC9wiBzLwKz796Vdlh">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="VcManS3Y5I9PgLkrEcz4UK" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="LPYFiWcYEUfOXwY6NRL3Qr" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="LC5Kv8PQedYLg8yrZzh1s3" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="DvebJB8Gcr3P9Md0OaTnNu" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="FpXfPWWyh7iOU9tCfoABMd" Comment="Key" Bounds="1296,316,120,15" ShowValueBox="true" isIOBox="true" Value="D">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1251,366,75,26" Id="Eysm0iQVKhRLVxqRHhQrQ7">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="QIIjkMx2HLeNhT91aGrZvd" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="P4J8F5D18G6O6roUGLTl8o" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="RhvCZiagZNWOaoBmvi3ymM" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="MrcEFUU7kKlNVBvE1Q9iJA" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="MoNHyZheQ10P1ZldEIzz44" Comment="Key" Bounds="1323,356,120,15" ShowValueBox="true" isIOBox="true" Value="Q">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1282,406,75,26" Id="VLE4DK2tLbXNmvpAuKOA7w">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="Sb0Z8vSsQ0NMitITvzrZdQ" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="TM1AWDfi5BqNn81symAeCu" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="KFgTm4ArygYMdqRkHuuhxo" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="OVTSBXIsAwtMGH3L8I2Ohk" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="UoRPWPRkg8tOoUSJyzva6u" Comment="Key" Bounds="1354,396,120,15" ShowValueBox="true" isIOBox="true" Value="E">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1088,546,132,19" Id="NbQFhtYohrBMugNxVY5yTR">
+                  <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="4043309058" Name="Vector3" />
+                    <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
+                  </p:NodeReference>
+                  <Pin Id="FsTfJyZHEioNPZKPJiBa0L" Name="X" Kind="InputPin" />
+                  <Pin Id="Oy8WTEJNiijLhJ1ejgUJN1" Name="Y" Kind="InputPin" />
+                  <Pin Id="A5PenvBOjNdPpe5QKLlfNl" Name="Z" Kind="InputPin" />
+                  <Pin Id="D8DkwqrxPhnOvd078A00T3" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="1088,466,22,19" Id="GgHJg1C5VPUP7R9caQN9N9">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="- (Negate)" />
+                  </p:NodeReference>
+                  <Pin Id="JN1Yq8hKESVMu4KhEa0yE4" Name="Input" Kind="InputPin" />
+                  <Pin Id="Kzi5gq5BSygLJfoOiICpRc" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Pad Id="HkSjGcoPOvtQcRvTk4SRw0" Comment="" Bounds="1090,446,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ImmutableTypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1088,496,25,19" Id="BgFy9TOvjvRNrvCtlszl0M">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="FxExx8wqCiXQA511rP9LXr" Name="Input" Kind="InputPin" />
+                  <Pin Id="NS2KUASLJicLnxrR2LXIDW" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="NqdPYVXRuDGOUfXaMfjozq" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1141,466,22,19" Id="R16K3GqxvKEPzndAH3kvDl">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="- (Negate)" />
+                  </p:NodeReference>
+                  <Pin Id="HdpUfD0JT8XOocn2acs3CD" Name="Input" Kind="InputPin" />
+                  <Pin Id="Ddt7WyPBgRDNQRaW7mpr84" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Pad Id="R7EmvI5tc5iMITUJ41HLO9" Comment="" Bounds="1143,446,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ImmutableTypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1141,496,25,19" Id="A1oedFHyOvwPrtopqKLycx">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="MDZTnBQms0IN9ASPFMpgMk" Name="Input" Kind="InputPin" />
+                  <Pin Id="PtBWU1JjlP1ONHGgR94Zut" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="BkyGSMK2KhwNUQJFt9B0B6" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Pad Id="ADyyY57LY4bNylbHVFAJ4O" Comment="" Bounds="740,1146,35,43" ShowValueBox="true" isIOBox="true" />
+                <Node Bounds="1194,466,22,19" Id="GLjCgiUP4P7Obl4ZJFrNb5">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="- (Negate)" />
+                  </p:NodeReference>
+                  <Pin Id="NQaGbNSy6G7MpJbcHANGzw" Name="Input" Kind="InputPin" />
+                  <Pin Id="HixzKdX9wTGOgdMfmgSiWq" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Pad Id="QZWthVpFVOMOqhf6PRe0NQ" Comment="" Bounds="1196,446,35,15" ShowValueBox="true" isIOBox="true">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ImmutableTypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1194,496,25,19" Id="ICN1WJkhH6CL0uIweFF1nx">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="DM9riYCcWblL0FBJzegVmt" Name="Input" Kind="InputPin" />
+                  <Pin Id="N8ty1m8XG8eQAwqRgNYi1M" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="PrAvyOCJue3OHvRrIpovgl" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1303,446,75,26" Id="TWVghXuFMxaPjATpe2qPUI">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="MjHaTGVka4hNMmVANbphns" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="GIPXjNTKlJBNf8LS5AWjRR" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="HXLrIfFyNXmLeVM9jaZum9" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="DrDToRwO6B1OWaf92unxRB" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="Eunl7FW7WPrN3oaSBLarjS" Comment="Key" Bounds="1375,436,120,15" ShowValueBox="true" isIOBox="true" Value="LeftShift">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1328,486,75,26" Id="SYvb8NHf1pmMEl23BwCEMM">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="Vu4pPlf8WmOOt1uEZMjIPb" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="HvqWyUtNeJ0LKR2EFbPDx6" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="KZI2ZZ73p8KP2NE1ESGczQ" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="E7no0wh9WoSOdYN4vtRqYL" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="ShP7hzyrvWROgkIu7O4ht9" Comment="Key" Bounds="1400,476,120,15" ShowValueBox="true" isIOBox="true" Value="RightShift">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1373,526,30,19" Id="POpftAmTHv6L67SAd0UsZu">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="OR" />
+                  </p:NodeReference>
+                  <Pin Id="EqoFTzBMlRBN0canPPkHy2" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="C8pbPahQsEIOhklz5K21p6" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="NtB7XjhiD3MOyUxzY7NSMZ" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="852,816,45,19" Id="Tb6yA4gkznlN9ByfQCZv0q">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Switch" />
+                  </p:NodeReference>
+                  <Pin Id="LVwovCphonpLn4R9w7AE8U" Name="Index" Kind="InputPin" />
+                  <Pin Id="F0Tt1E1q5VMLJ3VPRfU9a2" Name="Input" Kind="InputPin" />
+                  <Pin Id="QVFoQ2wJERbLdUCkVKYZFz" Name="Input 2" Kind="InputPin" DefaultValue="0.3" />
+                  <Pin Id="SGUsY7fQjTRL3ira7TE47F" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Pad Id="PsM4OXst2CAMJ34Pylw6Eb" Comment="" Bounds="874,786,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="ImmutableTypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Pad Id="MGhGfKf5L3hN6FYBNKS1OE" Comment="" Bounds="894,803,35,15" ShowValueBox="true" isIOBox="true" Value="0.4">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <ControlPoint Id="D7s6aEwG4bRPtediTtKboD" Bounds="815,675" />
+                <Node Bounds="868,436,45,19" Id="I49NwlQFRNgOMLkvouuBbT">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="OR" />
+                  </p:NodeReference>
+                  <Pin Id="IiVh43EpMrRNpswI3O75VM" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="JNL4QbLg7tgPMlWuLVUEC7" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="PXg0Sb02cNJP1fKyHQ9NR5" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="NFkGTStR5XINzt7HBuUr3A" Name="Input 3" Kind="InputPin" />
+                </Node>
+                <ControlPoint Id="FMpRe2Oj3q1PaeIVvxu4Pm" Bounds="874,740" />
+                <ControlPoint Id="HuPgBTh7vm5QUryYd1vN78" Bounds="894,760" />
+              </Canvas>
+              <ProcessDefinition Id="JfVa4ztlLUCQMNBMEG8DKv">
+                <Fragment Id="Ran8gJX74QRQWUS7qa4ohX" Patch="LQPKm5PtWAGOjOsQCTd6Yj" Enabled="true" />
+                <Fragment Id="IWAiiGKBZ4AN1KhSU8jnBk" Patch="JGRy32Nq5tCQAXAmj6ngTA" Enabled="true" />
+                <Fragment Id="OjYt3FUWHD9OVNx7YwoC0Y" Patch="Hb9a6I24BZSQZgyKJkT967" />
+              </ProcessDefinition>
+              <Patch Id="LQPKm5PtWAGOjOsQCTd6Yj" Name="Create" IsGeneric="true" />
+              <Patch Id="JGRy32Nq5tCQAXAmj6ngTA" Name="Update">
+                <Pin Id="PlnIF3o77eONdnoomz4lTj" Name="Camera Controls" Kind="InputPin" />
+                <Pin Id="Tra4UUQKcK0LJSRmNkDBid" Name="Filter Time" Kind="InputPin" DefaultValue="0.3">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="Szb343uB0YzLJUR3pImZyl" Name="Window Input Source" Kind="InputPin" />
+                <Pin Id="KbbMLEhIH6IQMxmU9imIKf" Name="Camera Controls" Kind="OutputPin" />
+                <Pin Id="EGeZKq7i414P4PnXEffc8C" Name="Speed" Kind="InputPin" />
+                <Pin Id="HsH0s03ESE6OScOdCc0E5O" Name="High Speed" Kind="InputPin" />
+                <Pin Id="LjBDa6v8t86OYSE23cmEOV" Name="Enable Controls" Kind="InputPin" />
+              </Patch>
+              <Link Id="AlNaVgfzCffLzOCUKkeUhC" Ids="PlnIF3o77eONdnoomz4lTj,DcvMjjEmhqnMpMZj3ZpWYj" IsHidden="true" />
+              <Link Id="PJWa58cNP5nLOAtwhhtppk" Ids="LjBDa6v8t86OYSE23cmEOV,BLPb0NxZTcINk0X54ys7kl" IsHidden="true" />
+              <Link Id="U0p9c7L9YUtQAhMM3yiYFs" Ids="Bk8Jv4lhvUkNVBTqhfqbdS,KbbMLEhIH6IQMxmU9imIKf" IsHidden="true" />
+              <Link Id="MxON3pKjEW5NZo8rlRks2i" Ids="IdHHmaBP9EGPUJA5dfICIt,Bk8Jv4lhvUkNVBTqhfqbdS" />
+              <Link Id="OLasVMHcbjNM8E7soKjebW" Ids="SbfnqnG3pouPHUww7uyvl0,VFXjWX0ldKvPz5eRk5M9CN" />
+              <Link Id="JccmZQViGCzPzwO8p4CuvT" Ids="PFhtGtmc5OfNHkTeAIPqYg,BMfRUW0h6SKQXIOQXXOYQ4" />
+              <Link Id="UDQQJ8t1WIYL749Z4KXoqV" Ids="AHzxmCTkkYcOYBluf9h4fV,BZ3VyM0pqApOOYhP7fw5ZC" />
+              <Link Id="OAwzdle1bCBL7ybZx0Gjzm" Ids="KLcbiBUHTIgNRmdFs7rI6s,STuSKtZO1e0NQcpFVlb126" />
+              <Link Id="C88TlD9LZxvPoP0KOJCJp2" Ids="Egu6kwaHJfyPr7NI4HSSju,UnQitK0mHpmPmfk7Tdus2r" />
+              <Link Id="C11lDUI07oSL4AjWyKHPj0" Ids="Lxdy0CFKltGNBzxBqwD6nb,SFmTGb3DloFLdDweFGzLSd" />
+              <Link Id="PSk2AiRtAxBNprOpWXoglP" Ids="Lxdy0CFKltGNBzxBqwD6nb,HLjC8o8jXiPNFUi58c7m9L" />
+              <Link Id="QNrHdwvfUFENYamAeY37P8" Ids="CCczD9jYXHqN0p0hPgft35,KHQ8tJeQpZdNvE7Z9JjVO3" />
+              <Link Id="PxL9wTP53NAOE4v9RiK4mN" Ids="H4JuIPwczynM0HJCFQKGje,Sv8aaI3ANM4LjpNfzbq7qk" />
+              <Link Id="MlFWvfrtTslMnynNzhZN0G" Ids="ODp7U9oARTKPqEGlxx173T,OQT4efZqAekO6i5kb8DH9V" />
+              <Link Id="ARsRz5fCRpVObyaPSKTNlH" Ids="GfnBEeMFq60LHntCY4fJUR,B6FWf29AW6PME3LmyUPAQd" />
+              <Link Id="MZ4orXH2PWdN7IjQUojplr" Ids="LsnuFrGqdQJQFk0X9RAgcI,JvdxJkSuxbLQdc8nWHFbnu" />
+              <Link Id="Eagx61P8tAnQTyuoBgslYG" Ids="BLPb0NxZTcINk0X54ys7kl,UdkX39gcNu2MGsGKWYNIuU" />
+              <Link Id="Mv4PEWJbnyeMn5f7aP7Gc2" Ids="L9sIHx2PVOOMUXiTgpNuAY,PKdh6QJqmadMp4KvYpC3NI" />
+              <Link Id="OByUehAd8H0NuRprEbbX7y" Ids="DcvMjjEmhqnMpMZj3ZpWYj,PX157mJzA5ELtAUMl7nwG9" />
+              <Link Id="Djv3opga0DqNWUyqpJp2sL" Ids="HibBUhJqfuIPlImL0Xa6kL,Tjg6R10a8NnLfVVBlcCcMD" />
+              <Link Id="DdWG2UQnOBPNXIeKu1QLiS" Ids="U53ivF6Yc9TMxdHMLDh1A1,Jzf4HNn2JRtPruv4nFx3G7" />
+              <Link Id="NC5DBs98vBaOZ2SYyAOPCQ" Ids="U53ivF6Yc9TMxdHMLDh1A1,BaB3y69BGTRMBYANGEvbSI" />
+              <Link Id="PCTeAINpOrfPemCpTvPjWM" Ids="OGenmaOqCD0LOCFu3ClkdX,Je6dwH58CxUOF7PMRM0UZu" />
+              <Link Id="J4Wj4LYIWvrM05jethFLBo" Ids="VhOIIBUVwETQb6Q6mmaJHs,LG9ic4bXYlAOXPwlFqk2IP" />
+              <Link Id="F3OodIR5RGEOdBig4jYaYB" Ids="QBM82I3EokeNtT5RXrxSXQ,R5WEcOyOr0XMYIO3Fy6xAg" />
+              <Link Id="FAamqlvVNgrL21epWBatI0" Ids="BZ0btSwBYvKLvVt2dvygBt,HnBOJvTeoc9OlQDTD4VOFa" />
+              <Link Id="D4GXLlVDHquNreQRXkAc5U" Ids="T58kw9kWQRBQLy5ahfJ8dB,Lu2QtuyE3DrQBfDxQ51Aaf" />
+              <Link Id="RDfISHKjc0YP3ORkpIg8SZ" Ids="Tra4UUQKcK0LJSRmNkDBid,T58kw9kWQRBQLy5ahfJ8dB" IsHidden="true" />
+              <Link Id="JPcjx9UashHOGK5Shwd5WU" Ids="T58kw9kWQRBQLy5ahfJ8dB,HFsRa513SjIPJViF7dmx6s" />
+              <Link Id="LMXM0ers2xCPeox1IGAcJn" Ids="T58kw9kWQRBQLy5ahfJ8dB,P7Paq3UMoZTOOJf44e0BKK" />
+              <Link Id="GIVJxtgJbc7NqkcwaDwCob" Ids="T58kw9kWQRBQLy5ahfJ8dB,VvgH64cwvJjOz4kqtTFh8v" />
+              <Link Id="PneekTuIKklNCEKFDYfwPu" Ids="T58kw9kWQRBQLy5ahfJ8dB,AYfWmC2ZWtvQGeKjM1tMeK" />
+              <Link Id="NmbKPRjr9P8MmJHHiIjQZb" Ids="LsnuFrGqdQJQFk0X9RAgcI,B0Oxb6yNTJcLhMZ8ob25Mo" />
+              <Link Id="AtCANd3jdorQdKBrJipnU7" Ids="LsnuFrGqdQJQFk0X9RAgcI,UcTh1PLqBlPQUVUzMEKz3L" />
+              <Link Id="QMAuzvjKcEaNeOPUPCNfQl" Ids="LsnuFrGqdQJQFk0X9RAgcI,Pz5urlCLF29MrAgOhXtFSh" />
+              <Link Id="PBXNtTgUP20ML3L6tNvxaZ" Ids="LsnuFrGqdQJQFk0X9RAgcI,IJ0t3FB1A2lQE0MUirxYDn" />
+              <Link Id="MvsEQjkKw1nMjkDuyDsQOZ" Ids="LsnuFrGqdQJQFk0X9RAgcI,DNJKHQtXQdtLT4WOztjYxN" />
+              <Link Id="C1UElI2mJsOLFc2eOYWm1X" Ids="DLlPRc5gPyfLnW9LgGddB2,TviM2112IPCOkg7d9IwlX8" />
+              <Link Id="EFeu2mLouqsND3NloxILla" Ids="MLh12DSPjagK98x7CkyRWl,Vjc5ApfniGvQZexmRiIzBZ" />
+              <Link Id="T4Zuqcbrce9NfFCxGbsMmk" Ids="QPciIjfPUUILMRfnM9WJuo,QnckOgVZ9mWPOnRbrt3swD" />
+              <Link Id="IfufQ1Gx8wDMwoYlgNVueW" Ids="EfC2tXGFygiNs0NjtrwHPo,LwmGlmrCqB7NQKWZqI13OW" />
+              <Link Id="FWtfugfG2fxLSoQc4PDcds" Ids="PBHFd0Wh2UFOpIB5dSfJLr,Q4DsMny8pFVNii2Mp0VWYu" />
+              <Link Id="OPCkrfHe3lQOuhY0qjvsSj" Ids="SIOwa06mkJcQAALfk300yd,Gj94CTzidjTLTuITm7Ug06" />
+              <Link Id="FT4McNtGGNDLArbfYFgzhO" Ids="VJvckSU7vBmOGHUIZMkjI1,VSX7NRHuBXMMmysoVE91o6" />
+              <Link Id="DpfFyF5sc2zLT4lrShEvZi" Ids="L4aMfxvW4KhPfn6drCudrV,M312X3rBRKKLaOOccQFFDk" />
+              <Link Id="Pa6mDPTfwi6QdJbTbPiQ4K" Ids="FbcZQiNdNtMMJnOalTbYD0,QHI186DTvLGMhzQnOvNRU1" />
+              <Link Id="PqCf3XXG0HlQWYJxiMubtU" Ids="HuthUuGlOdOOVFzKjJ0Ed5,F8AM8cwbTuuLnqLbudpNCD" />
+              <Link Id="UhXXH1xXf5EP9XDVDBA7hm" Ids="S9HOIa7KgXaO0o4encKFQx,FjRbawjPkxbLdKUqbwHXo5" />
+              <Link Id="IRNYFdODemzO6wiUGDTIg1" Ids="S9HOIa7KgXaO0o4encKFQx,SQNS6J4Ecx7PgeVpslCMZN" />
+              <Link Id="H1hXyMm6yOLMqOvxivbFGz" Ids="BZ0btSwBYvKLvVt2dvygBt,Qxj540M5vGgMJLoAkZa7Vy" />
+              <Link Id="Khf7y6AsKwiLU9jpjRj2Az" Ids="QBM82I3EokeNtT5RXrxSXQ,OiibOUBPnbJLzsNdGNutA1" />
+              <Link Id="EWI3eDvS8mcM46aDdmjka6" Ids="VhOIIBUVwETQb6Q6mmaJHs,Csxb4SA4SjFL12DVvO7Q2A" />
+              <Link Id="MV8TwaElDQGL6d0PDRUFrn" Ids="Lxdy0CFKltGNBzxBqwD6nb,M8W6izI3X5vMouSa0akS98" />
+              <Link Id="KaJIykOu8UVLyIhEU3CbKo" Ids="CCczD9jYXHqN0p0hPgft35,VO43lp6Q6wALZaoWWkm0NF" />
+              <Link Id="EpVtAhno2ovPmd8RPsVyb0" Ids="QqTwSThVzYhMiPzLul4e6v,TwIh3iMnLCeNWOcRJ4x9CN" />
+              <Link Id="FTMMwZm3SnMLEzLONeul5a" Ids="FHC7S9YdKZULl4q7Whnn4V,OUUOisCDZw3ODy9L07BDwm" />
+              <Link Id="QMjgzmYJLxKQaGCSFRqJtl" Ids="PNiGnJnpMFYLv0LcwHjlEg,MgNeGLJZof6N7jXgTFvoXH" />
+              <Link Id="Hoolukm6RMHLrx4JvqIJtY" Ids="FHC7S9YdKZULl4q7Whnn4V,TKSCSZ1ZWhKPoiBF15yjTb" />
+              <Link Id="ItESgQMOPsYQEfyu1aKlGu" Ids="Szb343uB0YzLJUR3pImZyl,RaCWubsw2dPQQ8tXRFnAwy" IsHidden="true" />
+              <Link Id="F3wdMEO5kO7LIunptuvFTW" Ids="DzTOMoBfWklLHHQgYLmJmv,EZdzNuAvqt1MVD0jPGucXP" />
+              <Link Id="Dkmp3TR0P8wMBGGovExxmx" Ids="Q0TUxBcummFQIp3i0dwUT2,CAYEgqHc6MvPdpfIcxpfb9" />
+              <Link Id="TVCUFrPdNJBLrEXKwfiBTd" Ids="DfluqSVsQ9XPc961B95JBF,Bw3t9Q8NgLLMoS8FC34jXa" />
+              <Link Id="G0Q3pRQgOrBPKbGMMlmW4w" Ids="SYQSAyceUajOOYDyOLyW6L,HMHW0gBJflVMOX7QFBLD79" />
+              <Link Id="R2IPTxobmYUPhmtApqYA4C" Ids="ClxjG2Lk5z9MbqkchqBD1R,BCANFPxPu19OVuyYrBRllX" />
+              <Link Id="HYwVLaiBxegLuqdhBj6oXF" Ids="ClxjG2Lk5z9MbqkchqBD1R,JR8baz05UghPLrTWJzIysH" />
+              <Link Id="OeRwXZGPx1gMQGHIH2atah" Ids="RaCWubsw2dPQQ8tXRFnAwy,La2ShL1FhwZPBJMmpP1mcm" />
+              <Link Id="ArfIMRBsbyuNuwDC3Y7gAO" Ids="Nh4bPo1nVjoND3QBobPJme,Jfj8tvS4g1tLH5ieXWJzGo" />
+              <Link Id="FsnY1HCqNo6PkGvd7cWdMh" Ids="Fu70tiuvgFvOb3Bd9lnxxs,CGdjq6S2F50PV4XlAUPfjc" />
+              <Link Id="QaxCqAa86VKQUClw08ipig" Ids="Fu70tiuvgFvOb3Bd9lnxxs,VYNddToP6pNOc5yeQGeO4n" />
+              <Link Id="CmqsjNwwy1PLGmX5IqAuWq" Ids="O0hZSf9oB8EMPsSVKpZYmT,B6ZiqcT4Xe7MnFHJvnrq4o" />
+              <Link Id="VqxIpJ1GDMQMpK17Lcxrve" Ids="HxiGBJqky9fPvjkg27liKt,PZsWVCobiIqLcAAYEokcFm" />
+              <Link Id="PDsuJSbCQipN611gvlVHe7" Ids="MqPnjIzEVjlLVvktMwkNJW,TZme2ME4LCdMRx2R3Vi6Y3" />
+              <Link Id="CDxpPmjmcFlM6SBM7X3aLz" Ids="HIFPHOOjyVjM6T46X4ykFj,FbPQypWCz5FO8cZV0XH254" />
+              <Link Id="TnXAXuh50A2MMDxW32l7E7" Ids="TeInYXX5Bc0OkmslVPRUUu,T4GJm7XW1IrNkluTzGYvob" />
+              <Link Id="Mga23K7OjMMPc6yEbf9Abh" Ids="FpXfPWWyh7iOU9tCfoABMd,LPYFiWcYEUfOXwY6NRL3Qr" />
+              <Link Id="D2cI3FD94MXNd8mLWNX0JH" Ids="CDYeCJAD9Y7Pt3E92sqvbL,G5pz85QLFNCMT6v0pThi4v" />
+              <Link Id="PAKsXgsP07qMnSd5RsqP8U" Ids="L7WbnSuSTPMMxV5K651Hch,VcManS3Y5I9PgLkrEcz4UK" />
+              <Link Id="H5NwKvN8qttQcTHqdx0yX1" Ids="MoNHyZheQ10P1ZldEIzz44,P4J8F5D18G6O6roUGLTl8o" />
+              <Link Id="SZvpdafZTuoO1PPrR1zEde" Ids="LC5Kv8PQedYLg8yrZzh1s3,QIIjkMx2HLeNhT91aGrZvd" />
+              <Link Id="DMFg7cfLwXdM8j1v979R3b" Ids="UoRPWPRkg8tOoUSJyzva6u,TM1AWDfi5BqNn81symAeCu" />
+              <Link Id="Mc6m9OgGOkNL8r4C3Aqpqb" Ids="RhvCZiagZNWOaoBmvi3ymM,Sb0Z8vSsQ0NMitITvzrZdQ" />
+              <Link Id="B05WaGFkAzFOdjwlsyV5LW" Ids="Fu70tiuvgFvOb3Bd9lnxxs,HS9I9i3sAViOSIAzxEfEoL" />
+              <Link Id="POBuave7VBMNXjSw6ReA1T" Ids="HkSjGcoPOvtQcRvTk4SRw0,JN1Yq8hKESVMu4KhEa0yE4" />
+              <Link Id="VLx1CffxUeoPRi6tLgNsOE" Ids="MDrmToyf2W1MKLDfh1OKYn,HkSjGcoPOvtQcRvTk4SRw0" />
+              <Link Id="GjnjglRndhcOccsaU8hf3S" Ids="PBo6KvgThj6P3eYpKfINT6,NS2KUASLJicLnxrR2LXIDW" />
+              <Link Id="UuSYy1ar7JLNtollAbWRIV" Ids="Kzi5gq5BSygLJfoOiICpRc,FxExx8wqCiXQA511rP9LXr" />
+              <Link Id="F0oB17xvujXO7bWQOUGoWM" Ids="NqdPYVXRuDGOUfXaMfjozq,A5PenvBOjNdPpe5QKLlfNl" />
+              <Link Id="E2ENVlwvn52Np6p5Xo9h8k" Ids="D8DkwqrxPhnOvd078A00T3,D7s6aEwG4bRPtediTtKboD,FFdovZzq7w3P03MfEtpTKU" />
+              <Link Id="Ft0uO5BtwrRPdctsrTyLoF" Ids="Q4MSsBlffv0ODC7AMjch14,DOf74aF95LKNssbHMJbohq" />
+              <Link Id="HN6i3rKDogFP80hJakEunJ" Ids="Kf9odCYpyNgLrUcqdnV5AT,S4t3CBoX3wiPgz4d3qmOCu" />
+              <Link Id="Rm7JSzQqNPoQaXeNcM7XxT" Ids="R7EmvI5tc5iMITUJ41HLO9,HdpUfD0JT8XOocn2acs3CD" />
+              <Link Id="CtHOY54Mu37Nuq1lYbBr7D" Ids="Ddt7WyPBgRDNQRaW7mpr84,MDZTnBQms0IN9ASPFMpgMk" />
+              <Link Id="TsA4JbaMHphMNUr8qIbPkz" Ids="DvebJB8Gcr3P9Md0OaTnNu,PtBWU1JjlP1ONHGgR94Zut" />
+              <Link Id="T58xrb31y5QMJgl7Q9BuLw" Ids="IsLphb3etfuLG4pMZwRo9Z,R7EmvI5tc5iMITUJ41HLO9" />
+              <Link Id="C06CFKxvKSoLIzpgDoMhAs" Ids="BkyGSMK2KhwNUQJFt9B0B6,FsTfJyZHEioNPZKPJiBa0L" />
+              <Link Id="CjMMjjFFGCyQKX6iIkzR50" Ids="Q4MSsBlffv0ODC7AMjch14,ADyyY57LY4bNylbHVFAJ4O" />
+              <Link Id="VWJQEnLhxLTQJPLqFXOWPP" Ids="QZWthVpFVOMOqhf6PRe0NQ,NQaGbNSy6G7MpJbcHANGzw" />
+              <Link Id="VZPs5nXBqszQM8a5kX7sf9" Ids="HixzKdX9wTGOgdMfmgSiWq,DM9riYCcWblL0FBJzegVmt" />
+              <Link Id="Kud6KuuJ7lRQZSuGt0l8VI" Ids="PrAvyOCJue3OHvRrIpovgl,Oy8WTEJNiijLhJ1ejgUJN1" />
+              <Link Id="RsOBnKQTvEmOZ4jBcjxumv" Ids="Eunl7FW7WPrN3oaSBLarjS,GIPXjNTKlJBNf8LS5AWjRR" />
+              <Link Id="JSDsQ34sPwkMIGoeTabPxD" Ids="KFgTm4ArygYMdqRkHuuhxo,MjHaTGVka4hNMmVANbphns" />
+              <Link Id="QRgYeLwSBC3OVVGU0oMHdH" Ids="ShP7hzyrvWROgkIu7O4ht9,HvqWyUtNeJ0LKR2EFbPDx6" />
+              <Link Id="HyykkDEsnNHPjzTfnImqQQ" Ids="HXLrIfFyNXmLeVM9jaZum9,Vu4pPlf8WmOOt1uEZMjIPb" />
+              <Link Id="BKsjSkF3HMvP6ZrnvP4hf6" Ids="E7no0wh9WoSOdYN4vtRqYL,C8pbPahQsEIOhklz5K21p6" />
+              <Link Id="Cr6jw0lKWpCNZUDlFA6t4H" Ids="DrDToRwO6B1OWaf92unxRB,EqoFTzBMlRBN0canPPkHy2" />
+              <Link Id="VxMFQYCYlTyO3OBkOgAj1T" Ids="NtB7XjhiD3MOyUxzY7NSMZ,LVwovCphonpLn4R9w7AE8U" />
+              <Link Id="FjemHcUQjHRMzLoX0fXXR3" Ids="PsM4OXst2CAMJ34Pylw6Eb,F0Tt1E1q5VMLJ3VPRfU9a2" />
+              <Link Id="Aq9iPjYF6jzNxh79TjOCmt" Ids="SGUsY7fQjTRL3ira7TE47F,OGenmaOqCD0LOCFu3ClkdX" />
+              <Link Id="RGFJjtgVeDfQY16bsdg9zk" Ids="MGhGfKf5L3hN6FYBNKS1OE,QVFoQ2wJERbLdUCkVKYZFz" />
+              <Link Id="O6Hbf3dTFXOMyW0gsroQwV" Ids="OVTSBXIsAwtMGH3L8I2Ohk,N8ty1m8XG8eQAwqRgNYi1M" />
+              <Link Id="BRJTzStTgz0QOFWQzq4blm" Ids="MrcEFUU7kKlNVBvE1Q9iJA,QZWthVpFVOMOqhf6PRe0NQ" />
+              <Link Id="TbPpSn2OHZJLehsQwYzeTS" Ids="KZI2ZZ73p8KP2NE1ESGczQ,JqFaObWwNx1MGdcnsXcb9g" />
+              <Link Id="Qf9aIgoQiPcLLOBK9zb1S6" Ids="Fu70tiuvgFvOb3Bd9lnxxs,IiVh43EpMrRNpswI3O75VM" />
+              <Link Id="K9W1ZrPnu7vP0V3bS22Dz8" Ids="BsC4v49fXeUPjWG958GSKI,JNL4QbLg7tgPMlWuLVUEC7" />
+              <Link Id="J6oR0ZgyvkHLhWWgnbtlVA" Ids="Dx9eJounU6CPfzkobZLdJZ,NFkGTStR5XINzt7HBuUr3A" />
+              <Link Id="MWMvb95sv4uO3CQtj9LRjG" Ids="PXg0Sb02cNJP1fKyHQ9NR5,Ed35c0TF7icNoooIz8i3BO" />
+              <Link Id="ExwUrxomqsJNQpsBa8GoH6" Ids="HuthUuGlOdOOVFzKjJ0Ed5,L5T4184PrLjPl9tY6EvnUU" />
+              <Link Id="AG2xMGhPJ06L2wE4CH70PT" Ids="FMpRe2Oj3q1PaeIVvxu4Pm,PsM4OXst2CAMJ34Pylw6Eb" />
+              <Link Id="RZQEWhclQxwMLwPEkk8muY" Ids="EGeZKq7i414P4PnXEffc8C,FMpRe2Oj3q1PaeIVvxu4Pm" IsHidden="true" />
+              <Link Id="H9KxGCiOOPDQJLENkGiJI7" Ids="HuPgBTh7vm5QUryYd1vN78,MGhGfKf5L3hN6FYBNKS1OE" />
+              <Link Id="L2cAPMXJJwYQNqAvsp59Hi" Ids="HsH0s03ESE6OScOdCc0E5O,HuPgBTh7vm5QUryYd1vN78" IsHidden="true" />
+            </Patch>
+          </Node>
+          <!--
+
+    ************************ WSADCameraLogic ************************
+
+-->
+          <Node Name="WSADCameraLogic" Bounds="320,380" Id="EiA4pThFhIEN5zffGSk4O1">
+            <p:NodeReference>
+              <Choice Kind="ContainerDefinition" Name="Process" />
+              <FullNameCategoryReference ID="Primitive" />
+            </p:NodeReference>
+            <Patch Id="BsYegPqMLTjNPFkw3NSP3V">
+              <Canvas Id="NKoY35B7T6QMxGSaqfRLWb" CanvasType="Group">
+                <Node Bounds="246,410,728,19" Id="JEANkFaTAaSQUceWeL02AE">
+                  <p:NodeReference LastCategoryFullName="Editors.3D" LastDependency="VL.EditingFramework.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="Editors.3D" />
+                    <Choice Kind="ProcessAppFlag" Name="WSADCamera" />
+                  </p:NodeReference>
+                  <Pin Id="QfODrjTgZgSMxX56q9oiE0" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="OdfL84GZvF5MsrZf0AsdPW" Name="Initial Interest" Kind="InputPin" />
+                  <Pin Id="CdLxf8qprWvL0RIO5vpl8E" Name="Initial Longitude" Kind="InputPin" />
+                  <Pin Id="Uh9o8PMvvlqOlUlvgHYzyT" Name="Initial Latitude" Kind="InputPin" />
+                  <Pin Id="AbquLXqPxnLN6f0inEqoKV" Name="Initial Distance" Kind="InputPin" />
+                  <Pin Id="MUwuYYNcHRlPPjDyQmSAq9" Name="Initial FOV" Kind="InputPin" />
+                  <Pin Id="AJ4lWVDGnqbMo5pnzE4o9h" Name="Near Plane" Kind="InputPin" />
+                  <Pin Id="Rl4hlJYwvUQPJ3JrEjFufc" Name="Far Plane" Kind="InputPin" />
+                  <Pin Id="Ta5pul5d5zAM0C2hnX9Uy8" Name="CameraControls3d" Kind="InputPin" />
+                  <Pin Id="NAQfYIDrN8zQXsIfa50S8y" Name="Renderer Hovered" Kind="InputPin" />
+                  <Pin Id="TtCGItcWCDQMdeo1XMZbH5" Name="Reset" Kind="InputPin" />
+                  <Pin Id="KML2yIGV7p4LBEqRt1kiLC" Name="CameraState3d" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="THzaPV0Uap3NNmxvpR6UFc" Bounds="248,130" />
+                <ControlPoint Id="RXYsXtswtl4LDWeupRGLvz" Bounds="328,130" />
+                <ControlPoint Id="UZ4X1n4NXctPu2qbd38t5y" Bounds="408,130" />
+                <ControlPoint Id="TcQpS72knwsOvU6JEhdIz6" Bounds="489,130" />
+                <ControlPoint Id="V0vssFhJVDNMyY8IfftiIA" Bounds="569,130" />
+                <ControlPoint Id="UfLvIuKRF7TPNZXe7yiDP0" Bounds="650,130" />
+                <ControlPoint Id="Ojcn4wh92b5OT3zBUH5ybG" Bounds="730,130" />
+                <ControlPoint Id="RJbGQ7I0Jv6LzOQ9IcTp1q" Bounds="248,470,474,0" />
+                <Node Bounds="969,360,57,19" Id="JJNcmI6H9aZPoHPqpSxj5O">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="OnOpen" />
+                  </p:NodeReference>
+                  <Pin Id="Nu043jut9GDOl41Gbpbsnb" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="JahQwuyMGVbOVGK7aNm1tm" Name="Simulate" Kind="InputPin" />
+                  <Pin Id="Rf03553zmyVQSpjGuZOcUT" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="808,300,124,19" Id="M9XPGommpF7NAisqAXO2oB">
+                  <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.Engine.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Cameras" NeedsToBeDirectParent="true" />
+                    <Choice Kind="ProcessAppFlag" Name="WSADCameraControls" />
+                  </p:NodeReference>
+                  <Pin Id="ILqzWEQ4fxtMrZ3taVDrJG" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="BV8jrkKu0SxNC7VWyYt7MM" Name="Camera Controls" Kind="InputPin" />
+                  <Pin Id="Iel0X8z1VVTLhkXQWDvZ4X" Name="Filter Time" Kind="InputPin" />
+                  <Pin Id="OqSxOw51wTNNhVV6S7d4mv" Name="Window Input Source" Kind="InputPin" />
+                  <Pin Id="Tc7GJUyxEkvMNatTMMF4d4" Name="Camera Controls" Kind="OutputPin" />
+                  <Pin Id="DjjndRj4xWmOBk1Co0475C" Name="Speed" Kind="InputPin" />
+                  <Pin Id="L8XJZCagnGbNAV5IvtULUd" Name="High Speed" Kind="InputPin" />
+                  <Pin Id="I2pz6cRj9kdNo1M9JSbMLz" Name="Enable Controls" Kind="InputPin" DefaultValue="True" />
+                </Node>
+                <Node Bounds="808,220,74,26" Id="KEKppRUvCgbMNYDwjs0I3N">
+                  <p:NodeReference LastCategoryFullName="Editors.3D.CameraControls" LastDependency="VL.EditingFramework.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Editors" />
+                    <CategoryReference Kind="Category" Name="3D" />
+                    <CategoryReference Kind="RecordType" Name="CameraControls" />
+                    <Choice Kind="OperationCallFlag" Name="Create" />
+                  </p:NodeReference>
+                  <Pin Id="E95QBwJBVZXOQmA7VlCfwE" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="QJFZehqwzjJNeC7UupB4mS" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Pad Id="VGAzuF9Zf3SOmPVmUNEUA7" SlotId="AQLc0oHwOyILPms3MDA2pq" Bounds="810,270" />
+                <ControlPoint Id="MZWa3ZD9ynsLSWNg4DPGcG" Bounds="858,130" />
+                <ControlPoint Id="Dvv7tnkVzxmPYJEC17mACQ" Bounds="1051,250" />
+                <Node Bounds="927,223,65,19" Id="Ce0YNqXhY7wLCJeRYAcP8K">
+                  <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsAssigned" />
+                  </p:NodeReference>
+                  <Pin Id="BMUiABJWL7LMK24sU6F3fw" Name="X" Kind="InputPin" />
+                  <Pin Id="D9N0mg4swMGPnB6mzB3RjG" Name="Result" Kind="OutputPin" />
+                  <Pin Id="V6AkfUIvXTMQFBpaxdF72h" Name="Not Assigned" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="TcYvcm1Pt5yPQEW0AzHZN9" Bounds="881,150" />
+                <ControlPoint Id="DKyzWCvXpr6NliKywMWP8E" Bounds="905,170" />
+              </Canvas>
+              <Link Id="JHp5qOXHmyYMxYoUSlwROJ" Ids="M2yeuhTJZCdMPlNmN11rUd,THzaPV0Uap3NNmxvpR6UFc" IsHidden="true" />
+              <Link Id="DSp2VX1bK60QVqOUE4Ox1n" Ids="S8zZt8bf53dPROawVvygrt,RXYsXtswtl4LDWeupRGLvz" IsHidden="true" />
+              <Link Id="D05wq0LDzHzMA3KdA5IK5a" Ids="TQESyHrC6loNaXtNgVYqv3,UZ4X1n4NXctPu2qbd38t5y" IsHidden="true" />
+              <Link Id="S8msWwpJJR6MOkpPLg3yQ7" Ids="IWNzpPAJSvENTWQ0VcsM6Q,TcQpS72knwsOvU6JEhdIz6" IsHidden="true" />
+              <Link Id="D68uWudYAObMqLP8tLzkYG" Ids="BY11GooWjtCLrvsXVuRqlB,V0vssFhJVDNMyY8IfftiIA" IsHidden="true" />
+              <Link Id="RRTaaf9PZxMMrcvyZVVN09" Ids="IpHG84Udca6L2oRALPoo9O,UfLvIuKRF7TPNZXe7yiDP0" IsHidden="true" />
+              <Link Id="F7pkBJnOQ5TOqWjq1FhUJT" Ids="UqWN1qSunzoPCC1o9WnEYE,Ojcn4wh92b5OT3zBUH5ybG" IsHidden="true" />
+              <Link Id="VEckx69tpZnOEP88iGfJbl" Ids="RJbGQ7I0Jv6LzOQ9IcTp1q,UKaudK9VyRzOF1hfaxVKeT" IsHidden="true" />
+              <Link Id="Txhs4lX4HhWNINIoERAQh0" Ids="THzaPV0Uap3NNmxvpR6UFc,OdfL84GZvF5MsrZf0AsdPW" />
+              <Link Id="UuhlKZHgsmWL27fwgFRDIM" Ids="RXYsXtswtl4LDWeupRGLvz,CdLxf8qprWvL0RIO5vpl8E" />
+              <Link Id="OofsSDxIIZxQMSNgaSxMCJ" Ids="UZ4X1n4NXctPu2qbd38t5y,Uh9o8PMvvlqOlUlvgHYzyT" />
+              <Link Id="TttFcZmQzRdL3eApPCOofF" Ids="TcQpS72knwsOvU6JEhdIz6,AbquLXqPxnLN6f0inEqoKV" />
+              <Link Id="CLATv79u0yWLRk4raTuz4i" Ids="V0vssFhJVDNMyY8IfftiIA,MUwuYYNcHRlPPjDyQmSAq9" />
+              <Link Id="J7JM3YS1gvwM2Y9Zj5MrV9" Ids="UfLvIuKRF7TPNZXe7yiDP0,AJ4lWVDGnqbMo5pnzE4o9h" />
+              <Link Id="Ihp1zznyixlNXG4594gb9S" Ids="Ojcn4wh92b5OT3zBUH5ybG,Rl4hlJYwvUQPJ3JrEjFufc" />
+              <Link Id="L01Y0ib3UBJMhfjWqtPSlR" Ids="KML2yIGV7p4LBEqRt1kiLC,RJbGQ7I0Jv6LzOQ9IcTp1q" />
+              <ProcessDefinition Id="PhWk2Jilm28Lwa8eHRIo6k">
+                <Fragment Id="IJwQx9tLnCUNZbaDU0cOU0" Patch="Sz0eqcFQqPtOUOx6cHmqgK" Enabled="true" />
+                <Fragment Id="KrgVjZaQfOrMOIkcESitOP" Patch="QN5SOQrhgCdNYKXHlpD6Iz" Enabled="true" />
+              </ProcessDefinition>
+              <Link Id="ROahnvP59X7PXvSqKH5Lja" Ids="Rf03553zmyVQSpjGuZOcUT,TtCGItcWCDQMdeo1XMZbH5" />
+              <Slot Id="AQLc0oHwOyILPms3MDA2pq" Name="Output" />
+              <Link Id="SRSjdBgAipsMxn00fqpSGP" Ids="QJFZehqwzjJNeC7UupB4mS,VGAzuF9Zf3SOmPVmUNEUA7" />
+              <Link Id="TUQtSbf8TNkLwVjgmiYhqN" Ids="VGAzuF9Zf3SOmPVmUNEUA7,BV8jrkKu0SxNC7VWyYt7MM" />
+              <Link Id="Bdpj0lpBhzDM5vvUVUmuEI" Ids="MZWa3ZD9ynsLSWNg4DPGcG,OqSxOw51wTNNhVV6S7d4mv" />
+              <Link Id="UQO2HsFOGldPgmdIizSjCh" Ids="AihyV56sPLILhMgn2r8nrB,MZWa3ZD9ynsLSWNg4DPGcG" IsHidden="true" />
+              <Link Id="PFnNbFZ4AohQaumeEWRByW" Ids="Dvv7tnkVzxmPYJEC17mACQ,JahQwuyMGVbOVGK7aNm1tm" />
+              <Link Id="EGBiFybu3p6PhzTle1oBZt" Ids="AcZ7j6rYuO0LOnIzEzncWU,Dvv7tnkVzxmPYJEC17mACQ" IsHidden="true" />
+              <Patch Id="Sz0eqcFQqPtOUOx6cHmqgK" Name="Create" ParticipatingElements="KEKppRUvCgbMNYDwjs0I3N" IsGeneric="true" />
+              <Patch Id="QN5SOQrhgCdNYKXHlpD6Iz" Name="Update" IsGeneric="true">
+                <Pin Id="M2yeuhTJZCdMPlNmN11rUd" Name="Initial Interest" Kind="InputPin" />
+                <Pin Id="S8zZt8bf53dPROawVvygrt" Name="Initial Yaw" Kind="InputPin" />
+                <Pin Id="TQESyHrC6loNaXtNgVYqv3" Name="Initial Pitch" Kind="InputPin" DefaultValue="-0.05">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="IWNzpPAJSvENTWQ0VcsM6Q" Name="Initial Distance" Kind="InputPin" DefaultValue="0">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="BY11GooWjtCLrvsXVuRqlB" Name="Initial FOV" Kind="InputPin" DefaultValue="0.2">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="IpHG84Udca6L2oRALPoo9O" Name="Near Plane" Kind="InputPin" />
+                <Pin Id="UqWN1qSunzoPCC1o9WnEYE" Name="Far Plane" Kind="InputPin" />
+                <Pin Id="AihyV56sPLILhMgn2r8nrB" Name="Window Inout Source" Kind="InputPin" Bounds="1082,143" />
+                <Pin Id="JNnRIf9w8OBMAOuCqgqK0R" Name="Speed" Kind="InputPin" Visibility="Optional" />
+                <Pin Id="TwUt0gy1OVIOeriQjHXgzU" Name="High Speed" Kind="InputPin" Visibility="Optional" />
+                <Pin Id="AcZ7j6rYuO0LOnIzEzncWU" Name="Reset" Kind="InputPin" Bounds="995,309" />
+                <Pin Id="UKaudK9VyRzOF1hfaxVKeT" Name="CameraState3d" Kind="OutputPin" />
+              </Patch>
+              <Link Id="VTfQIcO2UmbPykZucZpAET" Ids="Tc7GJUyxEkvMNatTMMF4d4,Ta5pul5d5zAM0C2hnX9Uy8" />
+              <Link Id="HYHPWvW0JBCLxKfDM9aXtO" Ids="MZWa3ZD9ynsLSWNg4DPGcG,BMUiABJWL7LMK24sU6F3fw" />
+              <Link Id="PdPF1OID0UwPuvVzdZNLPY" Ids="D9N0mg4swMGPnB6mzB3RjG,I2pz6cRj9kdNo1M9JSbMLz" />
+              <Link Id="U8hnaJtw0FYL1zMEF1vnxd" Ids="TcYvcm1Pt5yPQEW0AzHZN9,DjjndRj4xWmOBk1Co0475C" />
+              <Link Id="P6YhVKT4wvuP1YOfrnMT0D" Ids="JNnRIf9w8OBMAOuCqgqK0R,TcYvcm1Pt5yPQEW0AzHZN9" IsHidden="true" />
+              <Link Id="AVLcjdOc2V0QOVVHzfisJu" Ids="DKyzWCvXpr6NliKywMWP8E,L8XJZCagnGbNAV5IvtULUd" />
+              <Link Id="LudDXZuWKwzNXR0LELwKVa" Ids="TwUt0gy1OVIOeriQjHXgzU,DKyzWCvXpr6NliKywMWP8E" IsHidden="true" />
             </Patch>
           </Node>
         </Canvas>
@@ -3734,6 +4792,348 @@
             <Patch Id="Q8gNvUsTME8MbBe4nZMr9T" Name="InverseView">
               <Pin Id="CBPl6b2XExMMqW5irB3yh1" Name="Inverse View" Kind="OutputPin" />
             </Patch>
+          </Patch>
+        </Node>
+        <!--
+
+    ************************ WSADCamera ************************
+
+-->
+        <Node Name="WSADCamera" Bounds="302,250" Id="SLMwOVkkynSOjl2ITqsMo8">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
+            <Choice Kind="ContainerDefinition" Name="Process" />
+          </p:NodeReference>
+          <Patch Id="SXHj101b7G1PXIhLEFqYYU">
+            <Canvas Id="HOA5YQmfY1vMfQhLbRNYsR" CanvasType="Group">
+              <Node Bounds="208,311,307,19" Id="KrLFabutIIgP8L9CYRO9S2">
+                <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.Engine.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="WSADCameraLogic" />
+                </p:NodeReference>
+                <Pin Id="DOJemkdKQnSLq2t0kUgQ81" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="PWjN0Us3DZtO6lddpz0EhT" Name="Initial Interest" Kind="InputPin" />
+                <Pin Id="V5kjKm65MUnLpk9f7fQHCt" Name="Initial Yaw" Kind="InputPin" />
+                <Pin Id="S0tWcenGP79PnhEbZPr28S" Name="Initial Pitch" Kind="InputPin" />
+                <Pin Id="P9rWe2wFjZcMuuRhVtxgF5" Name="Initial Distance" Kind="InputPin" />
+                <Pin Id="DBOCApqZdU9P0WrnE5kT1e" Name="Initial FOV" Kind="InputPin" />
+                <Pin Id="QxwDCUavlteOQwWJqsO1FP" Name="Near Plane" Kind="InputPin" DefaultValue="0.05">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="QjMraLtmXLHMAlkaCcP2TV" Name="Far Plane" Kind="InputPin" />
+                <Pin Id="VegKeueAolON6qSQNoAa1t" Name="Window Inout Source" Kind="InputPin" />
+                <Pin Id="FwxSw5CANMyOOfQZBDUnyZ" Name="Speed" Kind="InputPin" />
+                <Pin Id="BiljkCTt2WVNkMnNfnFh2X" Name="High Speed" Kind="InputPin" />
+                <Pin Id="Ar5CiU0CGYwLWLoJ5pMBJ8" Name="Reset" Kind="InputPin" />
+                <Pin Id="BbechrXOMAwQIyXUR9NYUP" Name="CameraState3d" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="DdocyXckJcXPRx6jvOhxmF" Bounds="520,961" />
+              <ControlPoint Id="MDWoOAnAlXqP3CWI7iYSu8" Bounds="310,401" />
+              <ControlPoint Id="Q0OcNN8YmMlLV2kplM08Ft" Bounds="391,221" />
+              <ControlPoint Id="AmoYWxD1rjyLNjE027wUzV" Bounds="361,201" />
+              <ControlPoint Id="HwCZaf35s01OfBa4wAzw8S" Bounds="331,181" />
+              <ControlPoint Id="Ke7ieEPfV1eLV7cDWRX6a0" Bounds="210,179" />
+              <ControlPoint Id="QTgfpPlSyUMQHlO3GJGBlu" Bounds="270,231" />
+              <ControlPoint Id="TgpOT343X2xOsat9iaVlUE" Bounds="301,251" />
+              <ControlPoint Id="L33ZbczbMUnPakufiHqgdz" Bounds="240,201" />
+              <ControlPoint Id="NQpRzqbbUljNkRAbb4NhEU" Bounds="474,619" />
+              <ControlPoint Id="RhPvowggyc6Lg2mQBg9Qmx" Bounds="290,421" />
+              <ControlPoint Id="OHg3QihbodpMN4WF19LXF0" Bounds="455,120" />
+              <ControlPoint Id="DFSflxHAMhCNXv4d0stcf8" Bounds="475,141" />
+              <Node Bounds="178,105,158,19" Id="JZEk013NeOELscyKnS2mSx">
+                <p:NodeReference LastCategoryFullName="Stride.Input" LastDependency="VL.Stride.Engine.Nodes">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessNode" Name="CameraInputSourceComponent" />
+                </p:NodeReference>
+                <Pin Id="BWNCkdI8lbrMqDSiC4iUKm" Name="Enabled" Kind="InputPin" />
+                <Pin Id="A4fqFcNkliILg3tXcHF8Ub" Name="Output" Kind="OutputPin" />
+                <Pin Id="LslVWYCa56PPF9BDzwGCTC" Name="Input Source" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="453,161,45,19" Id="NdYOktQsUgwOWVTqWIs9f5">
+                <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
+                  <Choice Kind="OperationCallFlag" Name="Switch (Boolean)" />
+                </p:NodeReference>
+                <Pin Id="MscHCs6drF0LspwBpZywDm" Name="Condition" Kind="InputPin" />
+                <Pin Id="JjMV2gj9RbvMYGFfAY2JZX" Name="Input" Kind="InputPin" />
+                <Pin Id="OE3k92dHD6aL1Jjxz7jFOy" Name="Input 2" Kind="InputPin" />
+                <Pin Id="VJGjY8ZLTkNPDCQaxdOW7W" Name="Output" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="I0U5DQmAXR0L9O3gxoSpY1" Bounds="149,895" />
+              <ControlPoint Id="JyvvxJSGOvkPSf57bdbFIm" Bounds="180,85" />
+              <ControlPoint Id="BFuY9UZ96cxPtxS6jk35TL" Bounds="375,669" />
+              <ControlPoint Id="VHZp3N6SkpbL8ZwPHjiq5W" Bounds="335,633" />
+              <Node Bounds="208,352,245,26" Id="B98CLkjyCBnOjW6TOxngUT">
+                <p:NodeReference LastCategoryFullName="Editors.3D.CameraState" LastDependency="VL.EditingFramework.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="Split" />
+                  <FullNameCategoryReference ID="Editors.3D.CameraState" />
+                </p:NodeReference>
+                <Pin Id="HMKbhPUReuXQcL8JBcasXn" Name="Input" Kind="StateInputPin" />
+                <Pin Id="RtUtrLoshb7NzU31NBmEgC" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="KzVFG4XOfsfLD7e8UbbhXQ" Name="View Projection" Kind="OutputPin" />
+                <Pin Id="IVrB9gQRMUJL5YnmIGWjID" Name="View" Kind="OutputPin" />
+                <Pin Id="QEFNTdwWqLKLwWYxRyJoe6" Name="Projection" Kind="OutputPin" />
+                <Pin Id="GeXwKRE5KNcQaS1IzX4xiV" Name="Inverse View" Kind="OutputPin" />
+                <Pin Id="KSEJt2ZgfNXQK1K8DZkrMd" Name="Position" Kind="OutputPin" />
+                <Pin Id="MXTRnxNrh2VMqyNQsI3Wov" Name="Interest" Kind="OutputPin" />
+                <Pin Id="DXzTEewFrxoOAmSSZ1RKNM" Name="FOV" Kind="OutputPin" />
+                <Pin Id="RoCfXBI8ybwNNcFrMVpT8c" Name="Distance" Kind="OutputPin" />
+                <Pin Id="D1NglemYDdbPkuF7KDnkYb" Name="Four Rooms" Kind="OutputPin" />
+                <Pin Id="E7gARLfO2hNPrRRjgMdkVa" Name="Active Viewport" Kind="OutputPin" />
+                <Pin Id="TJtxwygDlGXPHpm2WaCUSp" Name="Renderer Hovered" Kind="OutputPin" />
+                <Pin Id="QLMM3OLAHziLAuWGVTiw1A" Name="Idle" Kind="OutputPin" />
+              </Node>
+              <Node Bounds="438,837,85,26" Id="SH8gjhtfbqyQaoy7aJE8xx">
+                <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="Update" />
+                  <CategoryReference Kind="ClassType" Name="CameraComponent" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="GJ7tOHeAjXuPZpfyo5e0C7" Name="Input" Kind="StateInputPin" />
+                <Pin Id="OslJ6c9OBOCQAaCGJqE2Us" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="PdLM8I1c110LyibCFJIkh1" Name="Apply" Kind="InputPin" />
+              </Node>
+              <Node Bounds="438,885,85,26" Id="TTxYsW82kF0OxeRx6CIYBk">
+                <p:NodeReference LastCategoryFullName="Stride.API.Cameras.CameraComponent" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="Frustum" />
+                  <CategoryReference Kind="ClassType" Name="CameraComponent" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="H8irNmbROH4MN31UfYLxBy" Name="Input" Kind="StateInputPin" />
+                <Pin Id="MzcsDC6J08VMaAUXH88fvG" Name="Output" Kind="StateOutputPin" />
+                <Pin Id="M00BQNxEls0N3ZM1Z1zpQc" Name="Frustum" Kind="OutputPin" />
+              </Node>
+              <Pad Id="SAeYI3LEgtxL2cx5EdSaT9" Bounds="532,714,500,129" ShowValueBox="true" isIOBox="true" Value="we have two modes:&#xD;&#xA;&#xD;&#xA;Using Custom Aspect Ratio&#xD;&#xA;* We know the Aspect Ratio. It is independant from the RenderWindows. We can Update the Camera here and know the Frustum.&#xD;&#xA;&#xD;&#xA;Using Aspect Ratio of DownStream RenderWindow&#xD;&#xA;* We don't know the Aspect Ratio. It's depending on the RenderWindow downstream. It will call the Update of the CameraCompnent. So we should not. We want to output the Frustum that depends on the Downstream RenderWindow.">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+                <p:ValueBoxSettings>
+                  <p:fontsize p:Type="Int32">9</p:fontsize>
+                  <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+                </p:ValueBoxSettings>
+              </Pad>
+              <Node Bounds="148,714,345,19" Id="UqwoaTmphjQLgEAWSlnuEL">
+                <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.Engine.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="ProcessAppFlag" Name="Camera" />
+                  <CategoryReference Kind="Category" Name="Cameras" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="F2othxw117xLN8fHq30HxA" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="Q9WtVN9F0PRNxLeqB7uuNv" Name="Initial Name" Kind="InputPin" />
+                <Pin Id="EGz1kvRFe7EPNdLgghQL02" Name="Base Components" Kind="InputPin" />
+                <Pin Id="LsfpXSuc5q8OZIjSLe6TDl" Name="Transformation" Kind="InputPin" />
+                <Pin Id="NHHHKJUWBDePCWf2cGdw49" Name="Components" Kind="InputPin" />
+                <Pin Id="BqcHLhxW1xaNDoddq65fOa" Name="Children" Kind="InputPin" />
+                <Pin Id="C16myibd9Z8L4DjH7kOQNQ" Name="Name" Kind="InputPin" />
+                <Pin Id="Q3Zl23PIXM2N62sVkHXXg4" Name="Use Custom View Matrix" Kind="InputPin" DefaultValue="True" />
+                <Pin Id="OLKl8tEjb5MQMyOPZCxTXy" Name="View Matrix" Kind="InputPin" />
+                <Pin Id="L9V6GruFkxEQG91i4gTTHQ" Name="Projection" Kind="InputPin" />
+                <Pin Id="JbomhpjOSlnM2rpefaqXnb" Name="Vertical Field Of View" Kind="InputPin" />
+                <Pin Id="NeOFHHIgkYJNPjBFWPTaJX" Name="Orthographic Size" Kind="InputPin" />
+                <Pin Id="Tvd2cATDMAFPhuITSfukyj" Name="Use Custom Aspect Ratio" Kind="InputPin" />
+                <Pin Id="MmN1vIA190fOkBY6bqx1k8" Name="Aspect Ratio" Kind="InputPin" />
+                <Pin Id="GD3VLIs2rqjNaNR0ofs12W" Name="Near Clip Plane" Kind="InputPin" />
+                <Pin Id="JSYowvrc6zZMQqFz5fPSZv" Name="Far Clip Plane" Kind="InputPin" />
+                <Pin Id="HaWbjT8DSi0LkOlFPCCkrl" Name="Show Helper" Kind="InputPin" />
+                <Pin Id="AhkmAowLLB5PchaauGhRp8" Name="Enabled" Kind="InputPin" />
+                <Pin Id="Khdjowz25SLP6OYApz7Cjt" Name="Projection Matrix" Kind="InputPin" />
+                <Pin Id="Rx9W2L24HF2NyOSF4TtB6f" Name="Output" Kind="OutputPin" />
+                <Pin Id="Q9U3eXVKE6LP21bGbL7czF" Name="Camera Component" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="A9Ul9jN5HPpMXO72p5b2Gr" Bounds="519,674" />
+              <ControlPoint Id="DhikEulXgMIQSUJlN1sLST" Bounds="341,578" />
+              <ControlPoint Id="B3keJ98ls3NOhoxDUaVFgv" Bounds="280,604" />
+              <ControlPoint Id="Vt0NzKOmsYSPeVrhMwYDFq" Bounds="449,589" />
+              <ControlPoint Id="EdxgtLLyJEwNDUYXqdIOgV" Bounds="385,959" />
+              <Node Bounds="168,657,65,19" Id="IyGZ47dV9hSL29k13nVcHd">
+                <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="FromValue" />
+                  <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
+                </p:NodeReference>
+                <Pin Id="Ux4BbwvndUCNeae7rWE0EF" Name="Input" Kind="InputPin" />
+                <Pin Id="RVdnlY3z4oaM2yiPlTP1yC" Name="Result" Kind="OutputPin" />
+              </Node>
+              <ControlPoint Id="ICS2UllckxGM5OR8xqN8e6" Bounds="557,623" />
+              <ControlPoint Id="H6a89VsFEUgMJFjdx2xGOW" Bounds="266,575" />
+              <Node Bounds="304,600,25,19" Id="A1air9Qown7NwUHB90ogfJ">
+                <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                  <Choice Kind="OperationCallFlag" Name="*" />
+                </p:NodeReference>
+                <Pin Id="PmxuU3C8tqLOxu43J7Hzit" Name="Input" Kind="InputPin" />
+                <Pin Id="EmR1VUSaWabQQqkRBZEx8L" Name="Input 2" Kind="InputPin" DefaultValue="100">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="Float32" />
+                  </p:TypeAnnotation>
+                </Pin>
+                <Pin Id="HYUYHAkkRt9Nkvz9V7lg0F" Name="Output" Kind="OutputPin" />
+              </Node>
+              <Pad Id="QQWjFG2wXEMM2AssPyQ0h1" Comment="FOV" Bounds="590,401,35,15" ShowValueBox="true" isIOBox="true" />
+              <ControlPoint Id="MkbGij0tPAaObDh21XJ1ls" Bounds="512,290" />
+              <Pad Id="J3QQYsAqZC8PcwssW8gnUp" Comment="Initial Name" Bounds="37,561,88,15" ShowValueBox="true" isIOBox="true" Value="WSAD Camera">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="String" />
+                </p:TypeAnnotation>
+              </Pad>
+              <ControlPoint Id="QRELfQQNpX4PxXj3De7fXS" Bounds="219,628" />
+              <ControlPoint Id="DINCpn6gDA1M79wSiCJjqy" Bounds="197,600" />
+              <ControlPoint Id="VQk5YocWD4cM8xtstHjRhG" Bounds="330,450" />
+              <ControlPoint Id="GRV9ABdaSCcMcfF4wNbI41" Bounds="452,250" />
+              <ControlPoint Id="DTjo4hLTkoXQUBrIdc6oPr" Bounds="482,270" />
+            </Canvas>
+            <Link Id="OjyNh9oMWG4QIew6b2awi4" Ids="DdocyXckJcXPRx6jvOhxmF,PQncWMgFvC0NdPgiIg4Da9" IsHidden="true" />
+            <Link Id="KxHxkxlzZcFPLDvNoufUrp" Ids="MDWoOAnAlXqP3CWI7iYSu8,UGUTtkxlIEJO9zeAF5wufH" IsHidden="true" />
+            <Link Id="V1ZCdhietytQATDV5rmy11" Ids="Q0OcNN8YmMlLV2kplM08Ft,QjMraLtmXLHMAlkaCcP2TV" />
+            <Link Id="Tc9K4Gnta0DPdoxbZ5SSqi" Ids="GeuwKGrHB11OnolBeJMklB,Q0OcNN8YmMlLV2kplM08Ft" IsHidden="true" />
+            <Link Id="U5ttGoM9yfeM0mkfbOSE6A" Ids="AmoYWxD1rjyLNjE027wUzV,QxwDCUavlteOQwWJqsO1FP" />
+            <Link Id="AwWC2vCoQfIOEs6bvxcoAP" Ids="MzY9NrTfYyuOWtaxhqcAtm,AmoYWxD1rjyLNjE027wUzV" IsHidden="true" />
+            <Link Id="HPZy7NRApesLTvgr4YOeK4" Ids="HwCZaf35s01OfBa4wAzw8S,DBOCApqZdU9P0WrnE5kT1e" />
+            <Link Id="LvSzfvYeurvPnkZT9zu7Zg" Ids="Q4hYPcf0qMpPXqLHdza2LP,HwCZaf35s01OfBa4wAzw8S" IsHidden="true" />
+            <Link Id="MHTJMnLH1eZL18Z0hVV5Vw" Ids="Ke7ieEPfV1eLV7cDWRX6a0,PWjN0Us3DZtO6lddpz0EhT" />
+            <Link Id="VqlAnMlGOK9Np7sQhqTbO6" Ids="PlAjY9qwl8zPGC4lfuw899,Ke7ieEPfV1eLV7cDWRX6a0" IsHidden="true" />
+            <Link Id="JhoS8avip92Mab5uVhXcgN" Ids="QTgfpPlSyUMQHlO3GJGBlu,S0tWcenGP79PnhEbZPr28S" />
+            <Link Id="P5opIOKIoSnOnaK337OnD3" Ids="FRgVqQV90EXP0CtScHFe6z,QTgfpPlSyUMQHlO3GJGBlu" IsHidden="true" />
+            <Link Id="V7LEF8Z1UFYPXbKOICO8sM" Ids="TgpOT343X2xOsat9iaVlUE,P9rWe2wFjZcMuuRhVtxgF5" />
+            <Link Id="QJ8BR9AMywfMiYRtVCPvT8" Ids="CdRMhzTpZheNqa1lQvYs67,TgpOT343X2xOsat9iaVlUE" IsHidden="true" />
+            <Link Id="NqVGQRhwRKhP5QjH0EYC9w" Ids="L33ZbczbMUnPakufiHqgdz,V5kjKm65MUnLpk9f7fQHCt" />
+            <Link Id="R0A3Q1p6CjpOkEU22VVJR7" Ids="QbvxfxHZK7JODdRKdM8FYp,L33ZbczbMUnPakufiHqgdz" IsHidden="true" />
+            <Link Id="EFaFVqX1km1OirXrFgOgIa" Ids="RGNZ7lCtyRLPSRvnFpxpo9,NQpRzqbbUljNkRAbb4NhEU" IsHidden="true" />
+            <Link Id="FOqb1SYE3W5POd48PrRk3M" Ids="RhPvowggyc6Lg2mQBg9Qmx,P5N9GeSVGvVMgW5ERRx0fe" IsHidden="true" />
+            <Link Id="MHxPTzIYLWlOkT4apRn5wl" Ids="KvzgGgQoZClM9IWeZUColy,OHg3QihbodpMN4WF19LXF0" IsHidden="true" />
+            <Link Id="GAC3gddLjeYM16kfYPMtcZ" Ids="HXnhCqIMSMwNL4qizS6rlU,DFSflxHAMhCNXv4d0stcf8" IsHidden="true" />
+            <Link Id="LZCHBFLJPrZLBGMbrCvYON" Ids="DFSflxHAMhCNXv4d0stcf8,JjMV2gj9RbvMYGFfAY2JZX" />
+            <Link Id="MJpz2TmI1wXNN9pM3NRdSh" Ids="LslVWYCa56PPF9BDzwGCTC,OE3k92dHD6aL1Jjxz7jFOy" />
+            <Link Id="EXYSd3BZ09ONYDfCLrwPon" Ids="VJGjY8ZLTkNPDCQaxdOW7W,VegKeueAolON6qSQNoAa1t" />
+            <Link Id="CfiVrUuvjvsNR7qczsMlZd" Ids="I0U5DQmAXR0L9O3gxoSpY1,JYLwCDeI5jpOsEAW88qYRB" IsHidden="true" />
+            <Link Id="KCFXHAaqnpxPwn1m6QW4IU" Ids="RGNZ7lCtyRLPSRvnFpxpo9,JyvvxJSGOvkPSf57bdbFIm" IsHidden="true" />
+            <Link Id="O9kqsm2ZREyMyHQw5fZ8oc" Ids="JyvvxJSGOvkPSf57bdbFIm,BWNCkdI8lbrMqDSiC4iUKm" />
+            <Link Id="AwWvbaTeXLBLU0OOXqUXAF" Ids="J8Zorqa5ZzuLOLsvbDmePb,BFuY9UZ96cxPtxS6jk35TL" IsHidden="true" />
+            <Link Id="M6lUlWFzHctMlb0oIO3LGi" Ids="CXWzZuzAYfxOIhIFAZpkGf,VHZp3N6SkpbL8ZwPHjiq5W" IsHidden="true" />
+            <Link Id="EAS230tVz6FPWdzbcw5DF9" Ids="BbechrXOMAwQIyXUR9NYUP,HMKbhPUReuXQcL8JBcasXn" />
+            <Link Id="E2sLMS3MumGNP93wQ7Pzes" Ids="KSEJt2ZgfNXQK1K8DZkrMd,MDWoOAnAlXqP3CWI7iYSu8" />
+            <Link Id="ISXxSQY2kk3MG6GbircvyG" Ids="GeXwKRE5KNcQaS1IzX4xiV,RhPvowggyc6Lg2mQBg9Qmx" />
+            <Link Id="C7ruigkmNKaN2zA7zwbdz8" Ids="OslJ6c9OBOCQAaCGJqE2Us,H8irNmbROH4MN31UfYLxBy" />
+            <Link Id="EfTf28fByptMPu4ZmKjo1s" Ids="M00BQNxEls0N3ZM1Z1zpQc,DdocyXckJcXPRx6jvOhxmF" />
+            <Link Id="UmgKaM7P0FKPp64utig4mA" Ids="VHZp3N6SkpbL8ZwPHjiq5W,A9Ul9jN5HPpMXO72p5b2Gr,PdLM8I1c110LyibCFJIkh1" />
+            <Link Id="JHCROIDDXkhMzdKc7fvALo" Ids="A4fqFcNkliILg3tXcHF8Ub,Ux4BbwvndUCNeae7rWE0EF" />
+            <Link Id="L0LyakxyQveL5GcGG9vYo7" Ids="DXzTEewFrxoOAmSSZ1RKNM,DhikEulXgMIQSUJlN1sLST,B3keJ98ls3NOhoxDUaVFgv,JbomhpjOSlnM2rpefaqXnb" />
+            <Link Id="R3aeE52RY2cNEUHIrSCvfc" Ids="AmoYWxD1rjyLNjE027wUzV,GD3VLIs2rqjNaNR0ofs12W" />
+            <Link Id="Ae6uCPD5QxjPr2THgMllnj" Ids="Q0OcNN8YmMlLV2kplM08Ft,JSYowvrc6zZMQqFz5fPSZv" />
+            <Link Id="AacP1SSamo3LgK5aiM9cRk" Ids="Rx9W2L24HF2NyOSF4TtB6f,I0U5DQmAXR0L9O3gxoSpY1" />
+            <Link Id="Dn1rB9hf8uBPWbAThY6ZBd" Ids="Q9U3eXVKE6LP21bGbL7czF,GJ7tOHeAjXuPZpfyo5e0C7" />
+            <Link Id="U5tgF3gSx4pPTRxss75KAE" Ids="BFuY9UZ96cxPtxS6jk35TL,MmN1vIA190fOkBY6bqx1k8" />
+            <Link Id="HTSS5JaMsdvMDmqK8mY2cz" Ids="VHZp3N6SkpbL8ZwPHjiq5W,Tvd2cATDMAFPhuITSfukyj" />
+            <Link Id="N2yPXwT2BW3PvCHNmnJzf0" Ids="NQpRzqbbUljNkRAbb4NhEU,AhkmAowLLB5PchaauGhRp8" />
+            <Link Id="Tk4WUrZ5TjYNMG0U5TmIAq" Ids="Vt0NzKOmsYSPeVrhMwYDFq,HaWbjT8DSi0LkOlFPCCkrl" />
+            <Link Id="KDqcw9WfVRKLrkXZKyVymr" Ids="FOg7MfVfUxjNiusvXPWAR3,Vt0NzKOmsYSPeVrhMwYDFq" IsHidden="true" />
+            <Link Id="KvU1YxB8dZ2P4iuOlT3ViA" Ids="MzcsDC6J08VMaAUXH88fvG,EdxgtLLyJEwNDUYXqdIOgV" />
+            <Link Id="O8rzBqS1l8sQAwgI2BCNVf" Ids="EdxgtLLyJEwNDUYXqdIOgV,Eis80HcddomQGQ1DH8QxK3" IsHidden="true" />
+            <Link Id="PDPczDgIGx0Nmq9e9RLgNd" Ids="ICS2UllckxGM5OR8xqN8e6,Khdjowz25SLP6OYApz7Cjt" />
+            <Link Id="JeLkeJk9IrBMTuzdNeoyjO" Ids="HlMH6Pg4rJGQAmCyviNyts,ICS2UllckxGM5OR8xqN8e6" IsHidden="true" />
+            <Link Id="GiFGxb6gTe1N1V72X9Na3a" Ids="H6a89VsFEUgMJFjdx2xGOW,L9V6GruFkxEQG91i4gTTHQ" />
+            <Link Id="J6nyCjzOYdBP2sFlFqnMgT" Ids="NnnMHOhyrAYM2CpMXGe2lP,H6a89VsFEUgMJFjdx2xGOW" IsHidden="true" />
+            <Link Id="Vil2UFuoqK5MJM1AX8YK9G" Ids="DXzTEewFrxoOAmSSZ1RKNM,PmxuU3C8tqLOxu43J7Hzit" />
+            <Link Id="FJubBGnOHI4N5sNQm9YRNy" Ids="HYUYHAkkRt9Nkvz9V7lg0F,NeOFHHIgkYJNPjBFWPTaJX" />
+            <Link Id="RPjb0ZZoGe8PgCQvhJHDvm" Ids="DXzTEewFrxoOAmSSZ1RKNM,QQWjFG2wXEMM2AssPyQ0h1" />
+            <Link Id="MmiNcFB13IwLhKkySSAUd7" Ids="OHg3QihbodpMN4WF19LXF0,MscHCs6drF0LspwBpZywDm" />
+            <Link Id="OVXAWPg85XKLOlX6nzKwm1" Ids="MkbGij0tPAaObDh21XJ1ls,Ar5CiU0CGYwLWLoJ5pMBJ8" />
+            <Link Id="P4iUl8EAGyUQbAO7cQukHK" Ids="ArdACP8rNpeOWEYQYWvKCU,MkbGij0tPAaObDh21XJ1ls" IsHidden="true" />
+            <Link Id="FHB2SBazH4tPtoZz8ykmSv" Ids="J3QQYsAqZC8PcwssW8gnUp,Q9WtVN9F0PRNxLeqB7uuNv" />
+            <Link Id="LpJYp1iJDgDPG71kNeelGW" Ids="RVdnlY3z4oaM2yiPlTP1yC,EGz1kvRFe7EPNdLgghQL02" />
+            <Link Id="QdKXwtWVVNxLusXu9k0Ii6" Ids="RbYBKgD6nyyN5HK8WJBSDQ,QRELfQQNpX4PxXj3De7fXS" IsHidden="true" />
+            <Link Id="KnfpO93SfjUOTZrQR0jjcp" Ids="QecXJLvpcoiPY7nUf20lWS,DINCpn6gDA1M79wSiCJjqy" IsHidden="true" />
+            <Link Id="EdE0PX9ZPt4LbFeCWHQe10" Ids="DINCpn6gDA1M79wSiCJjqy,NHHHKJUWBDePCWf2cGdw49" />
+            <Link Id="LN4BhaaMzsVLNofEi3Tab0" Ids="QRELfQQNpX4PxXj3De7fXS,BqcHLhxW1xaNDoddq65fOa" />
+            <ProcessDefinition Id="N7swEhidWojOcU3AaIDwKZ">
+              <Fragment Id="U7eRmBsaUuJNeXCMT2h6s8" Patch="JxAFA8kOdYzOc7CHEboJdw" Enabled="true" />
+              <Fragment Id="SnQa5ILKjAVNjWVYZSgvNV" Patch="FkGlD0vhqYrLwq9UVp80kQ" Enabled="true" />
+              <Fragment Id="LTB34rPAmjkMLJy5BIGTdv" Patch="Q5Ufc9DAoCWM1vIMBdfzM2" Enabled="true" />
+              <Fragment Id="Kx8XIImGHatMvui7XkTnsK" Patch="VhKdiUysJcfQFVRZyZLDlE" Enabled="true" />
+              <Fragment Id="RVxovLoWW0iN0XcGfKwRW9" Patch="PIOT4rIzjwSL5nMhGrFw9x" />
+            </ProcessDefinition>
+            <Link Id="G6LDtrk9ayRLg7IFpDclas" Ids="IVrB9gQRMUJL5YnmIGWjID,OLKl8tEjb5MQMyOPZCxTXy" />
+            <Patch Id="JxAFA8kOdYzOc7CHEboJdw" Name="Create" />
+            <Patch Id="VhKdiUysJcfQFVRZyZLDlE" Name="Update" ManuallySortedPins="true">
+              <Pin Id="PlAjY9qwl8zPGC4lfuw899" Name="Initial Interest" Kind="InputPin" Bounds="249,127" />
+              <Pin Id="QbvxfxHZK7JODdRKdM8FYp" Name="Initial Yaw" Kind="InputPin" Bounds="331,130" />
+              <Pin Id="FRgVqQV90EXP0CtScHFe6z" Name="Initial Pitch" Kind="InputPin" Bounds="420,139" />
+              <Pin Id="CdRMhzTpZheNqa1lQvYs67" Name="Initial Distance" Kind="InputPin" Bounds="507,142" />
+              <Pin Id="Q4hYPcf0qMpPXqLHdza2LP" Name="Initial Vertical Field Of View" Kind="InputPin" Bounds="615,153" DefaultValue="0.14">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Float32" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="NnnMHOhyrAYM2CpMXGe2lP" Name="Projection" Kind="InputPin" Bounds="281,455" />
+              <Pin Id="MzY9NrTfYyuOWtaxhqcAtm" Name="Near Clip Plane" Kind="InputPin" Bounds="733,155" />
+              <Pin Id="GeuwKGrHB11OnolBeJMklB" Name="Far Clip Plane" Kind="InputPin" Bounds="957,137" />
+              <Pin Id="KvzgGgQoZClM9IWeZUColy" Name="Auto Fetch Input Source" Kind="InputPin" Bounds="-73,105" DefaultValue="True" Visibility="Optional">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Boolean" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="HXnhCqIMSMwNL4qizS6rlU" Name="Input Source" Kind="InputPin" Bounds="-61,68" Visibility="Optional" />
+              <Pin Id="J8Zorqa5ZzuLOLsvbDmePb" Name="Aspect Ratio" Kind="InputPin" Bounds="916,276" DefaultValue="1.777778">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Float32" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="CXWzZuzAYfxOIhIFAZpkGf" Name="Use Custom Aspect Ratio" Kind="InputPin" Bounds="921,250" DefaultValue="False">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Boolean" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="FOg7MfVfUxjNiusvXPWAR3" Name="Show Helper" Kind="InputPin" Bounds="433,554" />
+              <Pin Id="HlMH6Pg4rJGQAmCyviNyts" Name="Projection Matrix" Kind="InputPin" Bounds="607,436" Visibility="Optional" />
+              <Pin Id="ArdACP8rNpeOWEYQYWvKCU" Name="Reset" Kind="InputPin" Bounds="490,273" />
+              <Pin Id="RGNZ7lCtyRLPSRvnFpxpo9" Name="Enabled" Kind="InputPin" Bounds="808,400" DefaultValue="True">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Boolean" />
+                </p:TypeAnnotation>
+              </Pin>
+              <Pin Id="JYLwCDeI5jpOsEAW88qYRB" Name="Output" Kind="OutputPin" Bounds="638,601" />
+              <Pin Id="UGUTtkxlIEJO9zeAF5wufH" Name="Position" Kind="OutputPin" Bounds="1140,631" />
+              <Pin Id="PQncWMgFvC0NdPgiIg4Da9" Name="Frustum" Kind="OutputPin" Bounds="365,563" />
+              <Pin Id="P5N9GeSVGvVMgW5ERRx0fe" Name="Inverse View" Kind="OutputPin" Bounds="549,833" />
+              <Pin Id="Eis80HcddomQGQ1DH8QxK3" Name="Camera Component" Kind="OutputPin" Bounds="453,824" />
+              <Pin Id="PTBGWJuWk6WM4Ij5VDsIU8" Name="Interest" Kind="OutputPin" />
+              <Pin Id="SXfrcmkItLpPHgrUJbFDFQ" Name="Speed" Kind="InputPin" Visibility="Optional" />
+              <Pin Id="PrHlMa4sJoVP7oIgXAaHgi" Name="High Speed" Kind="InputPin" Visibility="Optional" />
+            </Patch>
+            <Patch Id="Q5Ufc9DAoCWM1vIMBdfzM2" Name="SetEntities">
+              <Pin Id="RbYBKgD6nyyN5HK8WJBSDQ" MergeId="19411" Name="Children" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Spread" />
+                  <p:TypeArguments>
+                    <TypeReference>
+                      <Choice Kind="TypeFlag" Name="Entity" />
+                    </TypeReference>
+                  </p:TypeArguments>
+                </p:TypeAnnotation>
+              </Pin>
+            </Patch>
+            <Patch Id="FkGlD0vhqYrLwq9UVp80kQ" Name="SetComponents">
+              <Pin Id="QecXJLvpcoiPY7nUf20lWS" MergeId="19413" Name="Components" Kind="InputPin">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
+                  <Choice Kind="TypeFlag" Name="Spread" />
+                  <p:TypeArguments>
+                    <TypeReference>
+                      <Choice Kind="TypeFlag" Name="EntityComponent" />
+                    </TypeReference>
+                  </p:TypeArguments>
+                </p:TypeAnnotation>
+              </Pin>
+            </Patch>
+            <Link Id="IIa3d7ExpviLJ2BAFFhUJ9" Ids="VQk5YocWD4cM8xtstHjRhG,PTBGWJuWk6WM4Ij5VDsIU8" IsHidden="true" />
+            <Patch Id="PIOT4rIzjwSL5nMhGrFw9x" Name="GetInterest" />
+            <Link Id="AlZaDWjQSJbMfgzENqOm6H" Ids="MXTRnxNrh2VMqyNQsI3Wov,VQk5YocWD4cM8xtstHjRhG" />
+            <Link Id="SsCgPUY5UMXOJ6ApAshVDX" Ids="GRV9ABdaSCcMcfF4wNbI41,FwxSw5CANMyOOfQZBDUnyZ" />
+            <Link Id="DYRzYDFfoqINLznMMtlEhE" Ids="SXfrcmkItLpPHgrUJbFDFQ,GRV9ABdaSCcMcfF4wNbI41" IsHidden="true" />
+            <Link Id="GgZrTcJNAJsLt4bYpMQ5Pm" Ids="DTjo4hLTkoXQUBrIdc6oPr,BiljkCTt2WVNkMnNfnFh2X" />
+            <Link Id="Pi0LTn6XA1xOWry8e05yN1" Ids="PrHlMa4sJoVP7oIgXAaHgi,DTjo4hLTkoXQUBrIdc6oPr" IsHidden="true" />
           </Patch>
         </Node>
       </Canvas>

--- a/VL.Stride/help/Cameras/Explanation WSAD Camera.vl
+++ b/VL.Stride/help/Cameras/Explanation WSAD Camera.vl
@@ -1,0 +1,305 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" xmlns:r="reflection" Id="VcJ2qjVJcsNM70bjE4R3LX" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2025.7.0" />
+  <Patch Id="EflKC5Ddi2BN1mZWLv60qK">
+    <Canvas Id="NBB3K3ClmntMsyQxzUGU5L" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="IpuziwkTppNOpmk0UoByDq">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="Vj25sLBZxhZPwNAg67Fwvh">
+        <Canvas Id="NWbLQWqcfy2P7zZPeYFfDI" CanvasType="Group">
+          <Node Bounds="326,620,65,19" Id="HUMLoKFjSjGNUJR4OZiNSV">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="RootScene" />
+            </p:NodeReference>
+            <Pin Id="OyRHFDEZEaSN5Kc1NeAg7Z" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="DCwdjyrchguNOS9twwaMdC" Name="Child" Kind="InputPin" />
+            <Pin Id="ARMPumrjFJsLmHmaTorkgp" Name="Child 2" Kind="InputPin" />
+            <Pin Id="QJBdga0DUOzLKH1WjqKut0" Name="Child 3" Kind="InputPin" />
+            <Pin Id="IQkW57Ud5RIPIwGQnm8oSF" Name="Child Scenes" Kind="InputPin" IsHidden="true" />
+            <Pin Id="KkIRMMUddCHQXFcGaigpfI" Name="Enabled" Kind="InputPin" />
+            <Pin Id="OrhiFun7LMjMlUx7Qm76yX" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="88,471,205,19" Id="NZnHxHMZWAWMbs7Guk2cq5">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.Engine.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Plane" />
+            </p:NodeReference>
+            <Pin Id="RVs4JZ9SFT5PgY0ImkepHf" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="PY700LXla95NgxOg1ASSHg" Name="Transformation" Kind="InputPin" />
+            <Pin Id="Jf04j3ht9seNd6YV9p1PcF" Name="Size" Kind="InputPin" />
+            <Pin Id="LvJNwEGXGvrMRuAL7CE7GN" Name="Tessellation" Kind="InputPin" />
+            <Pin Id="FJc0MNRF6ZCLEVL6gkunv7" Name="Normal" Kind="InputPin" />
+            <Pin Id="APUx6LV1dKcM3TC6urQGIk" Name="Generate Back Face" Kind="InputPin" />
+            <Pin Id="OH1cvhBSa0kLEuNa7cgJMy" Name="Material" Kind="InputPin" />
+            <Pin Id="J5Yakj48SwnOYvaM3QlE3w" Name="Is Shadow Caster" Kind="InputPin" />
+            <Pin Id="KA1ThfjOch7Pcihzyd9fvn" Name="Components" Kind="InputPin" />
+            <Pin Id="Kd9lKkeMm8rMGKD0DRFROh" Name="Children" Kind="InputPin" />
+            <Pin Id="CcJ3WL6RwgTM3iYeiH8qKO" Name="Name" Kind="InputPin" />
+            <Pin Id="KsV0noRN1QkPxFWWM4BpLF" Name="Enabled" Kind="InputPin" />
+            <Pin Id="DLjgPcSkGQTLqkDLDKzXxe" Name="Output" Kind="OutputPin" IsHidden="true" />
+            <Pin Id="PKDYGrWFdnGNJRl7RQ8WMb" Name="Entity" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="108,496,185,19" Id="DP7dmqfGZabNmyQcj4uiz7">
+            <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.Engine.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="DirectionalLight" />
+            </p:NodeReference>
+            <Pin Id="Fo22YLHSPrdNgEZECm1r9i" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="OsA1QhcXgWGOmKL93bUczy" Name="Position" Kind="InputPin" />
+            <Pin Id="L6WGkWiUQuoMVkw9jnYVp2" Name="Target" Kind="InputPin" />
+            <Pin Id="Fj28hWfYRqhNid0G6fgoKi" Name="Color" Kind="InputPin" />
+            <Pin Id="QGDNpO3JnrdO8Tx9V9Muj1" Name="Intensity" Kind="InputPin" />
+            <Pin Id="NHKLx5XFt8dLKHi3QtAtrh" Name="Shadow" Kind="InputPin" />
+            <Pin Id="UNqrxpOCaOTQL8xmU0Ae9d" Name="Enable Default Shadow" Kind="InputPin" />
+            <Pin Id="JPv9tYgcrsPO3oKRlfshX3" Name="Component" Kind="InputPin" />
+            <Pin Id="JsVGqXTrRS2P9iI71MZDGr" Name="Children" Kind="InputPin" />
+            <Pin Id="IZuMF58Luc4MWqrIiHIPxX" Name="Name" Kind="InputPin" />
+            <Pin Id="I43mMDUa6BROD8BcaNTpGP" Name="Enabled" Kind="InputPin" />
+            <Pin Id="NoQzUnpGhX5NItxVuB5YF1" Name="Output" Kind="OutputPin" IsHidden="true" />
+            <Pin Id="RXJyKlXbWORQYTCG1OPxMX" Name="Entity" Kind="OutputPin" />
+            <Pin Id="K0OSNiDbUXIMcZMUWlS0go" Name="Show Helper" Kind="InputPin" IsHidden="true" />
+          </Node>
+          <Node Bounds="346,485,105,19" Id="HzdUzgWqJNvNpVGqChnxHq">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Group" />
+              <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
+            </p:NodeReference>
+            <Pin Id="GXl2TYByxJaQdbZ8wJA6kR" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="HkaxQG7lLskLrSl2TRZ1Ii" Name="Transformation" Kind="InputPin" />
+            <Pin Id="U4E3TyrGqQ4My4e3YbikCV" Name="Child" Kind="InputPin" />
+            <Pin Id="CErlOWXNAECLdCErHssa6p" Name="Child 2" Kind="InputPin" />
+            <Pin Id="VTuqMm1Un86Oz2ERDgSxw2" Name="Child 3" Kind="InputPin" />
+            <Pin Id="KpkLbxWe4opLwAl8WBaRoz" Name="Name" Kind="InputPin" />
+            <Pin Id="IORkbNcGj1yMSOTUWM8ln9" Name="Enabled" Kind="InputPin" />
+            <Pin Id="UaTZWDMPicSL3QlrvF1UJp" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="68,569,105,19" Id="QUmu9tDldNBMw9j1uxn88C">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Group" />
+              <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
+            </p:NodeReference>
+            <Pin Id="MPCbK2g9LHSQOYs7fXsWDV" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="GDWazRECf1fPJe4melTlFr" Name="Transformation" Kind="InputPin" />
+            <Pin Id="CsTkmyswQzpPPhWEoBEseO" Name="Child" Kind="InputPin" />
+            <Pin Id="Pic8sHvdl8ANKm6EIIneSC" Name="Child 2" Kind="InputPin" />
+            <Pin Id="HigQ7qCGgu3N7fGXM84AS7" Name="Child 3" Kind="InputPin" />
+            <Pin Id="K0ZfgkIe29gMyKx8NERYQ7" Name="Name" Kind="InputPin" />
+            <Pin Id="BgTSBCMSA2EOENPtU1CojS" Name="Enabled" Kind="InputPin" />
+            <Pin Id="TEC2boM0rLXNDfs5MvFVPB" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="544,482,325,19" Id="HNMQXZ6ZlA7N69T6YIX9tD">
+            <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="WSADCamera" />
+            </p:NodeReference>
+            <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
+            <Pin Id="GkSM8Evm0yZPxGyYVi0YbS" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="TKmm3PyKycBPpOixWhJDBT" Name="Components" Kind="InputPin" />
+            <Pin Id="OFBR9TSOdkPPoKZE52gwwM" Name="Children" Kind="InputPin" />
+            <Pin Id="KTvdaR3kAQ4NKXs3YieIkY" Name="Initial Interest" Kind="InputPin" />
+            <Pin Id="SlXU3KYOu52P9yfJ6GJruj" Name="Initial Yaw" Kind="InputPin" />
+            <Pin Id="TPm33vrsYJRNEcRH5alpWm" Name="Initial Pitch" Kind="InputPin" />
+            <Pin Id="PPmCHY8xagjNOtRGIx2HdL" Name="Initial Distance" Kind="InputPin" />
+            <Pin Id="BnR2dfvylMMLWY0uF7G9BX" Name="Initial Vertical Field Of View" Kind="InputPin" />
+            <Pin Id="Lmm6VMJE9uAL6LA1AU7bWn" Name="Projection" Kind="InputPin" />
+            <Pin Id="HDC6twxYQWlP5FHSvCEMoF" Name="Near Clip Plane" Kind="InputPin" />
+            <Pin Id="Knq8urwh5FVL9uKGKp2TSW" Name="Far Clip Plane" Kind="InputPin" />
+            <Pin Id="JicG2B24CRaO5ygyLTnEDx" Name="Auto Fetch Input Source" Kind="InputPin" IsHidden="true" />
+            <Pin Id="RBgsRX0ldaUPZJwlSEpyIe" Name="Input Source" Kind="InputPin" IsHidden="true" />
+            <Pin Id="EPmmVvgX9wNLfoap9RkCx5" Name="Aspect Ratio" Kind="InputPin" />
+            <Pin Id="KVysRTXdRCjP5KWYA51KbO" Name="Use Custom Aspect Ratio" Kind="InputPin" />
+            <Pin Id="UdHIVFWfIIuQRHfFi7t3qt" Name="Show Helper" Kind="InputPin" />
+            <Pin Id="MeoQqNHdut9McKMzmv1RWl" Name="Projection Matrix" Kind="InputPin" IsHidden="true" />
+            <Pin Id="OM33IYlABOXLz0U5Bz6uoX" Name="Reset" Kind="InputPin" />
+            <Pin Id="Dk9ENpfoBWZQOecdg1sBF6" Name="Enabled" Kind="InputPin" />
+            <Pin Id="UBNKKtaEU0ALHrm7moEeq4" Name="Output" Kind="OutputPin" />
+            <Pin Id="SiTzezMkKYSLy2WBEMFfLB" Name="Position" Kind="OutputPin" />
+            <Pin Id="UVKRWnnUgP6OLnWPpnTlHD" Name="Frustum" Kind="OutputPin" />
+            <Pin Id="FXBwINicOzOLLqAEhjtvvA" Name="Inverse View" Kind="OutputPin" />
+            <Pin Id="AhbIFGUmB8vL6LKV8kSk3s" Name="Camera Component" Kind="OutputPin" />
+            <Pin Id="S2i7irGAp4aMOJe54SQ6gc" Name="Interest" Kind="OutputPin" />
+            <Pin Id="TsfavvToTdjOgZpXn4BjBT" Name="Speed" Kind="InputPin" />
+            <Pin Id="ECVlzaEfh3nL216yHO2vbZ" Name="High Speed" Kind="InputPin" />
+          </Node>
+          <Node Bounds="366,409,165,19" Id="HVZLeyR1AVQOVHzjURWhnM">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.Engine.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Sphere" />
+            </p:NodeReference>
+            <Pin Id="EY9mQoy57IUMZsHS9I5yiH" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="CMTFxc4CQeMQZYfTcsSadV" Name="Transformation" Kind="InputPin" DefaultValue="1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -0.64, 0.31, 0, 1">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Matrix" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="RxA0h8gAEi5QabMwMoaqBV" Name="Radius" Kind="InputPin" />
+            <Pin Id="OF1rhoyOn2lMYQxHkMzaix" Name="Tessellation" Kind="InputPin" />
+            <Pin Id="LKyXElJKszdL6i8NPpwGst" Name="Material" Kind="InputPin" />
+            <Pin Id="GrCU2KsfQISOLbAiwObFNS" Name="Is Shadow Caster" Kind="InputPin" />
+            <Pin Id="Kz5sfmL7Bi1OTnh77nbdyn" Name="Components" Kind="InputPin" />
+            <Pin Id="KTAMzzG5dswLuj8ynNlk3C" Name="Children" Kind="InputPin" />
+            <Pin Id="SciT0LrzuaGPUpEZMukZyx" Name="Name" Kind="InputPin" />
+            <Pin Id="BtHcQqIRvcPL8NES2ZQ3sn" Name="Enabled" Kind="InputPin" />
+            <Pin Id="T8sm79K6cH3PCjfTKnKqmQ" Name="Output" Kind="OutputPin" IsHidden="true" />
+            <Pin Id="VyL6dBWK067NncquWn8FKD" Name="Entity" Kind="OutputPin" />
+          </Node>
+          <Node Bounds="386,439,165,19" Id="BBcmsZFIX92P9N7smrdB2v">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.Engine.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="Box" />
+            </p:NodeReference>
+            <Pin Id="DrW9N2U9qmZMPUHeOyQnSH" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="LzyJA63l1xMLGr9NtYdZaL" Name="Transformation" Kind="InputPin" DefaultValue="1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.86, 0.51, 0, 1">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Matrix" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="GZp7FLEcGF9P1LAAHOofmT" Name="Size" Kind="InputPin" />
+            <Pin Id="MHtffjFTG4ONRlqYvJiSbv" Name="Tessellation" Kind="InputPin" />
+            <Pin Id="QXFBbbwxBYgQEjwA9ZgVfh" Name="Material" Kind="InputPin" />
+            <Pin Id="IshMWm3Gj85QLDDk6ZUOy0" Name="Is Shadow Caster" Kind="InputPin" />
+            <Pin Id="QS1RGYebPMfPkfKBYraCtp" Name="Components" Kind="InputPin" />
+            <Pin Id="BPmTn3RL5eJOy7uHCWu85q" Name="Children" Kind="InputPin" />
+            <Pin Id="QpUBMZNgebaOi7ZaVLu8Da" Name="Name" Kind="InputPin" />
+            <Pin Id="Pk9rrPQXOaXPukuCoUhlhC" Name="Enabled" Kind="InputPin" />
+            <Pin Id="NyH7YJ7JP68L5GGI8rPweG" Name="Output" Kind="OutputPin" IsHidden="true" />
+            <Pin Id="VG1RQI80Je5QR3k4ZiqDG8" Name="Entity" Kind="OutputPin" />
+          </Node>
+          <Pad Id="FLiSFs8Zb6ZNFOM7j3xRHW" Bounds="566,536,276,214" ShowValueBox="true" isIOBox="true" Value="Switch to Edit Mode [F4] to see a representation of the Camera.&#xD;&#xA;&#xD;&#xA;For that to work the Camera needs to be part of the Scene Graph. Here we connect it to Scene directly, but we could have used a Group node as well.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">11</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Pad Id="So4ec8pMghWNMs24Qx43vd" Bounds="574,56,505,298" ShowValueBox="true" isIOBox="true" Value="Orbit: Drag with Right Mouse Button&#xD;&#xA;Move: Hold down Right Mouse Button and press to move&#xD;&#xA;  W - forward&#xD;&#xA;  S - backward&#xD;&#xA;  A - Left&#xD;&#xA;  D - Right&#xD;&#xA;  E - Up&#xD;&#xA;  Q - Down&#xD;&#xA;(Hold down SHIFT key for high movement speed)&#xD;&#xA;&#xD;&#xA;Zoom: Hold Ctrl &amp; Use Mouse Wheel&#xD;&#xA;&#xD;&#xA;Reset: Press &amp; Hold [R] on the Keyboard">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">11</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Node Bounds="128,525,105,19" Id="MmOSm6LpeVOLkkxnckfrkc">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="Category" Name="Models" NeedsToBeDirectParent="true" />
+              <Choice Kind="ProcessAppFlag" Name="AxisAndGrid" />
+            </p:NodeReference>
+            <Pin Id="INYVq4FK5iuM10P6OXcDmz" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="FhPTEnt93otOmyxiy8Q91S" Name="Transformation" Kind="InputPin" />
+            <Pin Id="COpAjVUDLw6Pm3vm3hOg99" Name="Axis" Kind="InputPin" />
+            <Pin Id="TtxacnhRWRtPy3Dc3akXKl" Name="Grid" Kind="InputPin" />
+            <Pin Id="QsNjFN2dupIPLplyJR7i90" Name="Grid Color" Kind="InputPin" />
+            <Pin Id="ShaCwBgJF0EOnGzNkG1KJq" Name="Radius" Kind="InputPin" />
+            <Pin Id="Ripl8xHDY6pPtDjZJM2jaK" Name="Enabled" Kind="InputPin" />
+            <Pin Id="DMTNEiuamu8MJk7QRwQCO2" Name="Output" Kind="OutputPin" />
+          </Node>
+          <Pad Id="N4YhZKHYEMlMdcOF0Wjvn0" Comment="Initial Interest" Bounds="586,385,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1, 3">
+            <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Vector3" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="LIt2cgHE3VLNNCG7XTwOJi" Comment="Speed" Bounds="846,436,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="ITEEHK6f5A8LALQOwM5fOe" Comment="High Speed" Bounds="866,456,35,15" ShowValueBox="true" isIOBox="true" Value="0.4">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="Ue8PSGGzE2gMue6rbXoWlc" Bounds="846,405,105,21" ShowValueBox="true" isIOBox="true" Value="Optional Pins">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="String" />
+            </p:TypeAnnotation>
+            <p:ValueBoxSettings>
+              <p:fontsize p:Type="Int32">9</p:fontsize>
+              <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
+            </p:ValueBoxSettings>
+          </Pad>
+          <Node Bounds="326,730,225,19" Id="QjXGH7XdXlHMAOTUhX2Wsa">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
+            </p:NodeReference>
+            <Pin Id="QdSQw7yI1xSQP8gNCpa6yM" Name="Bounds" Kind="InputPin" DefaultValue="1000, 40, 786, 432" IsHidden="true" />
+            <Pin Id="PFlWFpZXFFAQKG3faINhK2" Name="Bound to Document" Kind="InputPin" IsHidden="true" />
+            <Pin Id="FJ0nDLipU6zL9vtoU9mvKk" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
+            <Pin Id="BgPSNFnL24gNWubHLMHTsN" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
+            <Pin Id="F4N4pj6vA2wLkEpR8CeNTa" Name="Back Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Vg39yUkhPeUNEYcnpuna1z" Name="Depth Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="VUaBgfa4gufLXTsYKKrd7U" Name="Input Priority" Kind="InputPin" IsHidden="true" />
+            <Pin Id="EQMzuBR9SECMzx1NsVetzY" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="IR5VtjjH9pHMZOkXt6JSAi" Name="Input" Kind="InputPin" />
+            <Pin Id="GxKY4nCXx99MKixjpC0RRf" Name="Camera" Kind="InputPin" />
+            <Pin Id="S7XaCYM0ZRoQLPdcDeW6bH" Name="Enable Default Camera" Kind="InputPin" />
+            <Pin Id="OMkPsRVDbukQPXiPvDm2td" Name="Title" Kind="InputPin" />
+            <Pin Id="HktRKEfG6ZNNaYw5xvAswC" Name="Clear Color" Kind="InputPin" />
+            <Pin Id="Sc8cQk3IZRaOnUbZ2n7TEp" Name="Clear" Kind="InputPin" />
+            <Pin Id="KVJl9viA0SeMhMa3rWjP1D" Name="Post Effects" Kind="InputPin" />
+            <Pin Id="O8VLY90YBYWOBbtCBZlpJt" Name="Enable Default Post Effects" Kind="InputPin" />
+            <Pin Id="Vm5aPMWLlaYOsr6Yhvwefu" Name="Render Group Mask" Kind="InputPin" IsHidden="true" />
+            <Pin Id="TefWSN7KfCSMJ8FfkcSW2p" Name="Commands" Kind="InputPin" IsHidden="true" />
+            <Pin Id="U8auYJHfxZePavmwrxgiEA" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
+            <Pin Id="FBHGyZgD4VLNbfouQrHjiI" Name="Model Effect Name" Kind="InputPin" IsHidden="true" />
+            <Pin Id="N0gyhPQkvJeNo0fumJDfCH" Name="Additional Scene Renderers" Kind="InputPin" IsHidden="true" />
+            <Pin Id="VOlpAQUGtAKNKcnKKhIoN6" Name="Enabled" Kind="InputPin" />
+            <Pin Id="M4apJbJOqhgNDo0sn0RcSm" Name="Input Source" Kind="InputPin" IsHidden="true" />
+            <Pin Id="DAV4uvMtv4GLOLlx8eY194" Name="Present Interval" Kind="InputPin" />
+            <Pin Id="JCEur3mm3BiQXRIh8tpVpF" Name="Output" Kind="OutputPin" />
+            <Pin Id="GxQeLXA9L6aPEhsGzTTbTR" Name="Client Bounds" Kind="OutputPin" />
+            <Pin Id="UjYs9ouQA4WMNvKqEopr07" Name="Input Source" Kind="OutputPin" />
+            <Pin Id="J3EcxGjr0AhO5XUk2OAOSF" Name="MSAALevel" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Qy6zOqelSGWMd9vT5PUYp4" Name="MSAAResolver" Kind="InputPin" IsHidden="true" />
+            <Pin Id="AYhnTQ3R3FIPKNM72FsrnI" Name="Light Shafts" Kind="InputPin" IsHidden="true" />
+            <Pin Id="JGQSJKZx929NpHrjjSvIpT" Name="VR Settings" Kind="InputPin" IsHidden="true" />
+            <Pin Id="BVaVYjIl2tOMy4OmV2wNoO" Name="Viewport Settings" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Vqsl1b6IOeGLwfIIoLDLHE" Name="Subsurface Scattering Blur Settings" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Vk5AJQf4tRDLx7ECkWbg9l" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" IsHidden="true" />
+            <Pin Id="DYDf0hZov5KPIXz7XKnwa4" Name="Present Call Intercept" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Kvovley2Kf1NQM434pj7pH" Name="Back Buffer" Kind="OutputPin" IsHidden="true" />
+            <Pin Id="QbzJ7VZGySiPB3bkazwm8X" Name="Depth Buffer" Kind="OutputPin" IsHidden="true" />
+          </Node>
+        </Canvas>
+        <Patch Id="MlJDEAkmWSCNFrBbC1wcnK" Name="Create" />
+        <Patch Id="FH0PMPoKAjCPHHW3NlP1Bj" Name="Update" />
+        <ProcessDefinition Id="ToE10OfOZCtP2nR8PZQL9b">
+          <Fragment Id="Mt8s71QcpWMNqBwTnFOSbo" Patch="MlJDEAkmWSCNFrBbC1wcnK" Enabled="true" />
+          <Fragment Id="Bo3KSHdkhaoPBqnye9XrJH" Patch="FH0PMPoKAjCPHHW3NlP1Bj" Enabled="true" />
+        </ProcessDefinition>
+        <Link Id="VHx2ac8AUFHMnWvbcw1aOc" Ids="PKDYGrWFdnGNJRl7RQ8WMb,CsTkmyswQzpPPhWEoBEseO" />
+        <Link Id="Qxnct7c587wPszVklsyaOv" Ids="RXJyKlXbWORQYTCG1OPxMX,Pic8sHvdl8ANKm6EIIneSC" />
+        <Link Id="OXbShh0n9E5Lds0nSZhEiC" Ids="TEC2boM0rLXNDfs5MvFVPB,DCwdjyrchguNOS9twwaMdC" />
+        <Link Id="LkY0KOUmrkSOOTrwktit28" Ids="UaTZWDMPicSL3QlrvF1UJp,ARMPumrjFJsLmHmaTorkgp" />
+        <Link Id="AcjIkiKpkChOpgb8BqUUdX" Ids="VyL6dBWK067NncquWn8FKD,U4E3TyrGqQ4My4e3YbikCV" />
+        <Link Id="JlnnqhrZoUIN7Q0wzqr00e" Ids="VG1RQI80Je5QR3k4ZiqDG8,CErlOWXNAECLdCErHssa6p" />
+        <Link Id="EA5mdl1PvhdNtSyy6WySfY" Ids="UBNKKtaEU0ALHrm7moEeq4,QJBdga0DUOzLKH1WjqKut0" />
+        <Link Id="AnpMe1f3sjEOYfUq8Lq2dl" Ids="DMTNEiuamu8MJk7QRwQCO2,HigQ7qCGgu3N7fGXM84AS7" />
+        <Link Id="Q3Itdatq57SPDRgOHlkYW5" Ids="N4YhZKHYEMlMdcOF0Wjvn0,KTvdaR3kAQ4NKXs3YieIkY" />
+        <Link Id="RYOi7Hxgd9ZOS276mLiiZH" Ids="LIt2cgHE3VLNNCG7XTwOJi,TsfavvToTdjOgZpXn4BjBT" />
+        <Link Id="U5CMOQQrBVAPXeI4xa1F0d" Ids="ITEEHK6f5A8LALQOwM5fOe,ECVlzaEfh3nL216yHO2vbZ" />
+        <Link Id="PbQ5NmoSUAPNLt7R634nQn" Ids="OrhiFun7LMjMlUx7Qm76yX,IR5VtjjH9pHMZOkXt6JSAi" />
+        <Link Id="NupBvWBIGUMMlXF1OxwmXG" Ids="UBNKKtaEU0ALHrm7moEeq4,GxKY4nCXx99MKixjpC0RRf" />
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="O4cakjMGDhTLmzD7Q9aWkK" Location="VL.Stride" Version="2025.7.0" />
+  <NugetDependency Id="Mcnpcocp0SfPUs1XkgPpcD" Location="VL.Skia" Version="2025.7.0" />
+  <NugetDependency Id="S86t6UtzK7hNhjpwKCEoMr" Location="VL.Stride.TextureFX" Version="2025.7.0" />
+</Document>


### PR DESCRIPTION
# PR Details
Added a WSAD camera that mimicks the camera from Unity Editor (right mousebutton hold + WSADEQ for movement).

## Description

While trying to stay as close as possible to existing cameras (orbit), the addition required changes to base types.
* CameraControls were modified to allow for 3D initial interest delta, which made adaption necessary for OrbitCamera as well. Before, *Interest Delta* was a Vector2 because the OrbitCam only was considering screen space input.
* Camera base type in VL.EditingFramework could not be reused as it contains a movement-speed scalar based on the distance to the *InitialInterest*, which would make camerahandling non-intuitive in this case. I therefore introduced a new *WSADCamera* type in VL.EditingFramework.

## Related Issue



## Motivation and Context
* A WSAD style camera is a useful addition for navigating in a different way
* OrbitCamera is quite limited when it comes to navigating large scenes. This is mainly due to the fact that its *dolly* is actually modifying the distance to the initial interest point, making it difficult to handle when navigating.


## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation

## Up for discussion
* VL.EditingFramework still contains legacy Orbit and Softimage cameras, which are not used any more as far as I can tell. Due to the type change of *Interest delta* in CameraControls, they are broken now. Even though this should be a non-issue, it would make sense either remove the legacy types or update them to keep the library clean of errors.
