### PR TITLE
Fix: Example Compute Shader Instancing with Oversampling

### DIFF
--- a/VL.Stride/help/Models/Example Compute Shader Instancing with Oversampling.vl
+++ b/VL.Stride/help/Models/Example Compute Shader Instancing with Oversampling.vl
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="RE855Gujf1yOn7Zn19aaI0" LanguageVersion="2021.4.0.301" Version="0.128">
-  <NugetDependency Id="TwGk0oqYRM9LNChgwzEPFV" Location="VL.CoreLib" Version="2021.4.0-0268-g1be600c242" />
+<Document xmlns:p="property" xmlns:r="reflection" Id="RE855Gujf1yOn7Zn19aaI0" LanguageVersion="2025.7.0" Version="0.128">
+  <NugetDependency Id="TwGk0oqYRM9LNChgwzEPFV" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="EZnIqZ0z0epNn1cF1kNIqy">
     <Canvas Id="OjqUphNS7lHNHXGqmkgtXs" DefaultCategory="Main" CanvasType="FullCategory">
       <!--
@@ -9,13 +9,13 @@
 
 -->
       <Node Name="PhysicsInstances" Bounds="232,185" Id="Qxp2e0lSSmSNq9zZjenfBr">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="LGB6AbX4BQWNvhkHB65qYq">
           <Canvas Id="DpIV4UQn1n8PX2QeWJ4jUf" CanvasType="Group">
             <Node Bounds="243,496,551,314" Id="SibUTAaUy9BO3xoZe7D72Z">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <CategoryReference Kind="Category" Name="Primitive" />
                 <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
@@ -29,7 +29,7 @@
                 <Patch Id="Ba42Ah0IhL9NLBm3EtqiUD" Name="Update" ManuallySortedPins="true" />
                 <Patch Id="RajXdWWqZ9LQR6bQOHrrc0" Name="Dispose" ManuallySortedPins="true" />
                 <Node Bounds="410,604,46,19" Id="MFuHZ38CceLPxDzTIqzAAA">
-                  <p:NodeReference LastCategoryFullName="Stride.Physics" LastSymbolSource="VL.Stride.Runtime.dll">
+                  <p:NodeReference LastCategoryFullName="Stride.Physics" LastDependency="VL.Stride.Runtime.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="Stride" />
                     <CategoryReference Kind="Category" Name="Physics" />
@@ -51,10 +51,11 @@
                   <Pin Id="OuEiFKMfbANQOUl4FosvCo" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="255,714,145,19" Id="T96rtDq72RwNINuLU1Zf9O">
-                  <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
+                  <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="Entity" />
                   </p:NodeReference>
+                  <Pin Id="KeoS8pbVLRZO8FDZCjIj5n" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="EeNLzL6sdsIPiFHlEzPa2A" Name="Initial Name" Kind="InputPin" />
                   <Pin Id="SeJ98EaMsWJLkaXIHralJU" Name="Base Components" Kind="InputPin" />
                   <Pin Id="Kf9bzjXfLPfPBFV75To6EI" Name="Transformation" Kind="InputPin" />
@@ -64,9 +65,10 @@
                   <Pin Id="G6nosiEP7YFOSE9OmhwCMr" Name="Name" Kind="InputPin" />
                   <Pin Id="M8CgQLrtqbtNpLxiTwDujy" Name="Enabled" Kind="InputPin" />
                   <Pin Id="IUmtjJpR3d3Lk1SzwdX3Hm" Name="Output" Kind="OutputPin" />
+                  <Pin Id="HdZRSyzkwbxNaUkRWPnbTD" Name="Patched Entity" Kind="InputPin" />
                 </Node>
                 <Node Bounds="410,674,45,19" Id="IM0JN11ANjnNImgBGQR9V8">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.Collections.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
                     <Choice Kind="OperationCallFlag" Name="Cons" />
@@ -76,22 +78,23 @@
                   <Pin Id="MFdxASeXky3LADz9LdKKvA" Name="Input 2" Kind="InputPin" />
                 </Node>
                 <Node Bounds="450,642,107,19" Id="UVbloAD5jPwM4gqhVA4wcZ">
-                  <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.Engine.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="InstanceComponent" />
                   </p:NodeReference>
+                  <Pin Id="MqDxjnV4lTjPjfistGlnll" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="CvoKpuR4HaMLcwIX17SxtH" Name="Instancing" Kind="InputPin" />
                   <Pin Id="FF1hJ0oAvT5OWC1LJ5rXlp" Name="Enabled" Kind="InputPin" />
                   <Pin Id="Txw39QuTgTfMRYJ88vu0wA" Name="Component" Kind="OutputPin" />
                 </Node>
                 <Node Bounds="288,530,100,107" Id="MxuUNoVxnbbMn5cHP8DidW">
-                  <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+                  <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                     <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                     <Choice Kind="ApplicationStatefulRegion" Name="If" />
                     <FullNameCategoryReference ID="Primitive" />
                   </p:NodeReference>
                   <Pin Id="TEf17CgVV4TO7x3SxcCbOR" Name="Condition" Kind="InputPin" DefaultValue="True">
-                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                    <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                       <Choice Kind="TypeFlag" Name="Boolean" />
                     </p:TypeAnnotation>
                   </Pin>
@@ -99,7 +102,7 @@
                     <Patch Id="HHWyuckzyoqL5lfPZxGwFP" Name="Create" ManuallySortedPins="true" />
                     <Patch Id="K2GDvHH1gKzNxTTiiuB62L" Name="Then" ManuallySortedPins="true" />
                     <Node Bounds="300,554,67,19" Id="R5jecj3UpJGLZ1DXzPok9c">
-                      <p:NodeReference LastCategoryFullName="3D.Matrix" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="3D.Matrix" LastDependency="CoreLibBasics.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="Translation" />
                       </p:NodeReference>
@@ -107,7 +110,7 @@
                       <Pin Id="HG8C1y0nUk4QPP8JCzw2o8" Name="Result" Kind="OutputPin" />
                     </Node>
                     <Node Bounds="300,589,76,19" Id="CfLLaBX6QncOcsgudEruz6">
-                      <p:NodeReference LastCategoryFullName="3D.Transform" LastSymbolSource="CoreLibBasics.vl">
+                      <p:NodeReference LastCategoryFullName="3D.Transform" LastDependency="CoreLibBasics.vl">
                         <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                         <Choice Kind="OperationCallFlag" Name="UniformScale" />
                         <CategoryReference Kind="Category" Name="Transform" NeedsToBeDirectParent="true">
@@ -123,7 +126,7 @@
                   <ControlPoint Id="If8lLNJIPhWPVPx6RNwHwv" Bounds="327,537" Alignment="Top" />
                 </Node>
                 <Pad Id="UhnT75bfw0UO4F1TGFCJDs" Bounds="425,728,350,52" ShowValueBox="true" isIOBox="true" Value="&lt;- Child Entities: RigidBody and InstanceComponent to instantiate the model of the parent entity">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="String" />
                   </p:TypeAnnotation>
                   <p:ValueBoxSettings>
@@ -132,17 +135,19 @@
                   </p:ValueBoxSettings>
                 </Pad>
                 <Node Bounds="262,758" Id="Uysq6CtIuDGPF4qUuJ5Fyp">
-                  <p:NodeReference LastCategoryFullName="Stride.Physics" LastSymbolSource="VL.Stride.Engine.vl">
+                  <p:NodeReference LastCategoryFullName="Stride.Physics" LastDependency="VL.Stride.Engine.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="ProcessAppFlag" Name="ResetPhysics" />
                   </p:NodeReference>
+                  <Pin Id="JPqhjVxxtBxLJSS5XxY3U0" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="C0zMo27RMC0LPf29MX1JdX" Name="Input" Kind="InputPin" />
                   <Pin Id="ETIzZUcEpPpLszRuW6zPUu" Name="Transformation" Kind="InputPin" />
                   <Pin Id="JWwINbFaiN3PkmmN4wSeHJ" Name="Reset" Kind="InputPin" />
                   <Pin Id="Fqldtd8jfEHO9svLEsbaEa" Name="Output" Kind="OutputPin" />
+                  <Pin Id="UINZMH09VECN8wHAvxp8Im" Name="Order Input" Kind="InputPin" IsHidden="true" />
                 </Node>
                 <Node Bounds="489,683" Id="KWHkw1qCI2iQSKJPZgB7Pk">
-                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                  <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.Collections.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="FromValue" />
                     <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -153,58 +158,60 @@
               </Patch>
             </Node>
             <Node Bounds="300,382,85,19" Id="FwdCFKBXKLYPjaUUl1qvHe">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.Collections.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="RandomSpread (3d)" />
               </p:NodeReference>
+              <Pin Id="EgX1i0nD7zvLEq6Sha1IUV" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="QEirl4b8z5iLWbnmVHhszd" Name="Center" Kind="InputPin" DefaultValue="0, 10, 0">
-                <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Vector3" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="ViVfvQ3uqmwPkOZjfynGYP" Name="Size" Kind="InputPin" />
               <Pin Id="BjGi2Xq7jiQOIGO3pUJ7uc" Name="Seed" Kind="InputPin" />
               <Pin Id="CIzN1fg7BFKNj5TpkCzugE" Name="Count" Kind="InputPin" DefaultValue="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="HUs1aLCmlhpNcHZCTuRqWs" Name="Output" Kind="OutputPin" />
             </Node>
             <Pad Id="HMspTCJN1y3Onpt46djYYk" Comment="Count" Bounds="382,345,35,15" ShowValueBox="true" isIOBox="true" Value="500">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="372,422,85,19" Id="CLc0DvK6v08P0GsANqdiaQ">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.Collections.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="RandomSpread" />
               </p:NodeReference>
+              <Pin Id="GIJa7W9MwdZLU7JGtXShKf" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="Cqdyx7A9wOvOmET0Wfpf2z" Name="Center" Kind="InputPin" DefaultValue="0.3">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="UXZwvKSFnE3MAU3dsMGOsh" Name="Width" Kind="InputPin" DefaultValue="0.2">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Float32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="NWWfPqCBKxvLgg9KE1DMS0" Name="Seed" Kind="InputPin" DefaultValue="20">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="GDzah6Zvg8oPLoSyxEtqKD" Name="Count" Kind="InputPin" DefaultValue="1">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="CK9e0U9kQP5LE74CzIhSXB" Name="Output" Kind="OutputPin" />
             </Node>
             <Pad Id="N088CR9R3sgLa03EyITaVJ" Comment="Size" Bounds="266,304,46,43" ShowValueBox="true" isIOBox="true" Value="2, 20, 2">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
@@ -212,20 +219,21 @@
             <ControlPoint Id="QddDlTGj7C5QI8SE8FoH5M" Bounds="132,418" />
             <ControlPoint Id="TSaD6Xzlp3qQFP1FfKYMue" Bounds="382,301" />
             <Pad Id="NkM5ZnGYPGSPhi4NdQyq09" Comment="Restitution" Bounds="572,470,35,15" ShowValueBox="true" isIOBox="true" Value="0.67">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="130,443,54,19" Id="OFdNdSn09UtLbuL2aarPtb">
-              <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Control" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="OnOpen" />
               </p:NodeReference>
+              <Pin Id="KrCZt3KoUC6MNmFvjEoBB3" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="QotiCF4Ihr7LSz5nt0JzjM" Name="Simulate" Kind="InputPin" />
               <Pin Id="AAIhWvQFIqAMBGVZl2Bhy6" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="494,397,131,19" Id="LSyusppwjgIQa3afr2cPY3">
-              <p:NodeReference LastCategoryFullName="Stride.Physics.ColliderShapes" LastSymbolSource="VL.Stride.Engine.Nodes">
+              <p:NodeReference LastCategoryFullName="Stride.Physics.ColliderShapes" LastDependency="VL.Stride.Engine.Nodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="SphereColliderShapeDesc" />
               </p:NodeReference>
@@ -235,7 +243,7 @@
               <Pin Id="EC3g3V55dQMPVDbtR5Cl0H" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="494,432,65,19" Id="AQU4WFWHsCVPslizGYC2x3">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.Collections.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="FromValue" />
                 <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -296,11 +304,12 @@
         <Patch Id="BlxTkS34Qt0N4Zbsk2xE0p">
           <Canvas Id="CkMOat2ljn1LqMNXNOZFeb" CanvasType="Group">
             <Node Bounds="942,653,147,19" Id="DOO4fGbTEEhOFG53GwTRqF">
-              <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.Engine.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="InstancingBufferComponent" />
               </p:NodeReference>
               <p:HelpFocus p:Assembly="VL.Lang" p:Type="VL.Model.HelpPriority">High</p:HelpFocus>
+              <Pin Id="JI17njCrE39MXyR5K8tCYb" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="MqpVIuwQ8hfNIDpHcdPM4h" Name="Matrices" Kind="InputPin" />
               <Pin Id="CYMDmYoYGKLMDu7wFxpPFc" Name="Inverse Matrices" Kind="InputPin" />
               <Pin Id="QKCQT3t9pHvQLc63nePmbW" Name="Instance Count" Kind="InputPin" />
@@ -310,7 +319,7 @@
               <Pin Id="FHsRdTZqYRuO36dcKquKOy" Name="Component" Kind="OutputPin" />
             </Node>
             <Node Bounds="136,636,194,19" Id="VVqyNWurhwWPZubAsW7gFc">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.ComputeShaders" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering.ComputeShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="HeadSimulationShader" />
               </p:NodeReference>
@@ -326,7 +335,7 @@
               <Pin Id="T28klc1dOgpMfVSvWz8RHb" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="372,302,97,19" Id="CoSOFXuw1PQPwy0nddQ6mZ">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.Utils" LastSymbolSource="VL.Stride.Rendering.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering.Utils" LastDependency="VL.Stride.Rendering.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="QuantizeCount1D" />
               </p:NodeReference>
@@ -335,7 +344,7 @@
               <Pin Id="SKqamVlVfZ5LcIqr9sarsU" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="60,527,92,19" Id="FX7erFk7BDJQA4X1y790pP">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.Nodes">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.Rendering.Nodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="DirectDispatcher" />
               </p:NodeReference>
@@ -343,7 +352,7 @@
               <Pin Id="JYezS4bh0T8NUBbtr0Dbcm" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="60,489,109,19" Id="LJLUTuRu84pOZLQeugnvPe">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.Utils" LastSymbolSource="VL.Stride.Rendering.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering.Utils" LastDependency="VL.Stride.Rendering.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="CalcDispatchArgs1D" />
               </p:NodeReference>
@@ -353,82 +362,107 @@
               <Pin Id="PZjn5SfC4phMD0DPOJcMe5" Name="Thread Group Size" Kind="OutputPin" />
             </Node>
             <Node Bounds="135,770,101,19" Id="LDTsXOrXfkVPL2BCsFvjia">
-              <p:NodeReference LastCategoryFullName="Stride.Utils" LastSymbolSource="VL.Stride.Games.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.Games.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="RendererScheduler" />
               </p:NodeReference>
+              <Pin Id="QPaNO7XxhFGLHeGn6ZMJbr" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="GSXsJVfNz3ENoyNAr6d9vU" Name="Renderer" Kind="InputPin" />
               <Pin Id="MJzQKeNFLj7Oby3tg8I8pf" Name="Output" Kind="OutputPin" />
             </Node>
             <Pad Id="PbtAz5MhlN4Pk5gcQIHixG" Comment="Particle Count" Bounds="466,275,35,15" ShowValueBox="true" isIOBox="true" Value="64">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="942,439,85,19" Id="RsxEXO4dfVgOjz0jl1waH5">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastSymbolSource="VL.Stride.Graphics.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.Graphics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ComputeBuffer" />
               </p:NodeReference>
+              <Pin Id="BoQec1wnZLWMTuhirch14F" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="UR6Acwydev1P49REkff0SW" Name="Element Count" Kind="InputPin" />
               <Pin Id="N98x9tBo77aNlhhcUWm7Fg" Name="Element Size In Bytes" Kind="InputPin" />
+              <Pin Id="SRzgBAaJaJcPbpspVgNQ2k" Name="Initial Data" Kind="InputPin" IsHidden="true" />
+              <Pin Id="JF07ew2WXZvLub7KNAEg2y" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
+              <Pin Id="SXEABTI7P71NMHQ8kNbiMf" Name="Structured Buffer Type" Kind="InputPin" IsHidden="true" />
+              <Pin Id="RrFJgYOUQmROF5TDcQ7q5b" Name="Is Stream Output" Kind="InputPin" IsHidden="true" />
+              <Pin Id="GMlNtjV0zOAOBjf5ssTDMm" Name="Allow Raw Views" Kind="InputPin" IsHidden="true" />
               <Pin Id="Dah4IbQ9a2QNYgy3aTkJ2E" Name="Recreate" Kind="InputPin" />
               <Pin Id="PAaIFZjuyCfLP8st9nfGCV" Name="Output" Kind="OutputPin" />
               <Pin Id="A1xb1HrVqkHOvPoCVp7XBj" Name="Has Changed" Kind="OutputPin" />
             </Node>
             <Node Bounds="1058,439,85,19" Id="FBV7BkaOXKQNPQONraAXo6">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastSymbolSource="VL.Stride.Graphics.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.Graphics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ComputeBuffer" />
               </p:NodeReference>
+              <Pin Id="PXOSrHgbxzoPKUCkfwuSU5" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="VZafYS7oZycQaR35XGiuH2" Name="Element Count" Kind="InputPin" />
               <Pin Id="Fr6qhThTDHwNXQbQ294Ni0" Name="Element Size In Bytes" Kind="InputPin" />
+              <Pin Id="OODLYJbTJ4YNt6GsqWehyx" Name="Initial Data" Kind="InputPin" IsHidden="true" />
+              <Pin Id="NfCteO74RT5PGVl3bGIguI" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
+              <Pin Id="Ruc4VUFVHoUN42XOgP3qFH" Name="Structured Buffer Type" Kind="InputPin" IsHidden="true" />
+              <Pin Id="Vw0czZyWEl1LbRebtYhJ5g" Name="Is Stream Output" Kind="InputPin" IsHidden="true" />
+              <Pin Id="EehNiZ7bBfQQNKZyr3HOvR" Name="Allow Raw Views" Kind="InputPin" IsHidden="true" />
               <Pin Id="QxdqDQfpFcDLX734247D2Y" Name="Recreate" Kind="InputPin" />
               <Pin Id="EkYFiy0oKigQS8ZcbPyZjn" Name="Output" Kind="OutputPin" />
               <Pin Id="RvjJq6AnMz0PnCEUp4vY0i" Name="Has Changed" Kind="OutputPin" />
             </Node>
             <Pad Id="S5xOYZDtTJfLFShs3VIMxQ" Comment="Matrix = 16x4 bytes" Bounds="1101,373,35,15" ShowValueBox="true" isIOBox="true" Value="64">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="522,436,85,19" Id="NIQbrgBiH1PPggTaZS1ZFn">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastSymbolSource="VL.Stride.Graphics.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.Graphics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ComputeBuffer" />
               </p:NodeReference>
+              <Pin Id="PMEIEaiJbmVM7z5fmphxRN" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="T8MD0XaDXToNxbYhIoJ80y" Name="Element Count" Kind="InputPin" />
               <Pin Id="BleNtT9h4ubLfsBaXu1bfg" Name="Element Size In Bytes" Kind="InputPin" />
+              <Pin Id="VVtqt89bDfAOIjzUNwBlI5" Name="Initial Data" Kind="InputPin" IsHidden="true" />
+              <Pin Id="B76YXTepNhhOaaFpoXfXLT" Name="Is Unordered Access" Kind="InputPin" IsHidden="true" />
+              <Pin Id="UjQCPMSd0pSOPB1CD0HRhJ" Name="Structured Buffer Type" Kind="InputPin" IsHidden="true" />
+              <Pin Id="P3reW0C1NXRQOhKTKvAswh" Name="Is Stream Output" Kind="InputPin" IsHidden="true" />
+              <Pin Id="RoOFkYp13c8NUmtIWg8K8P" Name="Allow Raw Views" Kind="InputPin" IsHidden="true" />
               <Pin Id="IcmdWfgBS9cOL3NUE8y5Yi" Name="Recreate" Kind="InputPin" />
               <Pin Id="Sp9AJ39Rfp6LXS33kga7tI" Name="Output" Kind="OutputPin" />
               <Pin Id="GtmVLSjeOkRPYpSyn2QZco" Name="Has Changed" Kind="OutputPin" />
             </Node>
             <Pad Id="DBl57x9wcSTN0OlOX5LQsR" Comment="TrailHead = 12x4 bytes" Bounds="564,401,35,15" ShowValueBox="true" isIOBox="true" Value="48">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="251,438,92,19" Id="QQwePVVszemOTIw32aQkPp">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastSymbolSource="VL.Stride.Graphics.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.Graphics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ImmutableBuffer" />
               </p:NodeReference>
+              <Pin Id="Uk095koFhVPP4izTmvOxLe" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="N6h5AQI4T4nOOU1WtnhdiM" Name="Initial Data" Kind="InputPin" />
               <Pin Id="NCnx656E9MJNY2qlX3hShc" Name="Element Size In Bytes" Kind="InputPin" />
+              <Pin Id="VXF9InXhj8uLP3b7O20qKX" Name="Is Structured Buffer" Kind="InputPin" IsHidden="true" />
+              <Pin Id="Br7mqt3lw3IP5z2zLGZaoL" Name="Is Vertex Buffer" Kind="InputPin" IsHidden="true" />
+              <Pin Id="S6luItJqM3rPsQ7S0DIocg" Name="Is Index Buffer" Kind="InputPin" IsHidden="true" />
+              <Pin Id="AJH1te405vkOOYYcypwruo" Name="Allow Raw Views" Kind="InputPin" IsHidden="true" />
               <Pin Id="VULsGGoq5KIMnOxqM9hXWV" Name="Recreate On Inital Data Change" Kind="InputPin" />
               <Pin Id="UYk5zII7lwqOTQzypIrc36" Name="Recreate" Kind="InputPin" />
               <Pin Id="NgJrtVNUKgWM250Eo8u6p4" Name="Output" Kind="OutputPin" />
               <Pin Id="MN05ulIoJvdLWESwEHcP8Z" Name="Has Changed" Kind="OutputPin" />
             </Node>
             <Node Bounds="251,404,85,19" Id="IVO8TRpVmySLO9CinzaKlp">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.Collections.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="RandomSpread (4d)" />
               </p:NodeReference>
+              <Pin Id="O8vxGPT5W3UK93QWC7GFOc" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="AXFFqyjNGblPb0D7VtV3Mh" Name="Center" Kind="InputPin" />
               <Pin Id="NNlblDSrgPEN9xcyqEmAhP" Name="Size" Kind="InputPin" />
               <Pin Id="CNqJQoV0L5WMxJzaUKTwqB" Name="Seed" Kind="InputPin" DefaultValue="24">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Integer32" />
                 </p:TypeAnnotation>
               </Pin>
@@ -436,7 +470,7 @@
               <Pin Id="JbAnZjtqzS7MkJKNc0yk6j" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="1122,588,68,26" Id="DgTyXEzuunePyv19hdxUC0">
-              <p:NodeReference LastCategoryFullName="3D.AlignedBox" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="3D.AlignedBox" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="RecordType" Name="AlignedBox" />
                 <Choice Kind="OperationCallFlag" Name="AlignedBox (Join)" />
@@ -446,17 +480,17 @@
               <Pin Id="RTsvsBQU60PP3tNiySlOa8" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Pad Id="L9CXCpuVU9cP8CrSstzBTI" Comment="Minimum" Bounds="1082,531,35,43" ShowValueBox="true" isIOBox="true" Value="-5, -5, -5">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="QznrrmAfeFTLaqTK8Lm5hP" Comment="Maximum" Bounds="1206,532,35,43" ShowValueBox="true" isIOBox="true" Value="5, 5, 5">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="447,635,274,19" Id="U3VWvTlUdcDNuwzehl2imk">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.ComputeShaders" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering.ComputeShaders" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="TrailTransformationsShader" />
               </p:NodeReference>
@@ -471,19 +505,20 @@
               <Pin Id="RG8UxIdc8uBLbfPk2BrGti" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="135,725,44,19" Id="EfczllFHXoHLUNeb8vd56c">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.Rendering.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="Group" />
                 <CategoryReference Kind="Category" Name="Rendering" NeedsToBeDirectParent="true">
                   <p:OuterCategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
                 </CategoryReference>
               </p:NodeReference>
+              <Pin Id="SmF7xSvm4ZbLuO1aNfUkUA" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="VauVn8B0PghLa2sR1TAuqy" Name="Input" Kind="InputPin" />
               <Pin Id="AtMeccHy2U8L9k22qFawkb" Name="Input 2" Kind="InputPin" />
               <Pin Id="TQdY3e2GCQrNmcju3E3AWr" Name="Output" Kind="OutputPin" />
             </Node>
             <Node Bounds="997,330,25,19" Id="MkT8sWSW20nNWY2lk4pFPa">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="*" />
               </p:NodeReference>
@@ -492,18 +527,19 @@
               <Pin Id="V8bXBAoVt94QRFJM08UYn8" Name="Output" Kind="OutputPin" />
             </Node>
             <Pad Id="HN2xPhz5dRsLBzOKv3xHGz" Comment="Trail Length" Bounds="872,220,35,15" ShowValueBox="true" isIOBox="true" Value="1024">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="764,538,81,19" Id="Nzym9mUshJ8L7UAxjYrICy">
-              <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="FrameCounter" />
                 <CategoryReference Kind="Category" Name="FrameBased" NeedsToBeDirectParent="true" />
               </p:NodeReference>
+              <Pin Id="ETXymTymWkjMURGdgPnpxE" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="TAY4Y2eNxodLX1kr0yMkDM" Name="Count" Kind="ApplyPin" DefaultValue="True">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="Boolean" />
                 </p:TypeAnnotation>
               </Pin>
@@ -511,7 +547,7 @@
               <Pin Id="Nogf229kYD6Laz93xhJKcW" Name="Value" Kind="OutputPin" />
             </Node>
             <Node Bounds="764,583,39,19" Id="Emheaazky2dLcObfTzCOEm">
-              <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+              <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="MOD" />
               </p:NodeReference>
@@ -525,12 +561,12 @@
               </p:ValueBoxSettings>
             </Pad>
             <Pad Id="Mta7CRWl3JrOnHWoy2TJyw" Comment="Thread Group Size" Bounds="170,251,35,15" ShowValueBox="true" isIOBox="true" Value="64">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="IDeqiKsfdPkNsiehk9GMVl" Bounds="143,678,123,19" ShowValueBox="true" isIOBox="true" Value="Head Simulation">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -539,7 +575,7 @@
               </p:ValueBoxSettings>
             </Pad>
             <Pad Id="VC6EX4eA9oLNHvz8T4w89s" Bounds="471,676,212,21" ShowValueBox="true" isIOBox="true" Value="Trail and copy to instance buffers">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -548,7 +584,7 @@
               </p:ValueBoxSettings>
             </Pad>
             <Pad Id="EugwTFf0IfuLTR0CAlIdoA" Bounds="611,442,61,19" ShowValueBox="true" isIOBox="true" Value="Heads">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -557,7 +593,7 @@
               </p:ValueBoxSettings>
             </Pad>
             <Pad Id="PRRiSV2aZSRMYR1JWsywWf" Bounds="355,446,100,19" ShowValueBox="true" isIOBox="true" Value="Random values">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -567,7 +603,7 @@
             </Pad>
             <ControlPoint Id="R2dSLAqTuPhN7C70ItOZ8k" Bounds="944,714" />
             <Pad Id="QQD7w1RwoJHOpyyjDX78et" Bounds="1152,446,161,19" ShowValueBox="true" isIOBox="true" Value="Instance Transformations">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -577,7 +613,7 @@
             </Pad>
             <Pad Id="PKZFHHymq7GORySVWVzIJx" Comment="" Bounds="766,640,35,15" ShowValueBox="true" isIOBox="true" />
             <Pad Id="SzWghODw4qRNuHsPF9452z" Bounds="511,743,148,84" ShowValueBox="true" isIOBox="true" Value="0 = free flow&#xD;&#xA;1 = flow in planes&#xD;&#xA;2 = 45° angles&#xD;&#xA;3 = 90° angles">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -586,7 +622,7 @@
               </p:ValueBoxSettings>
             </Pad>
             <Node Bounds="371,920,52,19" Id="FxAmjxK9WrrQTRYt1CkaVw">
-              <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.Collections.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="GetSlice" />
                 <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -597,7 +633,7 @@
               <Pin Id="PQEQoFFHCX9M4Y5vgbklnG" Name="Result" Kind="OutputPin" />
             </Node>
             <Pad Id="RshrRuvdeoYMRJDIfw0hqW" Comment="" Bounds="460,770,35,29" ShowValueBox="true" isIOBox="true" Value="2">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Integer32" />
               </p:TypeAnnotation>
               <p:ValueBoxSettings>
@@ -605,10 +641,10 @@
               </p:ValueBoxSettings>
             </Pad>
             <Pad Id="H6FbUAhDMv8OXU0WP3YW7K" Comment="Mass" Bounds="370,795,35,80" ShowValueBox="true" isIOBox="true" Value="3, 3, 0.42, 0.5">
-              <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.Collections.vl">
                 <Choice Kind="TypeFlag" Name="Spread" />
                 <p:TypeArguments>
-                  <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                  <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </TypeReference>
                 </p:TypeArguments>
@@ -619,10 +655,11 @@
             </Pad>
             <ControlPoint Id="Moa27rPkPQCNsRDbnyUFU8" Bounds="460,719" />
             <Node Bounds="779,947,225,19" Id="QzoMBd4s24fMWesDiucpIu">
-              <p:NodeReference LastCategoryFullName="Stride.Materials" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Materials" LastDependency="VL.Stride.Rendering.ShaderFX.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="PBRMaterial (Metallic)" />
               </p:NodeReference>
+              <Pin Id="P0RGRM7WmQJMTERZ0MIlDm" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="Kk5GS3LFF6DPNAPO2XJ7OU" Name="Diffuse" Kind="InputPin" />
               <Pin Id="Vhbc2qw8UOzPRKmnqHo3nN" Name="Metalness" Kind="InputPin" />
               <Pin Id="EIyLe9jsGpTLWP92Ns8UwT" Name="Roughness" Kind="InputPin" />
@@ -635,37 +672,22 @@
               <Pin Id="Hfgq85klh07OrYLOX7Qr6q" Name="Transparency" Kind="InputPin" />
               <Pin Id="UYjigSgUFU4O1vMUCuSaN8" Name="Layers" Kind="InputPin" />
               <Pin Id="J54ed9vB4QFOUUIkJipuC1" Name="Cull Mode" Kind="InputPin" />
+              <Pin Id="Ih12i8GJvrGOV0QCHpg9az" Name="State Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="QDSPrKe9ZkzNTfsuOjZSkT" Name="Output" Kind="OutputPin" />
             </Node>
             <ControlPoint Id="Ctr36FZPjmVOCZmsiLmsoF" Bounds="781,1000" />
-            <Node Bounds="799,876,50,19" Id="Vgnj0RivqTDPUWcxLwbslj">
-              <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="ValueIn" />
-              </p:NodeReference>
-              <Pin Id="SCDSYkgyYg5NXAP1LcmupH" Name="Value" Kind="InputPin" />
-              <Pin Id="AOsdYaZyLw5ORH2B2D2cBc" Name="Output" Kind="OutputPin" />
-            </Node>
-            <Node Bounds="871,892,50,19" Id="VfscUwzKIZ2O2NC9AnAdji">
-              <p:NodeReference LastCategoryFullName="Stride.Materials.Inputs" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
-                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                <Choice Kind="ProcessAppFlag" Name="ValueIn" />
-              </p:NodeReference>
-              <Pin Id="ODHjwvbiBENLfaj5r52hOF" Name="Value" Kind="InputPin" />
-              <Pin Id="SbNFoSYwzJGPzMfnvB0UtT" Name="Output" Kind="OutputPin" />
-            </Node>
             <Pad Id="LeiriJTilCyLIy9SjLwRI5" Comment="Roughness" Bounds="873,872,35,15" ShowValueBox="true" isIOBox="true" Value="0.94">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
             <Pad Id="OM9ZWx4hCktLJhW6mU63Nc" Comment="Metalness" Bounds="801,832,35,15" ShowValueBox="true" isIOBox="true" Value="0.09999999">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pad>
             <Node Bounds="778,765,108,19" Id="RTaRJGIyOEiOSR6NkqwfSe">
-              <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+              <p:NodeReference LastCategoryFullName="Stride.Rendering.ShaderFX" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessNode" Name="ColorFromTrailHead" />
               </p:NodeReference>
@@ -675,22 +697,27 @@
             </Node>
             <ControlPoint Id="TO9XgmsNpGUPn11BLOiGFh" Bounds="857,575" />
             <Node Bounds="-102,711,92,19" Id="T8aHY2wXLldNx5SNCGUXsV">
-              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastSymbolSource="VL.Stride.Graphics.vl">
+              <p:NodeReference LastCategoryFullName="Stride.Buffers" LastDependency="VL.Stride.Graphics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ImmutableBuffer" />
               </p:NodeReference>
+              <Pin Id="KoySnJpRSNyMgFPv8PzjQI" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="UmBl3SFeruYMsQVwoTBBYy" Name="Initial Data" Kind="InputPin" />
               <Pin Id="OoO6akfyrqSLogpDcKVpDH" Name="Element Size In Bytes" Kind="InputPin" />
+              <Pin Id="GczJZ1OouHiOJaUN3qHU2J" Name="Is Structured Buffer" Kind="InputPin" IsHidden="true" />
+              <Pin Id="I0vurAiaKQpNGqyd1i5VH4" Name="Is Vertex Buffer" Kind="InputPin" IsHidden="true" />
+              <Pin Id="AktaCUXyjklLGaAH8GIAgx" Name="Is Index Buffer" Kind="InputPin" IsHidden="true" />
+              <Pin Id="CCLJJxUVM1PNaMnv9eU3cm" Name="Allow Raw Views" Kind="InputPin" IsHidden="true" />
               <Pin Id="LwS49uiKcjPPZTtZovgQlt" Name="Recreate On Inital Data Change" Kind="InputPin" />
               <Pin Id="Q42lPnpSsiBNeRltn9OSTT" Name="Recreate" Kind="InputPin" />
               <Pin Id="MhE5VvShtr1LAQJnB8LyKf" Name="Output" Kind="OutputPin" />
               <Pin Id="MkPfk3eoE93OUze4t76Oc2" Name="Has Changed" Kind="OutputPin" />
             </Node>
             <Pad Id="VGV7NIeed6SN1GooDYomj5" Comment="Colors" Bounds="-100,628,136,65" ShowValueBox="true" isIOBox="true">
-              <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.Collections.vl">
                 <Choice Kind="TypeFlag" Name="Spread" />
                 <p:TypeArguments>
-                  <TypeReference LastCategoryFullName="Color" LastSymbolSource="CoreLibBasics.vl">
+                  <TypeReference LastCategoryFullName="Color" LastDependency="CoreLibBasics.vl">
                     <Choice Kind="TypeFlag" Name="RGBA" />
                   </TypeReference>
                 </p:TypeArguments>
@@ -701,6 +728,15 @@
                 <Item>1, 1, 1, 1</Item>
               </p:Value>
             </Pad>
+            <Node Bounds="779,880,52,19" Id="E30CglMqIV6M7Xo30iJ4ym">
+              <p:NodeReference LastCategoryFullName="Stride.Utils" LastDependency="VL.Stride.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <FullNameCategoryReference ID="Stride.Utils" />
+                <Choice Kind="ProcessNode" Name="Convert (Vector4ToRGBA)" />
+              </p:NodeReference>
+              <Pin Id="TVpqhL8qMPiLzT1SZfdX1i" Name="Value" Kind="InputPin" />
+              <Pin Id="Hwjy20vOldmOFlR8xo9fRr" Name="Output" Kind="OutputPin" />
+            </Node>
           </Canvas>
           <ProcessDefinition Id="TRj1xS76ZCOOKAtNPGdaUu">
             <Fragment Id="S9YfmYEhmB2QVoV611bzn7" Patch="G3GTL7Y9RW4LM0bjYVWQTX" Enabled="true" />
@@ -761,15 +797,14 @@
             <Pin Id="VXxb3hbosY4NNq5xdtKhe4" Name="Material" Kind="OutputPin" Bounds="557,983" />
             <Pin Id="DUGoS0fXhz1MQ5K9xRGoBQ" Name="Instancing Component" Kind="OutputPin" Bounds="1197,820" />
           </Patch>
-          <Link Id="G4KLznVYxz4MTl5JGqN3BK" Ids="AOsdYaZyLw5ORH2B2D2cBc,Vhbc2qw8UOzPRKmnqHo3nN" />
-          <Link Id="FESwQQ7svNaMXohRXOzzqr" Ids="SbNFoSYwzJGPzMfnvB0UtT,EIyLe9jsGpTLWP92Ns8UwT" />
-          <Link Id="QKMI9a2hYGiOPctTWF85yq" Ids="LeiriJTilCyLIy9SjLwRI5,ODHjwvbiBENLfaj5r52hOF" />
-          <Link Id="BWT3X8rRgszLsRyq3GVka5" Ids="OM9ZWx4hCktLJhW6mU63Nc,SCDSYkgyYg5NXAP1LcmupH" />
           <Link Id="VfuQ8FDuJQrOW3WIs7ns9j" Ids="HN2xPhz5dRsLBzOKv3xHGz,DMZRdpN73gNPHpEtLDB1ir" />
-          <Link Id="Bx1B6j874DrOmHRrTbBIFh" Ids="LVdwiBPjy2zL2E84AyBltV,Kk5GS3LFF6DPNAPO2XJ7OU" />
           <Link Id="MuqL6W00C3NMhIn7XihJT8" Ids="Sp9AJ39Rfp6LXS33kga7tI,EKm31rCjdi2P89v3EjbMF3" />
           <Link Id="CIMl9Cwkhq2ODU7NfCCoWH" Ids="VGV7NIeed6SN1GooDYomj5,UmBl3SFeruYMsQVwoTBBYy" />
           <Link Id="URuFWOoCUmULuh5V4cx9rQ" Ids="MhE5VvShtr1LAQJnB8LyKf,JlQu7GRe13APTNOAzld9pl" />
+          <Link Id="Akt721ZBXMaOOXlnsw4fJc" Ids="OM9ZWx4hCktLJhW6mU63Nc,Vhbc2qw8UOzPRKmnqHo3nN" />
+          <Link Id="FMYOcIe9tbUOryuBJUJF39" Ids="LeiriJTilCyLIy9SjLwRI5,EIyLe9jsGpTLWP92Ns8UwT" />
+          <Link Id="DyoXmCp0EjIQDA06ifkaCJ" Ids="LVdwiBPjy2zL2E84AyBltV,TVpqhL8qMPiLzT1SZfdX1i" />
+          <Link Id="LTWnPXOoRUtPpGfzxMtGXa" Ids="Hwjy20vOldmOFlR8xo9fRr,Kk5GS3LFF6DPNAPO2XJ7OU" />
         </Patch>
       </Node>
     </Canvas>
@@ -786,31 +821,34 @@
       <Patch Id="PfVqWprw842PxGv9YZwzKZ">
         <Canvas Id="SnecRzN0V1MMBAkcocz2Xe" CanvasType="Group">
           <Node Bounds="290,583,65,19" Id="Otqh9wYoaL3MSd9aJtju4F">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="Category" Name="Stride" NeedsToBeDirectParent="true" />
               <Choice Kind="ProcessAppFlag" Name="RootScene" />
             </p:NodeReference>
+            <Pin Id="Bu3i7zj4Ci2PtVAcwk5HYt" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="KnEybTT42GwQLrWbC0QOAg" Name="Child" Kind="InputPin" />
             <Pin Id="CfgQZg2dgZAMKdrumb5fvZ" Name="Child 2" Kind="InputPin" />
             <Pin Id="F1oXx1N5GY5OPrC6nRhW5f" Name="Child 3" Kind="InputPin" />
+            <Pin Id="OpDdR4IcDUDOT2xA3vtdXn" Name="Child Scenes" Kind="InputPin" IsHidden="true" />
             <Pin Id="Bdfk6W5BbCRNIW64O4yyjz" Name="Enabled" Kind="InputPin" />
             <Pin Id="OH5Fl8xuLVtPbCSWwJvfIV" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="310,471,185,19" Id="Alt2RtJi7VtMFw6ookaoN1">
-            <p:NodeReference LastCategoryFullName="Stride.Lights" LastSymbolSource="VL.Stride.Engine.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="DirectionalLight" />
             </p:NodeReference>
+            <Pin Id="MkOV0JcLqcLOKDCkKNK7Aj" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="PaR3GznFrfwNGH5j6uDr3j" Name="Position" Kind="InputPin" DefaultValue="3, 1.69, 1.08">
-              <p:TypeAnnotation LastCategoryFullName="3D" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Vector3" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="VyjfKswtQkxNE30yT2ZmKH" Name="Target" Kind="InputPin" />
             <Pin Id="Qgz7XEJn2JsNRkz72SMGqG" Name="Color" Kind="InputPin" />
             <Pin Id="K5JhFRropbEO0yAOQAPqZ5" Name="Intensity" Kind="InputPin" DefaultValue="5">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -820,22 +858,25 @@
             <Pin Id="Q951Im5dg7aPsgGOcYTwLw" Name="Children" Kind="InputPin" />
             <Pin Id="FHb0joGiYw1PLD6lwAdK0s" Name="Name" Kind="InputPin" />
             <Pin Id="OQAPZRkH5XpMchtj3FAw4l" Name="Enabled" Kind="InputPin" />
+            <Pin Id="VfuIJjC2RLKO5hpennblwj" Name="Output" Kind="OutputPin" IsHidden="true" />
             <Pin Id="VodrPNTV2Z4P0yDRBJ4Msj" Name="Entity" Kind="OutputPin" />
+            <Pin Id="BQnjn8JHRo0OlRtF2GhTKo" Name="Show Helper" Kind="InputPin" IsHidden="true" />
           </Node>
           <Node Bounds="330,546,245,19" Id="B9XLJa2lDKaO7glQYcfHmH">
-            <p:NodeReference LastCategoryFullName="Stride.Lights" LastSymbolSource="VL.Stride.Engine.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Lights" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SkyboxLight" />
             </p:NodeReference>
+            <Pin Id="Mvt36bKtl5ML6Knii3oYYO" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="Ol4sqcS9HxVMZ4pt1EGkQK" Name="Transformation" Kind="InputPin" />
             <Pin Id="Uznvw7xgu7aNSAhtfm9rl7" Name="Cube Map" Kind="InputPin" />
             <Pin Id="HsE0GmXtCB7MVE7QuSXFl9" Name="Is Specular Only" Kind="InputPin" DefaultValue="False">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="VfsLtLemgoNNWBfpzOR57a" Name="Intensity" Kind="InputPin" DefaultValue="0.5">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -843,12 +884,12 @@
             <Pin Id="Lelnl6NwmkvL6ZF9P1qChK" Name="Specular Cube Map Size" Kind="InputPin" />
             <Pin Id="Tkd6veOWuSLLEAzC2cawjA" Name="Force Build" Kind="InputPin" />
             <Pin Id="QhYq1PWUrOdPhmRyRCjSxJ" Name="Background Intensity" Kind="InputPin" DefaultValue="0.12">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="MhnXAXYmOllMkx06kqIfen" Name="Background Enabled" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
@@ -856,68 +897,76 @@
             <Pin Id="U7SFn7flvDuMOeoqC0UPwY" Name="Children" Kind="InputPin" />
             <Pin Id="Ijl2rbumHlfNXYooiP6lft" Name="Name" Kind="InputPin" />
             <Pin Id="TmVC26lMeKuMQm44XRarze" Name="Enabled" Kind="InputPin" />
+            <Pin Id="SPEsvYC04AlPzb0fJsEKXU" Name="Output" Kind="OutputPin" IsHidden="true" />
             <Pin Id="Km290vZCGlfNQvmYbpR2IN" Name="Entity" Kind="OutputPin" />
           </Node>
           <Node Bounds="290,384,165,19" Id="K3GHUSe8TfzMyOonnwHZhA">
-            <p:NodeReference LastCategoryFullName="Stride.Models" LastSymbolSource="VL.Stride.Engine.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Box" />
             </p:NodeReference>
+            <Pin Id="QjPkVrD1MLBPN7Jh8vcY9S" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="NiWyQOk9kM7LCe2CUmMI1l" Name="Transformation" Kind="InputPin" />
             <Pin Id="HzVWhDQraaQNOB71H3gV0R" Name="Size" Kind="InputPin" />
+            <Pin Id="EoGaANLC2F5LI2DZEXtYeg" Name="Tessellation" Kind="InputPin" />
             <Pin Id="FBvFgGphy6qPi8C3ZSNZnu" Name="Material" Kind="InputPin" />
             <Pin Id="KUOeBicbexHLfa9QGLCs8y" Name="Is Shadow Caster" Kind="InputPin" />
             <Pin Id="OdpSxt0TqeVMr5yaGUUXOx" Name="Components" Kind="InputPin" />
             <Pin Id="UlA4UiuaEaUNKCv39JqLoF" Name="Children" Kind="InputPin" />
             <Pin Id="EidoCVFyRWILAjhqh2dFoS" Name="Name" Kind="InputPin" />
             <Pin Id="BKkUIYcadgfQJqk8pWFZ4j" Name="Enabled" Kind="InputPin" />
+            <Pin Id="TAlAt3wB4dLPCxPBsdkPta" Name="Output" Kind="OutputPin" IsHidden="true" />
             <Pin Id="JRH9wrffwOKQSi9MMls3lB" Name="Entity" Kind="OutputPin" />
           </Node>
-          <Node Bounds="624,680,185,19" Id="JtHCwwOr7LqNr5XzwaluB9">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
+          <Node Bounds="624,680,225,19" Id="JtHCwwOr7LqNr5XzwaluB9">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="PostFX" />
             </p:NodeReference>
+            <Pin Id="GrYMDLpe0rNN95Bo5CWBpO" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="PiUgvkWAvxNL7OmrKxM4JQ" Name="Ambient Occlusion" Kind="InputPin" />
             <Pin Id="RncnB7ULLP1PLD0UrXZaxh" Name="Local Reflections" Kind="InputPin" />
             <Pin Id="Vs1J3ELieSRMQ6U5GOPLOT" Name="Depth Of Field" Kind="InputPin" />
+            <Pin Id="Uaos3A83Th3Pkhs54SaVDp" Name="Fog" Kind="InputPin" />
+            <Pin Id="Hc5U1PODp3mP1nA4SbVzlB" Name="Outline" Kind="InputPin" />
             <Pin Id="TeEchnQzoo2N2qwozx9Bhy" Name="Bright Filter" Kind="InputPin" />
             <Pin Id="KjrrVbLIjQEN4KXbSXwA4G" Name="Bloom" Kind="InputPin" />
             <Pin Id="Isejs5W7I6yM3BqVY6S3YF" Name="Light Streak" Kind="InputPin" />
             <Pin Id="HzA6ieh5B6rMDq5W3hHTYv" Name="Lens Flare" Kind="InputPin" />
             <Pin Id="JvQZJO5be6EMbUcuHQ18GR" Name="Color Transforms" Kind="InputPin" />
             <Pin Id="M8ulyKWfravLliPSGF9Xzz" Name="Enable Default ToneMap" Kind="InputPin" DefaultValue="True">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Boolean" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="FdMX0jraBiBPUQnlVfZGRE" Name="Antialiasing" Kind="InputPin" />
+            <Pin Id="VGVZUTQuXA7N9Yr1qhkk4I" Name="State Output" Kind="OutputPin" IsHidden="true" />
             <Pin Id="MCPtOfFWj91QZQyl1R64xu" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="624,541,185,19" Id="SV4bfFccVKKNW4PthEyQAV">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Rendering.Nodes">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastDependency="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="AmbientOcclusion" />
               <CategoryReference Kind="Category" Name="PostFX" NeedsToBeDirectParent="true" />
             </p:NodeReference>
             <Pin Id="FH0Ko4phsxwMDBqRD0f2fP" Name="Samples" Kind="InputPin" />
             <Pin Id="Q3cn9fGjsOGOuyhAfZy3aZ" Name="Projection Scale" Kind="InputPin" DefaultValue="0.09999999">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="KKrQrmyVfeWMyPXHKiq2AT" Name="Intensity" Kind="InputPin" DefaultValue="0.5">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="CCho7F6o1IJOyGH02glNRN" Name="Sample Bias" Kind="InputPin" DefaultValue="0.05">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="KTUzu53bUjILMXkrQJQ1iW" Name="Sample Radius" Kind="InputPin" DefaultValue="1.13">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -929,14 +978,14 @@
             <Pin Id="SqM0yQVfubtOZfqJT65g5a" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="704,580,125,19" Id="HVWX0AV1l37P5f5or0Z805">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Rendering.Nodes">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastDependency="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Bloom" />
               <CategoryReference Kind="Category" Name="PostFX" NeedsToBeDirectParent="true" />
             </p:NodeReference>
             <Pin Id="LAb1bIPtZEoNcTcFjg3csG" Name="Radius" Kind="InputPin" />
             <Pin Id="EPadTtRlwg7Nu3sM1fbXH6" Name="Amount" Kind="InputPin" DefaultValue="0.21">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -948,19 +997,19 @@
             <Pin Id="GHTFkYiUhX3Nglj7pl4DLf" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="724,622,125,19" Id="KHYag6jHFSfQL0rB0reNKW">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastSymbolSource="VL.Stride.Rendering.Nodes">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering.PostFX" LastDependency="VL.Stride.Rendering.Nodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LightStreak" />
               <CategoryReference Kind="Category" Name="PostFX" NeedsToBeDirectParent="true" />
             </p:NodeReference>
             <Pin Id="LMP8zDlzvzfO8tbYjdCMrd" Name="Amount" Kind="InputPin" DefaultValue="0.21">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="OkLr1aUSH9uLZTgXV4yFWS" Name="Streaks" Kind="InputPin" />
             <Pin Id="LvWuq6WgyDgObutEJDfUB7" Name="Attenuation" Kind="InputPin" DefaultValue="0.69">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
@@ -971,44 +1020,48 @@
             <Pin Id="SMeppcyuKZnMovxvVb41nw" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="350,507,105,19" Id="GBHroToVxKgOqS5FEpJNIs">
-            <p:NodeReference LastCategoryFullName="Stride.Textures.Source" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+            <p:NodeReference LastCategoryFullName="Stride.Textures.Source" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessNode" Name="Gradient" />
             </p:NodeReference>
+            <Pin Id="DWuoAPtASdIL7uVU0ZbFc3" Name="Is Horizontal" Kind="InputPin" DefaultValue="False">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
+                <Choice Kind="TypeFlag" Name="Boolean" />
+              </p:TypeAnnotation>
+            </Pin>
             <Pin Id="NMH8N9bXFO2L4qB03cOlD5" Name="From" Kind="InputPin" DefaultValue="0.6800002, 0.6800002, 0.6800002, 1">
-              <p:TypeAnnotation LastCategoryFullName="Color" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="RGBA" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="Jt7e9mTpoiJMq2ebrNTQdt" Name="To" Kind="InputPin" DefaultValue="0, 0, 0, 1">
-              <p:TypeAnnotation LastCategoryFullName="Color" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Color" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="RGBA" />
               </p:TypeAnnotation>
             </Pin>
-            <Pin Id="DWuoAPtASdIL7uVU0ZbFc3" Name="Is Horizontal" Kind="InputPin" DefaultValue="False">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
-                <Choice Kind="TypeFlag" Name="Boolean" />
-              </p:TypeAnnotation>
-            </Pin>
             <Pin Id="TktPTm3aq7wOR5RUdUYweu" Name="Gamma" Kind="InputPin" DefaultValue="2.45">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="EOve3lMtsllQaje622dZZu" Name="Output Size" Kind="InputPin" />
+            <Pin Id="EbZwjMdGKymLAzDIn4A9Fv" Name="Output Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="MZRpyrcIOYbLk0H6wjVXy6" Name="Render Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="CFHV1j5rIKjNmeIcgmTVH6" Name="Output Texture" Kind="InputPin" IsHidden="true" />
             <Pin Id="V7Q6hfkt4yRMoNyoT1MZLy" Name="Enabled" Kind="InputPin" />
             <Pin Id="SkzDRsiTsT8OM2Fx0ohzzf" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="336,268,135,19" Id="CxqaPCjb8rPOc6c0kZSPtM">
-            <p:NodeReference>
+            <p:NodeReference LastCategoryFullName="Main" LastDependency="Example Compute Shader Instancing with Oversampling.vl">
               <Choice Kind="ProcessNode" Name="ComputeShaderInstancing" />
             </p:NodeReference>
+            <Pin Id="TDIAR0GWVrXPRBtesdl16P" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="LmjHlLRNcsqOtN5EQGLWwk" Name="Direction Quantization" Kind="InputPin" />
             <Pin Id="NJgigURm1VFMaooLZvzvzz" Name="Material" Kind="OutputPin" />
             <Pin Id="RZ2aVqGsNhXPOwwwLVgU47" Name="Instancing Component" Kind="OutputPin" />
           </Node>
           <Node Bounds="382,346,65,19" Id="LX3UNxC0aZxLhk6wfTAGp8">
-            <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Spread" LastDependency="VL.Collections.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="FromValue" />
               <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
@@ -1017,7 +1070,7 @@
             <Pin Id="ELi6VbpjT8XQGyjPC8dfbJ" Name="Result" Kind="OutputPin" />
           </Node>
           <Pad Id="EJ6PFdP3fvYMb9xXr2fLpE" Bounds="491,276,96,19" ShowValueBox="true" isIOBox="true" Value="&lt;- look inside">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -1027,10 +1080,11 @@
           </Pad>
           <Overlay Id="VpqtdGkFuzlMS5VRlDTJ6R" Name="Compute shader instancing" Bounds="301,111,329,202" />
           <Node Bounds="380,815,185,19" Id="K4bm8VIpddvLY5FOAe5DBx">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneTexture" />
             </p:NodeReference>
+            <Pin Id="F4bi241cG2tQcc1e6aBpjo" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="CvqTpkQcEHrMHwMvZkNvDY" Name="Input" Kind="InputPin" />
             <Pin Id="FIpO2EbL8UsPbrOuPGzwSN" Name="Size" Kind="InputPin" />
             <Pin Id="Fu0yGiGqxyfK9tgHHm1uSc" Name="Camera" Kind="InputPin" />
@@ -1040,20 +1094,37 @@
             <Pin Id="HICdpms62vWLN7PV0XmoBx" Name="Enable Default Post Effects" Kind="InputPin" />
             <Pin Id="AOxFK7B5BSDMFzCMUNsGRR" Name="Format" Kind="InputPin" />
             <Pin Id="Gjgm2TCcSXIOPh8XWmVs5Z" Name="Depth Format" Kind="InputPin" />
+            <Pin Id="SZhBgFYbrAWPMMj8D6ecgi" Name="Render Group Mask" Kind="InputPin" IsHidden="true" />
+            <Pin Id="E4YJkBVBTFfOiFpLRY6MwW" Name="Model Effect Name" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Vjjy73prFdRLgnezPqubUb" Name="Additional Scene Renderers" Kind="InputPin" IsHidden="true" />
             <Pin Id="M0i0aorEpbLN3xNV0m9lLe" Name="Enabled" Kind="InputPin" />
             <Pin Id="FxpNive4DD9MKI1jjGPPVY" Name="Output" Kind="OutputPin" />
             <Pin Id="LuPkWSlM1mUMn7a91ZhY36" Name="Depth" Kind="OutputPin" />
+            <Pin Id="QPlqJGN6cR3LovzYDBikly" Name="MSAALevel" Kind="InputPin" IsHidden="true" />
+            <Pin Id="UtebsUGMpK8PglqYRUxE71" Name="MSAAResolver" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Rft4nNhyrg5P1eJeYaCaAg" Name="Light Shafts" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Nvm2P6Bsoe5LAqfeYChGuc" Name="VR Settings" Kind="InputPin" IsHidden="true" />
+            <Pin Id="KS6By3ip3i9LkVPNFT4jjB" Name="Viewport Settings" Kind="InputPin" IsHidden="true" />
+            <Pin Id="ROtJUuBFXufOGxk0Jsk00M" Name="Subsurface Scattering Blur Settings" Kind="InputPin" IsHidden="true" />
+            <Pin Id="SCibQo3iIqcOGaFQOSg1yq" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" IsHidden="true" />
           </Node>
-          <Node Bounds="322,1121,225,19" Id="IpGzxrk1PZLLTdvkRUSPDI">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
+          <Node Bounds="322,1121,245,19" Id="IpGzxrk1PZLLTdvkRUSPDI">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="SceneWindow" />
             </p:NodeReference>
-            <Pin Id="BKhrvzOZYcuPt2AXs7RGkC" Name="Bounds" Kind="InputPin" DefaultValue="1364.667, 99.33334, 821.3333, 704.6667">
-              <p:TypeAnnotation LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl">
+            <Pin Id="BKhrvzOZYcuPt2AXs7RGkC" Name="Bounds" Kind="InputPin" DefaultValue="1364, 99, 821, 704">
+              <p:TypeAnnotation LastCategoryFullName="2D" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Rectangle" />
               </p:TypeAnnotation>
             </Pin>
+            <Pin Id="EM8Pharv8v3PdN7KztKyL8" Name="Bound to Document" Kind="InputPin" IsHidden="true" />
+            <Pin Id="F3otyj5lyOONzxyJYm2IYZ" Name="Dialog If Document Changed" Kind="InputPin" IsHidden="true" />
+            <Pin Id="T4TyfzN0GCpNysMTeWSw4H" Name="Save Bounds" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Szro8f5odabO9UT0bY8Iw5" Name="Back Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="LFSYIiwHcJmM1I1BTAyYHX" Name="Depth Buffer Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="KkzdwZx4og7QWLq86zIbM5" Name="Input Priority" Kind="InputPin" IsHidden="true" />
+            <Pin Id="G1Zon6HgQVGPAB59lUXem5" Name="Node Context" Kind="InputPin" />
             <Pin Id="Q288WDRi3VyMccO9zEK4Nq" Name="Input" Kind="InputPin" />
             <Pin Id="QgAIUxA5WcNOubL0POnams" Name="Camera" Kind="InputPin" />
             <Pin Id="HepM0PsAGyyNF1nSl9Mcjo" Name="Enable Default Camera" Kind="InputPin" />
@@ -1062,20 +1133,34 @@
             <Pin Id="IX3Edg74LguOvrHEwmPnoO" Name="Clear" Kind="InputPin" />
             <Pin Id="Gzw0ywy6G3PN7rcJ9qG2Fu" Name="Post Effects" Kind="InputPin" />
             <Pin Id="TJj7HV0taJ8OfAP6yYyJJY" Name="Enable Default Post Effects" Kind="InputPin" />
+            <Pin Id="PQdIupCAYOKMGYSztM5uee" Name="Render Group Mask" Kind="InputPin" IsHidden="true" />
+            <Pin Id="J6xGBQpsY3rMybYA547bA0" Name="Commands" Kind="InputPin" IsHidden="true" />
             <Pin Id="TBC5PWWjhD7Nr1EKo7IMrN" Name="Enable Keyboard Shortcuts" Kind="InputPin" />
+            <Pin Id="IZDRq968TYMNTveFvpsb1S" Name="Model Effect Name" Kind="InputPin" IsHidden="true" />
+            <Pin Id="S9LjeW10m82QE221QOkC97" Name="Additional Scene Renderers" Kind="InputPin" IsHidden="true" />
             <Pin Id="FoREpO43djOMX4LUbtn6nQ" Name="Enabled" Kind="InputPin" />
+            <Pin Id="DrLBlwe6cxqNrW35quFDWj" Name="Input Source" Kind="InputPin" IsHidden="true" />
             <Pin Id="Tbui9OliAzoMufA6VszCN1" Name="Present Interval" Kind="InputPin" />
             <Pin Id="LSWGh5A4KsRLcl1APEjvKT" Name="Output" Kind="OutputPin" />
             <Pin Id="KrOJHQEmOf2LcuNqUaM5yJ" Name="Client Bounds" Kind="OutputPin" />
             <Pin Id="Km9WpHJDw0ZLvO7mXyXjvu" Name="Input Source" Kind="OutputPin" />
             <Pin Id="CbmrhvRQdedMD1aDoeJqGt" Name="Back Buffer" Kind="OutputPin" />
             <Pin Id="Cx1k9LjXCxONSx4jpi9k8l" Name="Depth Buffer" Kind="OutputPin" />
+            <Pin Id="Rj9pkGS8aYWPdWPHd4Zz2S" Name="MSAALevel" Kind="InputPin" IsHidden="true" />
+            <Pin Id="GzJg5FRM8YwOVpRv2NLW4u" Name="MSAAResolver" Kind="InputPin" IsHidden="true" />
+            <Pin Id="KOyHEKr9rCYN1hLrCpZ7hj" Name="Light Shafts" Kind="InputPin" IsHidden="true" />
+            <Pin Id="OVcp7nI04VSLwMcnNttzDv" Name="VR Settings" Kind="InputPin" IsHidden="true" />
+            <Pin Id="RoNZzVcNgHeNWTLJfLuqSr" Name="Viewport Settings" Kind="InputPin" IsHidden="true" />
+            <Pin Id="NoEdGmjyKmMMJlTs5yyV85" Name="Subsurface Scattering Blur Settings" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Dz77HXhOUg7QKywbSVpTWV" Name="Bind Depth As Resource During Transparent Rendering" Kind="InputPin" IsHidden="true" />
+            <Pin Id="UnWEjSWnktpOreBs0UCG1K" Name="Present Call Intercept" Kind="InputPin" IsHidden="true" />
           </Node>
           <Node Bounds="362,1002,145,19" Id="NyvtMG4EcTgOT31a5Mzhqc">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Rendering.ShaderFX.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.Rendering.ShaderFX.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="FullscreenQuadRenderer" />
             </p:NodeReference>
+            <Pin Id="S3fWtbD3GouMaEhMDyYXhB" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="HfBtMhLAfoILsR3Y2PQMka" Name="Transformation" Kind="InputPin" />
             <Pin Id="AN1earAcF5kOaPLeRyAsNY" Name="Texture" Kind="InputPin" />
             <Pin Id="Utd383iEv9hPlEiOwmdlR3" Name="Sampler" Kind="InputPin" />
@@ -1087,7 +1172,7 @@
             <Pin Id="VBBeThVBekoNllUZS9i0Fo" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="377,1150,35,19" Id="KCAOjO4s0iZLqWYaZIlWVT">
-            <p:NodeReference LastCategoryFullName="2D.Rectangle" LastSymbolSource="CoreLibBasics.vl">
+            <p:NodeReference LastCategoryFullName="2D.Rectangle" LastDependency="CoreLibBasics.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <CategoryReference Kind="RecordType" Name="Rectangle" />
               <Choice Kind="OperationCallFlag" Name="Size" />
@@ -1096,71 +1181,69 @@
             <Pin Id="S70In9zlfjwOWwdObsCLRS" Name="Size" Kind="OutputPin" />
           </Node>
           <Pad Id="FAWYl8Wr4nwMCwkgZuFrqN" SlotId="TY7pgvChIvHNOzsA4BC8QE" Bounds="379,1188" />
-          <Node Bounds="400,728,46,26" Id="AmRG0LN2FGDMgRhMgWmPlf">
-            <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <CategoryReference Kind="RecordType" Name="Int2" />
-              <Choice Kind="OperationCallFlag" Name="Create" />
-              <PinReference Kind="InputPin" Name="Value">
-                <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl">
-                  <Choice Kind="TypeFlag" Name="Vector2" />
-                </p:DataTypeReference>
-              </PinReference>
-            </p:NodeReference>
-            <Pin Id="Jsp6g8QTo4rOXYjNjhHKi3" Name="Value" Kind="InputPin" />
-            <Pin Id="PtvFiAv4RkaLEHK3iRP199" Name="Output" Kind="StateOutputPin" />
-          </Node>
           <Pad Id="AnGLcxcsJFoL6M3g8RL5GO" SlotId="TY7pgvChIvHNOzsA4BC8QE" Bounds="402,668" />
           <Node Bounds="400,693,25,19" Id="IytKI2FRxSfOvH6vrH7DWi">
-            <p:NodeReference LastCategoryFullName="Math" LastSymbolSource="CoreLibBasics.vl">
+            <p:NodeReference LastCategoryFullName="Math" LastDependency="CoreLibBasics.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="* (Scale)" />
             </p:NodeReference>
             <Pin Id="MBCDvX2jaA2M8EoxJqIjuv" Name="Input" Kind="InputPin" />
             <Pin Id="Gspaj9cWtWVPPXaldmchEy" Name="Scalar" Kind="InputPin" DefaultValue="1">
-              <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="TypeFlag" Name="Float32" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="RevGTuzj5V4PFaDs5UMTpt" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="593,743,205,19" Id="RJ7FNox5bcKNmVfQQq91Hs">
-            <p:NodeReference LastCategoryFullName="Stride.Cameras" LastSymbolSource="VL.Stride.Engine.vl">
+          <Node Bounds="593,743,285,19" Id="RJ7FNox5bcKNmVfQQq91Hs">
+            <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="OrbitCamera" />
             </p:NodeReference>
+            <Pin Id="O5VBBeXUEJ5PUCSNc5kDee" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Lv3PNkl6uLtPDGKv5U1QnS" Name="Components" Kind="InputPin" />
+            <Pin Id="QGkZDCWBfKHN80owc2dXgc" Name="Children" Kind="InputPin" />
             <Pin Id="DZMgzP4lUgBOaX1jwVuARi" Name="Initial Interest" Kind="InputPin" />
             <Pin Id="KsAN6uIvou0LduBNCEYuq2" Name="Initial Yaw" Kind="InputPin" />
             <Pin Id="S02Y2AdaZBhNpG5WcTb54l" Name="Initial Pitch" Kind="InputPin" />
             <Pin Id="D7QgGuJC46UNFpNe7bbEP7" Name="Initial Distance" Kind="InputPin" />
             <Pin Id="VZUgT8plTaNMK3cG0dYaCk" Name="Initial Vertical Field Of View" Kind="InputPin" />
+            <Pin Id="TQVZ5QmevmmMy4DJntCGLl" Name="Projection" Kind="InputPin" />
             <Pin Id="AIlkJiH4SqiN5EcxK6psns" Name="Near Clip Plane" Kind="InputPin" />
             <Pin Id="JzaualkEewqNWztPw8czys" Name="Far Clip Plane" Kind="InputPin" />
+            <Pin Id="OBydsY8sxXPQX3d8mefzy2" Name="Auto Fetch Input Source" Kind="InputPin" IsHidden="true" />
+            <Pin Id="SwO3oXcA61sPQ4Wlw46vIu" Name="Input Source" Kind="InputPin" IsHidden="true" />
             <Pin Id="M7x8CyPa06JOCpKdNSPY82" Name="Aspect Ratio" Kind="InputPin" />
             <Pin Id="BLYABCT9xNUOU6j5WV6HTT" Name="Use Custom Aspect Ratio" Kind="InputPin" />
             <Pin Id="D4PCbSALEUyLKiYyufs6Fl" Name="Show Helper" Kind="InputPin" />
+            <Pin Id="IHdOEXxlOY8NqKIZoFe285" Name="Projection Matrix" Kind="InputPin" IsHidden="true" />
+            <Pin Id="Pmh79dH0fL0P07z95ZAKT6" Name="Reset" Kind="InputPin" />
             <Pin Id="Uvf3xqVyHMHLJe6SaCzqEs" Name="Enabled" Kind="InputPin" />
             <Pin Id="SpvPdPgV6AsNXDBbOW36zs" Name="Output" Kind="OutputPin" />
             <Pin Id="DouqNbqtZgSPqc7wLTbyhO" Name="Position" Kind="OutputPin" />
             <Pin Id="Nef601V7WVEOh8tzr9yINI" Name="Frustum" Kind="OutputPin" />
             <Pin Id="RFI8GSqQ26DM7EqinCo6DZ" Name="Inverse View" Kind="OutputPin" />
             <Pin Id="PopzlWClVUfP1whlbmsijI" Name="Camera Component" Kind="OutputPin" />
+            <Pin Id="FnSLZfDnSpyLOs7yjumFXK" Name="Interest" Kind="OutputPin" />
           </Node>
           <Node Bounds="342,1074,63,19" Id="Opta1737fmhLp7SK8QfRXH">
-            <p:NodeReference LastCategoryFullName="Stride" LastSymbolSource="VL.Stride.Engine.vl">
+            <p:NodeReference LastCategoryFullName="Stride" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="RootScene" />
             </p:NodeReference>
+            <Pin Id="VP0LYDTXF0EOk69EhBvJDk" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="TqJmrBVD1z8QSUj9UIwscx" Name="Child" Kind="InputPin" />
             <Pin Id="Qf50DEHdfMULXcWhIpBgqG" Name="Child 2" Kind="InputPin" />
+            <Pin Id="AlexDjgDflSNRIZ0JrcLBH" Name="Child Scenes" Kind="InputPin" IsHidden="true" />
             <Pin Id="E8NPybdGVHCMdfLG6dESZF" Name="Enabled" Kind="InputPin" />
             <Pin Id="BhNwKBXYREBNeOFYgQDcu2" Name="Output" Kind="OutputPin" />
           </Node>
           <Node Bounds="342,1038,165,19" Id="STCieTiDSYDLSajjnFGDSI">
-            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastSymbolSource="VL.Stride.Engine.vl">
+            <p:NodeReference LastCategoryFullName="Stride.Rendering" LastDependency="VL.Stride.Engine.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="RenderEntity" />
             </p:NodeReference>
+            <Pin Id="Hva4RjW54cnPbCb2FjZEX1" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="NZL72dYEVNMOa722mmttMU" Name="Transformation" Kind="InputPin" />
             <Pin Id="Mdl1u6cwfYBNGcCz7zvOvM" Name="Input" Kind="InputPin" />
             <Pin Id="TYXrYyNd5uWLlUVkC4phpG" Name="Render Stage" Kind="InputPin" />
@@ -1173,7 +1256,7 @@
             <Pin Id="JUWlPhigYK8MzgVcsKItUZ" Name="Output" Kind="OutputPin" />
           </Node>
           <Pad Id="I0gu5XU0GdvPLWLyFRTqJC" Comment="Oversampling Factor" Bounds="431,663,65,29" ShowValueBox="true" isIOBox="true" Value="1.5">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -1181,7 +1264,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Node Bounds="382,968,65,19" Id="EnSidpjejeSNUiJFkgbOkf">
-            <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastSymbolSource="VL.Stride.Rendering.EffectShaderNodes">
+            <p:NodeReference LastCategoryFullName="Stride.Textures.Utils" LastDependency="VL.Stride.Rendering.EffectShaderNodes">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Resize" />
               <CategoryReference Kind="Category" Name="Utils" NeedsToBeDirectParent="true">
@@ -1189,35 +1272,26 @@
               </CategoryReference>
             </p:NodeReference>
             <Pin Id="Uj2K8sutBV1Nn5BCx8LrRE" Name="Input" Kind="InputPin" />
+            <Pin Id="JVE4MpD7Xn7PvAePNzhJwQ" Name="Point Sampler" Kind="InputPin" IsHidden="true" />
+            <Pin Id="TVsU97ogFT4PwjyWbRjqAI" Name="Linear Sampler" Kind="InputPin" IsHidden="true" />
             <Pin Id="LkWuouN2wlwN5e27GFwmQJ" Name="Mode" Kind="InputPin" />
+            <Pin Id="RLjIF9rJUQKO6Gi1l3J3OT" Name="Output Texture" Kind="InputPin" IsHidden="true" />
             <Pin Id="OCFmYVQLVH4O1l1dmW3ZDj" Name="Output Size" Kind="InputPin" />
+            <Pin Id="U8N8lLICVGoQYzTpkFIEve" Name="Output Format" Kind="InputPin" IsHidden="true" />
+            <Pin Id="QBwwsZUnS6KOQMTjbxEwrZ" Name="Render Format" Kind="InputPin" IsHidden="true" />
             <Pin Id="KitJXVP5DOOOfTAzlEHrYc" Name="Apply" Kind="InputPin" />
             <Pin Id="H8YeFJx7UwAM7Gf5rMaHzZ" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="E2LwuFSPwMQLFAucyZ9rjf" Comment="Mode" Bounds="404,949,109,15" ShowValueBox="true" isIOBox="true" Value="CubicCatmullRom">
-            <p:TypeAnnotation LastCategoryFullName="VL.Stride.Effects.TextureFX" LastSymbolSource="VL.Stride.Runtime.dll">
+          <Pad Id="E2LwuFSPwMQLFAucyZ9rjf" Comment="Mode" Bounds="404,949,111,15" ShowValueBox="true" isIOBox="true" Value="CubicCatmullRom">
+            <p:TypeAnnotation LastCategoryFullName="VL.Stride.Effects.TextureFX" LastDependency="VL.Stride.Runtime.dll">
               <Choice Kind="TypeFlag" Name="ResizeInterpolationType" />
             </p:TypeAnnotation>
           </Pad>
-          <Node Bounds="486,892,46,26" Id="EjkFd17lEroMyMMRKQ8LDJ">
-            <p:NodeReference LastCategoryFullName="Primitive.Int2" LastSymbolSource="CoreLibBasics.vl">
-              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-              <CategoryReference Kind="RecordType" Name="Int2" />
-              <Choice Kind="OperationCallFlag" Name="Create" />
-              <PinReference Kind="InputPin" Name="Value">
-                <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="2D" LastSymbolSource="CoreLibBasics.vl">
-                  <Choice Kind="TypeFlag" Name="Vector2" />
-                </p:DataTypeReference>
-              </PinReference>
-            </p:NodeReference>
-            <Pin Id="EJoHFy6Wqh1LVo2k4SFlpX" Name="Value" Kind="InputPin" />
-            <Pin Id="TjfufrbtTBPNN4yPvqoze3" Name="Output" Kind="StateOutputPin" />
-          </Node>
           <Pad Id="Llz0O3jlDrjNznvQv6tOHY" SlotId="TY7pgvChIvHNOzsA4BC8QE" Bounds="488,872" />
           <ControlPoint Id="Hd1zewams2OP7v9w5x2JIF" Bounds="593,1084" />
           <Overlay Id="OJFCbx52WiwNRFevaJoO0J" Name="Oversampling" Bounds="219,848,478,385" />
           <Pad Id="PCATpruwoL8QBkF3IWSj2G" Bounds="395,172,148,84" ShowValueBox="true" isIOBox="true" Value="0 = free flow&#xD;&#xA;1 = flow in planes&#xD;&#xA;2 = 45° angles&#xD;&#xA;3 = 90° angles">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -1226,13 +1300,29 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="UoWyXF2nFcjLjtEhsdNKxq" Comment="" Bounds="338,175,35,29" ShowValueBox="true" isIOBox="true" Value="2">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="Integer32" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
               <p:fontsize p:Type="Int32">14</p:fontsize>
             </p:ValueBoxSettings>
           </Pad>
+          <Node Bounds="400,750,34,26" Id="Ni3z86Ykx9hNZKuezcOhdT">
+            <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="Int2 (Create Vector2)" />
+            </p:NodeReference>
+            <Pin Id="Vz756l6HpYPMdJLxGkpWYj" Name="Value" Kind="InputPin" />
+            <Pin Id="LbBAjBIOtL5LMLS0y84Mtm" Name="Output" Kind="StateOutputPin" />
+          </Node>
+          <Node Bounds="486,890,34,26" Id="Ms24TusgTueOoWo5Z0mDTp">
+            <p:NodeReference LastCategoryFullName="Primitive.Int2" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <Choice Kind="OperationCallFlag" Name="Int2 (Create Vector2)" />
+            </p:NodeReference>
+            <Pin Id="MlJpeQpDH0aNZPdi3MfRL4" Name="Value" Kind="InputPin" />
+            <Pin Id="VbDSbPjazyZNztl5RsqYZl" Name="Output" Kind="StateOutputPin" />
+          </Node>
         </Canvas>
         <Patch Id="T8ovmlYRmaJLu62pOjM1kA" Name="Create" />
         <Patch Id="KxlV5QdZexmM1guqrr8G3S" Name="Update" />
@@ -1259,9 +1349,7 @@
         <Link Id="VStn1IQqi7DPkLn2V79qep" Ids="KrOJHQEmOf2LcuNqUaM5yJ,EyJJep1wjhVQEyJ8Em9EvQ" />
         <Slot Id="TY7pgvChIvHNOzsA4BC8QE" Name="Window Size" />
         <Link Id="ASDoSyXBIzpPTyTPu3n5dp" Ids="S70In9zlfjwOWwdObsCLRS,FAWYl8Wr4nwMCwkgZuFrqN" />
-        <Link Id="JXv8sQb628DPW4kvtG13WO" Ids="PtvFiAv4RkaLEHK3iRP199,FIpO2EbL8UsPbrOuPGzwSN" />
         <Link Id="O5kevpSUlbCMulXhoUTYvr" Ids="AnGLcxcsJFoL6M3g8RL5GO,MBCDvX2jaA2M8EoxJqIjuv" />
-        <Link Id="DaIV0nosUd0LlXVJKhpvLA" Ids="RevGTuzj5V4PFaDs5UMTpt,Jsp6g8QTo4rOXYjNjhHKi3" />
         <Link Id="To6JdSVZeLfNM7rgSIEjUy" Ids="BhNwKBXYREBNeOFYgQDcu2,Q288WDRi3VyMccO9zEK4Nq" />
         <Link Id="KkpHQ2Du3guLM331444gTI" Ids="JUWlPhigYK8MzgVcsKItUZ,TqJmrBVD1z8QSUj9UIwscx" />
         <Link Id="BsIzT632CB7NUA4gSyQszB" Ids="SpvPdPgV6AsNXDBbOW36zs,Hd1zewams2OP7v9w5x2JIF,QgAIUxA5WcNOubL0POnams" />
@@ -1270,12 +1358,15 @@
         <Link Id="DvkPpJgbcU1PKOvzanhnoS" Ids="FxpNive4DD9MKI1jjGPPVY,Uj2K8sutBV1Nn5BCx8LrRE" />
         <Link Id="Pmcz0qjO8mhQdDrpFSYBKW" Ids="E2LwuFSPwMQLFAucyZ9rjf,LkWuouN2wlwN5e27GFwmQJ" />
         <Link Id="CE5jOK7mgOmMBDQCrnAta9" Ids="H8YeFJx7UwAM7Gf5rMaHzZ,AN1earAcF5kOaPLeRyAsNY" />
-        <Link Id="QV9g80dfPwXMlrBi5ngH2G" Ids="Llz0O3jlDrjNznvQv6tOHY,EJoHFy6Wqh1LVo2k4SFlpX" />
-        <Link Id="BjrnGcDLgafOCGSiceLNIn" Ids="TjfufrbtTBPNN4yPvqoze3,OCFmYVQLVH4O1l1dmW3ZDj" />
         <Link Id="NR3cOisnp1CMphUmXpNmq2" Ids="UoWyXF2nFcjLjtEhsdNKxq,LmjHlLRNcsqOtN5EQGLWwk" />
         <Link Id="Jm3x7oYzjjgLCaLgTi6JYh" Ids="NJgigURm1VFMaooLZvzvzz,FBvFgGphy6qPi8C3ZSNZnu" />
+        <Link Id="L5jdntd00nzQTLoyJ4kAwg" Ids="RevGTuzj5V4PFaDs5UMTpt,Vz756l6HpYPMdJLxGkpWYj" />
+        <Link Id="MlZuvwBqLbNN6tRluEiC74" Ids="LbBAjBIOtL5LMLS0y84Mtm,FIpO2EbL8UsPbrOuPGzwSN" />
+        <Link Id="GAaLeYGbulLO7qC2qj2A55" Ids="Llz0O3jlDrjNznvQv6tOHY,MlJpeQpDH0aNZPdi3MfRL4" />
+        <Link Id="HSdJTPfOvwQO1USDk6J6tX" Ids="VbDSbPjazyZNztl5RsqYZl,OCFmYVQLVH4O1l1dmW3ZDj" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="Q6thn2Y7IMaPIwMZVU2Sfj" Location="VL.Stride" Version="2021.4.0-0301-g1e6e81affe" />
+  <NugetDependency Id="Q6thn2Y7IMaPIwMZVU2Sfj" Location="VL.Stride" Version="2025.7.0" />
+  <NugetDependency Id="DjMWHShFb3mOSpo3VQOwNi" Location="VL.Stride.TextureFX" Version="2025.7.0" />
 </Document>


### PR DESCRIPTION
# PR Details

Fixes https://forum.vvvv.org/t/example-compute-shader-instancing-has-errors/24684

<img width="705" height="857" alt="image" src="https://github.com/user-attachments/assets/fe9ae821-e81d-42f5-a5d7-3be55924f173" />


## Description

* Fixed GPU<Vector4> with Convert GPU<RGBA>
* Fixed Int2 Create Deprecation notices

## Related Issue

https://forum.vvvv.org/t/example-compute-shader-instancing-has-errors/24684

## Motivation and Context

Fixes help patch

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation
