### PR TITLE
[Redis] updates StackExchange.Redis nuget to version 2.8.31

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="SkiaSharp" Version="2.88.8" />
     <PackageVersion Include="SkiaSharp.Skottie" Version="2.88.6" />
     <PackageVersion Include="SkiaSharp.Svg" Version="1.60.0" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.7.4" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.31" />
     <PackageVersion Include="MeaMod.DNS" Version="1.0.70" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="Topten.RichTextKit" Version="0.4.167" />


### PR DESCRIPTION
# PR Details

Upadates StackExchange.Redis to version `2.8.31`.

## Motivation and Context

I need to use [_hangfire.io_](https://www.hangfire.io/) to perform some background processing. Hangfire can use Redis as storage. This is facilitated by the [_Hangfire.Redis.StackExchange_](https://github.com/marcoCasamento/Hangfire.Redis.StackExchange) library. This library in turn is based on [_StackExchange.Redis_](https://github.com/StackExchange/StackExchange.Redis).
_Hangfire.Redis.StackExchange_  depends on version `2.8.31`  of _StackExchange.Redis_. VVVV is currently using  `2.7.4` which causes some issues.

I've updated the package and checked all Redis related help patches. Afaict everything is still working as it is suppused to.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation
