### PR TITLE
WASD cam tweaks

### DIFF
--- a/VL.Stride.Runtime/VL.Stride.Engine.vl
+++ b/VL.Stride.Runtime/VL.Stride.Engine.vl
@@ -2085,7 +2085,7 @@
             </p:NodeReference>
             <Patch Id="CLMJeT89mmJQbgQWlVdTC8">
               <Canvas Id="AxOIxlod9ptMTCyH1NlZGG">
-                <Pad Id="SbfnqnG3pouPHUww7uyvl0" Comment="FOV Delta Speed" Bounds="679,840,35,15" ShowValueBox="true" isIOBox="true" Value="0.01">
+                <Pad Id="SbfnqnG3pouPHUww7uyvl0" Comment="FOV Delta Speed" Bounds="679,870,35,15" ShowValueBox="true" isIOBox="true" Value="0.01">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
@@ -2143,13 +2143,14 @@
                   <Pin Id="HS9I9i3sAViOSIAzxEfEoL" Name="Scalar" Kind="InputPin" />
                   <Pin Id="Q4MSsBlffv0ODC7AMjch14" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="658,906,25,19" Id="Ld1f1rZoaZkPtg0uijCHSJ">
+                <Node Bounds="658,906,45,19" Id="Ld1f1rZoaZkPtg0uijCHSJ">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="OperationNode" Name="*" />
                   </p:NodeReference>
                   <Pin Id="SQNS6J4Ecx7PgeVpslCMZN" Name="Input" Kind="InputPin" />
                   <Pin Id="VFXjWX0ldKvPz5eRk5M9CN" Name="Input 2" Kind="InputPin" />
                   <Pin Id="GfnBEeMFq60LHntCY4fJUR" Name="Output" Kind="OutputPin" />
+                  <Pin Id="PT9mxvYgLNYLXClbIGqwC1" Name="Input 3" Kind="InputPin" />
                 </Node>
                 <Node Bounds="967,906,45,19" Id="I9jZhSHuvpcNfaG6rmoCUD">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
@@ -2170,7 +2171,7 @@
                   <Pin Id="LsnuFrGqdQJQFk0X9RAgcI" Name="Up Edge" Kind="OutputPin" />
                   <Pin Id="Bi1FaPU8Se8OzQBZ7HIrvX" Name="Down Edge" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="351,926,45,19" Id="FbsBeOhTcZXMI3rGqGVxpO">
+                <Node Bounds="351,911,45,19" Id="FbsBeOhTcZXMI3rGqGVxpO">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="OperationNode" Name="*" />
                   </p:NodeReference>
@@ -2201,7 +2202,7 @@
                   <Pin Id="Egu6kwaHJfyPr7NI4HSSju" Name="X" Kind="OutputPin" />
                   <Pin Id="Lxdy0CFKltGNBzxBqwD6nb" Name="Y" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="288,926,45,19" Id="NRjsP2kPtcAOyqap3TPLgA">
+                <Node Bounds="288,911,45,19" Id="NRjsP2kPtcAOyqap3TPLgA">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="OperationNode" Name="*" />
                   </p:NodeReference>
@@ -2213,12 +2214,12 @@
                 <ControlPoint Id="DcvMjjEmhqnMpMZj3ZpWYj" Bounds="134,468" />
                 <ControlPoint Id="BLPb0NxZTcINk0X54ys7kl" Bounds="1371,996" />
                 <ControlPoint Id="Bk8Jv4lhvUkNVBTqhfqbdS" Bounds="138,1166,462,20" />
-                <Pad Id="HibBUhJqfuIPlImL0Xa6kL" Comment="Distance Delta Speed" Bounds="1009,817,35,15" ShowValueBox="true" isIOBox="true" Value="20">
+                <Pad Id="HibBUhJqfuIPlImL0Xa6kL" Comment="Distance Delta Speed" Bounds="1009,832,35,15" ShowValueBox="true" isIOBox="true" Value="20">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="U53ivF6Yc9TMxdHMLDh1A1" Comment="Longitude / Latitude Delta Speed " Bounds="330,827,35,15" ShowValueBox="true" isIOBox="true" Value="1">
+                <Pad Id="U53ivF6Yc9TMxdHMLDh1A1" Comment="Longitude / Latitude Delta Speed " Bounds="330,842,35,15" ShowValueBox="true" isIOBox="true" Value="1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
@@ -2345,7 +2346,7 @@
                   <Pin Id="Fd8wgj0eCy0L8NNWko0x37" Name="Progress" Kind="OutputPin" />
                 </Node>
                 <ControlPoint Id="T58kw9kWQRBQLy5ahfJ8dB" Bounds="451,926" />
-                <Node Bounds="695,226,128,26" Id="MaP1O4JZ3r1Nkx7vTqiPx6">
+                <Node Bounds="695,196,162,26" Id="MaP1O4JZ3r1Nkx7vTqiPx6">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsButtonDown" />
@@ -2355,7 +2356,7 @@
                   <Pin Id="DLlPRc5gPyfLnW9LgGddB2" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="Dx9eJounU6CPfzkobZLdJZ" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="695,306,107,26" Id="UIy6cTD9nXsPJ5a3zFjJyc">
+                <Node Bounds="695,261,142,26" Id="UIy6cTD9nXsPJ5a3zFjJyc">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsButtonDown" />
@@ -2365,7 +2366,7 @@
                   <Pin Id="MLh12DSPjagK98x7CkyRWl" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="BsC4v49fXeUPjWG958GSKI" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="695,396,142,26" Id="Pjduk6N4SuEOeVr4QWGesL">
+                <Node Bounds="695,321,122,26" Id="Pjduk6N4SuEOeVr4QWGesL">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IMouseDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsButtonDown" />
@@ -2375,17 +2376,17 @@
                   <Pin Id="I1X5OsTIJwWOEbzOz85vOG" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="Fu70tiuvgFvOb3Bd9lnxxs" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="QPciIjfPUUILMRfnM9WJuo" Comment="Mouse Button" Bounds="799,281,85,19" ShowValueBox="true" isIOBox="true" Value="Middle">
+                <Pad Id="QPciIjfPUUILMRfnM9WJuo" Comment="Mouse Button" Bounds="861,241,85,19" ShowValueBox="true" isIOBox="true" Value="Middle">
                   <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                     <Choice Kind="TypeFlag" Name="MouseButton" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="EfC2tXGFygiNs0NjtrwHPo" Comment="Mouse Button" Bounds="834,361,85,19" ShowValueBox="true" isIOBox="true" Value="Right">
+                <Pad Id="EfC2tXGFygiNs0NjtrwHPo" Comment="Mouse Button" Bounds="863,301,85,19" ShowValueBox="true" isIOBox="true" Value="Right">
                   <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                     <Choice Kind="TypeFlag" Name="MouseButton" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="435,426,112,26" Id="CIL99EIcnkMNJ08RovOMwS">
+                <Node Bounds="435,411,112,26" Id="CIL99EIcnkMNJ08RovOMwS">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.InputManager" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="MouseWheelDelta" />
@@ -2394,7 +2395,7 @@
                   <Pin Id="DYJsxnzVfQHNcJSjZM0t8r" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="S9HOIa7KgXaO0o4encKFQx" Name="Mouse Wheel Delta" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1328,580,75,26" Id="HSWUDya5dB4NATfGU1u6YF">
+                <Node Bounds="1348,565,75,26" Id="HSWUDya5dB4NATfGU1u6YF">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
@@ -2405,12 +2406,12 @@
                   <Pin Id="PBHFd0Wh2UFOpIB5dSfJLr" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="FbcZQiNdNtMMJnOalTbYD0" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="SYQSAyceUajOOYDyOLyW6L" Comment="Item" Bounds="1400,564,127,19" ShowValueBox="true" isIOBox="true" Value="R">
+                <Pad Id="SYQSAyceUajOOYDyOLyW6L" Comment="Item" Bounds="1420,549,127,19" ShowValueBox="true" isIOBox="true" Value="R">
                   <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="Stride.Input.dll">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="FjRbawjPkxbLdKUqbwHXo5" Comment="Mouse Wheel Delta" Bounds="544,485,29,18" ShowValueBox="true" isIOBox="true" />
+                <Pad Id="FjRbawjPkxbLdKUqbwHXo5" Comment="Mouse Wheel Delta" Bounds="544,470,29,18" ShowValueBox="true" isIOBox="true" />
                 <Pad Id="Qxj540M5vGgMJLoAkZa7Vy" Comment="Position" Bounds="897,1147,58,15" ShowValueBox="true" isIOBox="true">
                   <p:ValueBoxSettings>
                     <p:precision p:Type="Int32">4</p:precision>
@@ -2419,7 +2420,7 @@
                 <Pad Id="OiibOUBPnbJLzsNdGNutA1" Comment="Position" Bounds="438,1147,35,15" ShowValueBox="true" isIOBox="true" />
                 <Pad Id="Csxb4SA4SjFL12DVvO7Q2A" Comment="Position" Bounds="279,1147,35,15" ShowValueBox="true" isIOBox="true" />
                 <Pad Id="M8W6izI3X5vMouSa0akS98" Comment="Y" Bounds="337,777,35,15" ShowValueBox="true" isIOBox="true" />
-                <Pad Id="VO43lp6Q6wALZaoWWkm0NF" Comment="" Bounds="290,974,35,15" ShowValueBox="true" isIOBox="true" />
+                <Pad Id="VO43lp6Q6wALZaoWWkm0NF" Comment="" Bounds="290,946,35,15" ShowValueBox="true" isIOBox="true" />
                 <Node Bounds="288,496,98,19" Id="UDCiQcJ4UXSNVqdftBVHXG">
                   <p:NodeReference LastCategoryFullName="Stride.Cameras.OrbitCameraControls" LastDependency="VL.Stride.Engine.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
@@ -2502,7 +2503,7 @@
                   <Pin Id="NAPqaGT9Zs7M7pYg64AZ1f" Name="Node Context" Kind="InputPin" IsHidden="true" />
                   <Pin Id="PNiGnJnpMFYLv0LcwHjlEg" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="435,336,70,26" Id="LwNUxwZ7GqTNf6u0hxKpyv">
+                <Node Bounds="435,306,70,26" Id="LwNUxwZ7GqTNf6u0hxKpyv">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.InputManager" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="MouseDelta" />
@@ -2511,7 +2512,7 @@
                   <Pin Id="DzTOMoBfWklLHHQgYLmJmv" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="FHC7S9YdKZULl4q7Whnn4V" Name="Mouse Delta" Kind="OutputPin" />
                 </Node>
-                <Pad Id="TKSCSZ1ZWhKPoiBF15yjTb" Comment="Mouse Delta" Bounds="502,390,35,28" ShowValueBox="true" isIOBox="true" />
+                <Pad Id="TKSCSZ1ZWhKPoiBF15yjTb" Comment="Mouse Delta" Bounds="502,360,35,28" ShowValueBox="true" isIOBox="true" />
                 <ControlPoint Id="RaCWubsw2dPQQ8tXRFnAwy" Bounds="697,56" />
                 <Pad Id="JR8baz05UghPLrTWJzIysH" Comment="Position" Bounds="557,1147,35,15" ShowValueBox="true" isIOBox="true" />
                 <Node Bounds="695,146,339,19" Id="TAspvHgenynLraywPTAfFB">
@@ -2528,7 +2529,7 @@
                   <Pin Id="O0hZSf9oB8EMPsSVKpZYmT" Name="Keyboard Device" Kind="OutputPin" />
                   <Pin Id="UisJKwlR8rePcAKeG5JFLo" Name="Pointer Device" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1144,206,75,26" Id="IeD2hH9rFeSMjr8Dy160hK">
+                <Node Bounds="1164,176,75,26" Id="IeD2hH9rFeSMjr8Dy160hK">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
@@ -2539,12 +2540,12 @@
                   <Pin Id="HIFPHOOjyVjM6T46X4ykFj" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="MDrmToyf2W1MKLDfh1OKYn" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="HxiGBJqky9fPvjkg27liKt" Comment="Key" Bounds="1216,196,120,15" ShowValueBox="true" isIOBox="true" Value="W">
+                <Pad Id="HxiGBJqky9fPvjkg27liKt" Comment="Key" Bounds="1236,166,120,15" ShowValueBox="true" isIOBox="true" Value="W">
                   <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1166,246,75,26" Id="BgbF8rMxXbDNgPKojkxSLA">
+                <Node Bounds="1186,216,75,26" Id="BgbF8rMxXbDNgPKojkxSLA">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
@@ -2555,12 +2556,12 @@
                   <Pin Id="CDYeCJAD9Y7Pt3E92sqvbL" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="PBo6KvgThj6P3eYpKfINT6" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="MqPnjIzEVjlLVvktMwkNJW" Comment="Key" Bounds="1238,236,120,15" ShowValueBox="true" isIOBox="true" Value="S">
+                <Pad Id="MqPnjIzEVjlLVvktMwkNJW" Comment="Key" Bounds="1258,206,120,15" ShowValueBox="true" isIOBox="true" Value="S">
                   <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1196,286,75,26" Id="SFrVYoWmAKnM457qikx6NW">
+                <Node Bounds="1216,256,75,26" Id="SFrVYoWmAKnM457qikx6NW">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
@@ -2571,12 +2572,12 @@
                   <Pin Id="L7WbnSuSTPMMxV5K651Hch" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="IsLphb3etfuLG4pMZwRo9Z" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="TeInYXX5Bc0OkmslVPRUUu" Comment="Key" Bounds="1268,276,120,15" ShowValueBox="true" isIOBox="true" Value="A">
+                <Pad Id="TeInYXX5Bc0OkmslVPRUUu" Comment="Key" Bounds="1288,246,120,15" ShowValueBox="true" isIOBox="true" Value="A">
                   <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1224,326,75,26" Id="ORjyxC9wiBzLwKz796Vdlh">
+                <Node Bounds="1244,296,75,26" Id="ORjyxC9wiBzLwKz796Vdlh">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
@@ -2587,12 +2588,12 @@
                   <Pin Id="LC5Kv8PQedYLg8yrZzh1s3" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="DvebJB8Gcr3P9Md0OaTnNu" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="FpXfPWWyh7iOU9tCfoABMd" Comment="Key" Bounds="1296,316,120,15" ShowValueBox="true" isIOBox="true" Value="D">
+                <Pad Id="FpXfPWWyh7iOU9tCfoABMd" Comment="Key" Bounds="1316,286,120,15" ShowValueBox="true" isIOBox="true" Value="D">
                   <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1251,366,75,26" Id="Eysm0iQVKhRLVxqRHhQrQ7">
+                <Node Bounds="1271,336,75,26" Id="Eysm0iQVKhRLVxqRHhQrQ7">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
@@ -2603,12 +2604,12 @@
                   <Pin Id="RhvCZiagZNWOaoBmvi3ymM" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="MrcEFUU7kKlNVBvE1Q9iJA" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="MoNHyZheQ10P1ZldEIzz44" Comment="Key" Bounds="1323,356,120,15" ShowValueBox="true" isIOBox="true" Value="Q">
+                <Pad Id="MoNHyZheQ10P1ZldEIzz44" Comment="Key" Bounds="1343,326,120,15" ShowValueBox="true" isIOBox="true" Value="Q">
                   <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1282,406,75,26" Id="VLE4DK2tLbXNmvpAuKOA7w">
+                <Node Bounds="1302,376,75,26" Id="VLE4DK2tLbXNmvpAuKOA7w">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
@@ -2619,12 +2620,12 @@
                   <Pin Id="KFgTm4ArygYMdqRkHuuhxo" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="OVTSBXIsAwtMGH3L8I2Ohk" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="UoRPWPRkg8tOoUSJyzva6u" Comment="Key" Bounds="1354,396,120,15" ShowValueBox="true" isIOBox="true" Value="E">
+                <Pad Id="UoRPWPRkg8tOoUSJyzva6u" Comment="Key" Bounds="1374,366,120,15" ShowValueBox="true" isIOBox="true" Value="E">
                   <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1043,546,132,19" Id="NbQFhtYohrBMugNxVY5yTR">
+                <Node Bounds="1058,476,132,19" Id="NbQFhtYohrBMugNxVY5yTR">
                   <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="4043309058" Name="Vector3" />
@@ -2635,7 +2636,7 @@
                   <Pin Id="A5PenvBOjNdPpe5QKLlfNl" Name="Z" Kind="InputPin" />
                   <Pin Id="D8DkwqrxPhnOvd078A00T3" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="1043,466,22,19" Id="GgHJg1C5VPUP7R9caQN9N9">
+                <Node Bounds="1058,396,22,19" Id="GgHJg1C5VPUP7R9caQN9N9">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="- (Negate)" />
@@ -2643,12 +2644,12 @@
                   <Pin Id="JN1Yq8hKESVMu4KhEa0yE4" Name="Input" Kind="InputPin" />
                   <Pin Id="Kzi5gq5BSygLJfoOiICpRc" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Pad Id="HkSjGcoPOvtQcRvTk4SRw0" Comment="" Bounds="1045,446,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+                <Pad Id="HkSjGcoPOvtQcRvTk4SRw0" Comment="" Bounds="1060,376,35,15" ShowValueBox="true" isIOBox="true" Value="0">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ImmutableTypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1043,496,25,19" Id="BgFy9TOvjvRNrvCtlszl0M">
+                <Node Bounds="1058,426,25,19" Id="BgFy9TOvjvRNrvCtlszl0M">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="+" />
@@ -2657,7 +2658,7 @@
                   <Pin Id="NS2KUASLJicLnxrR2LXIDW" Name="Input 2" Kind="InputPin" />
                   <Pin Id="NqdPYVXRuDGOUfXaMfjozq" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1096,466,22,19" Id="R16K3GqxvKEPzndAH3kvDl">
+                <Node Bounds="1111,396,22,19" Id="R16K3GqxvKEPzndAH3kvDl">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="- (Negate)" />
@@ -2665,12 +2666,12 @@
                   <Pin Id="HdpUfD0JT8XOocn2acs3CD" Name="Input" Kind="InputPin" />
                   <Pin Id="Ddt7WyPBgRDNQRaW7mpr84" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Pad Id="R7EmvI5tc5iMITUJ41HLO9" Comment="" Bounds="1098,446,35,15" ShowValueBox="true" isIOBox="true" Value="0">
+                <Pad Id="R7EmvI5tc5iMITUJ41HLO9" Comment="" Bounds="1113,376,35,15" ShowValueBox="true" isIOBox="true" Value="0">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ImmutableTypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1096,496,25,19" Id="A1oedFHyOvwPrtopqKLycx">
+                <Node Bounds="1111,426,25,19" Id="A1oedFHyOvwPrtopqKLycx">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="+" />
@@ -2680,7 +2681,7 @@
                   <Pin Id="BkyGSMK2KhwNUQJFt9B0B6" Name="Output" Kind="OutputPin" />
                 </Node>
                 <Pad Id="ADyyY57LY4bNylbHVFAJ4O" Comment="" Bounds="781,1150,35,43" ShowValueBox="true" isIOBox="true" />
-                <Node Bounds="1149,466,22,19" Id="GLjCgiUP4P7Obl4ZJFrNb5">
+                <Node Bounds="1164,396,22,19" Id="GLjCgiUP4P7Obl4ZJFrNb5">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="- (Negate)" />
@@ -2688,12 +2689,12 @@
                   <Pin Id="NQaGbNSy6G7MpJbcHANGzw" Name="Input" Kind="InputPin" />
                   <Pin Id="HixzKdX9wTGOgdMfmgSiWq" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Pad Id="QZWthVpFVOMOqhf6PRe0NQ" Comment="" Bounds="1151,446,35,15" ShowValueBox="true" isIOBox="true">
+                <Pad Id="QZWthVpFVOMOqhf6PRe0NQ" Comment="" Bounds="1166,376,35,15" ShowValueBox="true" isIOBox="true">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ImmutableTypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1149,496,25,19" Id="ICN1WJkhH6CL0uIweFF1nx">
+                <Node Bounds="1164,426,25,19" Id="ICN1WJkhH6CL0uIweFF1nx">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="+" />
@@ -2702,7 +2703,7 @@
                   <Pin Id="N8ty1m8XG8eQAwqRgNYi1M" Name="Input 2" Kind="InputPin" />
                   <Pin Id="PrAvyOCJue3OHvRrIpovgl" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1303,446,75,26" Id="TWVghXuFMxaPjATpe2qPUI">
+                <Node Bounds="1323,416,75,26" Id="TWVghXuFMxaPjATpe2qPUI">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
@@ -2713,12 +2714,12 @@
                   <Pin Id="HXLrIfFyNXmLeVM9jaZum9" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="DrDToRwO6B1OWaf92unxRB" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="Eunl7FW7WPrN3oaSBLarjS" Comment="Key" Bounds="1375,436,120,15" ShowValueBox="true" isIOBox="true" Value="LeftShift">
+                <Pad Id="Eunl7FW7WPrN3oaSBLarjS" Comment="Key" Bounds="1395,406,120,15" ShowValueBox="true" isIOBox="true" Value="LeftShift">
                   <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1328,486,75,26" Id="SYvb8NHf1pmMEl23BwCEMM">
+                <Node Bounds="1348,456,75,26" Id="SYvb8NHf1pmMEl23BwCEMM">
                   <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
@@ -2729,12 +2730,12 @@
                   <Pin Id="KZI2ZZ73p8KP2NE1ESGczQ" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="E7no0wh9WoSOdYN4vtRqYL" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Pad Id="ShP7hzyrvWROgkIu7O4ht9" Comment="Key" Bounds="1400,476,120,15" ShowValueBox="true" isIOBox="true" Value="RightShift">
+                <Pad Id="ShP7hzyrvWROgkIu7O4ht9" Comment="Key" Bounds="1420,446,120,15" ShowValueBox="true" isIOBox="true" Value="RightShift">
                   <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
                     <Choice Kind="TypeFlag" Name="Keys" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Node Bounds="1373,526,30,19" Id="POpftAmTHv6L67SAd0UsZu">
+                <Node Bounds="1393,496,30,19" Id="POpftAmTHv6L67SAd0UsZu">
                   <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
@@ -2744,29 +2745,13 @@
                   <Pin Id="C8pbPahQsEIOhklz5K21p6" Name="Input 2" Kind="InputPin" />
                   <Pin Id="NtB7XjhiD3MOyUxzY7NSMZ" Name="Output" Kind="StateOutputPin" />
                 </Node>
-                <Node Bounds="852,816,45,19" Id="Tb6yA4gkznlN9ByfQCZv0q">
-                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
-                    <Choice Kind="OperationCallFlag" Name="Switch" />
-                  </p:NodeReference>
-                  <Pin Id="LVwovCphonpLn4R9w7AE8U" Name="Index" Kind="InputPin" />
-                  <Pin Id="F0Tt1E1q5VMLJ3VPRfU9a2" Name="Input" Kind="InputPin" />
-                  <Pin Id="QVFoQ2wJERbLdUCkVKYZFz" Name="Input 2" Kind="InputPin" DefaultValue="0.3" />
-                  <Pin Id="SGUsY7fQjTRL3ira7TE47F" Name="Output" Kind="OutputPin" />
-                </Node>
-                <Pad Id="PsM4OXst2CAMJ34Pylw6Eb" Comment="" Bounds="874,786,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
+                <Pad Id="PsM4OXst2CAMJ34Pylw6Eb" Comment="" Bounds="953,545,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="ImmutableTypeFlag" Name="Float32" />
                   </p:TypeAnnotation>
                 </Pad>
-                <Pad Id="MGhGfKf5L3hN6FYBNKS1OE" Comment="" Bounds="894,803,35,15" ShowValueBox="true" isIOBox="true" Value="0.4">
-                  <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-                    <Choice Kind="TypeFlag" Name="Float32" />
-                  </p:TypeAnnotation>
-                </Pad>
                 <ControlPoint Id="D7s6aEwG4bRPtediTtKboD" Bounds="815,675" />
-                <Node Bounds="868,436,45,19" Id="I49NwlQFRNgOMLkvouuBbT">
+                <Node Bounds="812,380,45,19" Id="I49NwlQFRNgOMLkvouuBbT">
                   <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
@@ -2777,9 +2762,9 @@
                   <Pin Id="PXg0Sb02cNJP1fKyHQ9NR5" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="NFkGTStR5XINzt7HBuUr3A" Name="Input 3" Kind="InputPin" />
                 </Node>
-                <ControlPoint Id="FMpRe2Oj3q1PaeIVvxu4Pm" Bounds="874,740" />
-                <ControlPoint Id="HuPgBTh7vm5QUryYd1vN78" Bounds="894,760" />
-                <Node Bounds="777,620,45,19" Id="DWci8eFYxTcMzrh4y7Unlw">
+                <ControlPoint Id="FMpRe2Oj3q1PaeIVvxu4Pm" Bounds="953,514" />
+                <ControlPoint Id="HuPgBTh7vm5QUryYd1vN78" Bounds="960,705" />
+                <Node Bounds="777,605,45,19" Id="DWci8eFYxTcMzrh4y7Unlw">
                   <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
@@ -2790,7 +2775,7 @@
                   <Pin Id="SLg4fTvz24vLPctcZj9BDZ" Name="Scalar 2" Kind="InputPin" />
                   <Pin Id="SvUfW4jjnvsNrg1CLnOZBP" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Pad Id="KzBUYCHShp3OGtCtc3liUm" Comment="Interest Delta Speed" Bounds="819,600,35,15" ShowValueBox="true" isIOBox="true" Value="2">
+                <Pad Id="KzBUYCHShp3OGtCtc3liUm" Comment="Interest Delta Speed" Bounds="819,585,35,15" ShowValueBox="true" isIOBox="true" Value="2">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="Float32" />
                     <CategoryReference Kind="Category" Name="Primitive" />
@@ -2806,7 +2791,7 @@
                   <Pin Id="NzHwQpsKbGbNDgdpgogge2" Name="Z" Kind="InputPin" />
                   <Pin Id="U6gg6KMLJzfLLHw2laFkPt" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="779,940,25,19" Id="Hoi5a71soheNxyFruPALlU">
+                <Node Bounds="779,940,39,19" Id="Hoi5a71soheNxyFruPALlU">
                   <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="+" />
@@ -2815,8 +2800,7 @@
                   <Pin Id="Cy4hUeJCozKNUxHl8tF4Ya" Name="Input 2" Kind="InputPin" />
                   <Pin Id="D8WSVrxe0WdL583mZgSv0b" Name="Output" Kind="OutputPin" />
                 </Node>
-                <ControlPoint Id="GHBQ6x0y966LXcqqQZRApS" Bounds="781,929" />
-                <Node Bounds="1214,720,163,19" Id="FR8ajo6k5yDMsKvGqSbaNA">
+                <Node Bounds="1234,660,163,19" Id="FR8ajo6k5yDMsKvGqSbaNA">
                   <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="BooleanType" Name="Boolean" NeedsToBeDirectParent="true" />
@@ -2842,14 +2826,290 @@
                   <Pin Id="UqMQtEY4ADQPlqgx4hVAqp" Name="Result" Kind="OutputPin" />
                   <Pin Id="KacFqLrrJdhL5giMzMQrav" Name="Unchanged" Kind="OutputPin" />
                 </Node>
+                <Node Bounds="1447,619,75,26" Id="G2UuAXYEG0SONiYKkKGY4b">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="MToEi6b09dBNLtNpED99ip" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="TpYeGsuEx43MTXgzVM48Oj" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="JBAMEICkj0qPlnD6WbeIx2" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="OmBs5waGyPuNsYK7SB1EH1" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="FZ8bXg7f87RQECCNDr1GzH" Comment="Key" Bounds="1519,609,120,15" ShowValueBox="true" isIOBox="true" Value="LeftCtrl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1472,654,75,26" Id="NWMhrgcO0MDLBr6jpMe9Fc">
+                  <p:NodeReference LastCategoryFullName="Stride.API.Input.IKeyboardDevice" LastDependency="VL.Stride.Runtime.TypeForwards.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="IsKeyDown" />
+                    <CategoryReference Kind="MutableInterfaceType" Name="IKeyboardDevice" NeedsToBeDirectParent="true" />
+                  </p:NodeReference>
+                  <Pin Id="M8HciEBn1fbNDKMBE6HjUH" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="RL08WOQZyKaNXzqVzsfNEg" Name="Key" Kind="InputPin" DefaultValue="W" />
+                  <Pin Id="TqPYoI0Y1MIN8CPeNyTdyq" Name="Output" Kind="StateOutputPin" />
+                  <Pin Id="PZsgRtyexPMMQuBofhnuep" Name="Result" Kind="OutputPin" />
+                </Node>
+                <Pad Id="NxI4JyDi3Z5L7fm67mEHDY" Comment="Key" Bounds="1544,644,120,15" ShowValueBox="true" isIOBox="true" Value="RightCtrl">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.API.Input" LastDependency="VL.Stride.Runtime.vl">
+                    <Choice Kind="TypeFlag" Name="Keys" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <Node Bounds="1517,690,30,19" Id="KohUY80KvQ4QW7euPATRgS">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="OR" />
+                  </p:NodeReference>
+                  <Pin Id="RIdY8KKTv0vLusxSOcBVSz" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="I7mpz6U6VWyLFbHwSouD2J" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="RncbTmMADMPMaKxD9kOgFZ" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Node Bounds="670,645,46,19" Id="Ks3D11vEoj4LTWnqjNEQyf">
+                  <p:NodeReference LastCategoryFullName="3D.Vector3" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="4043309058" Name="Vector3" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
+                  </p:NodeReference>
+                  <Pin Id="QHep3K7swZtMuPNCJnAt96" Name="X" Kind="InputPin" />
+                  <Pin Id="IgQzBWUo2rGNLkMrEk8qrZ" Name="Y" Kind="InputPin" />
+                  <Pin Id="E3trQRKdwiwN8vIaDB5JXb" Name="Z" Kind="InputPin" />
+                  <Pin Id="LMqsVcauNyMQWjPpLnV8hD" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="777,780,25,19" Id="KQkBZOfr2LoM0IB8OoDYmI">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="+" />
+                  </p:NodeReference>
+                  <Pin Id="A9f8OODxMbnLU6a05LmFmY" Name="Input" Kind="InputPin" />
+                  <Pin Id="N7wM42J8YUZLp3drj8hZgh" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Ip77gfcEizmOOCoKSHp8KJ" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="711,610,25,19" Id="HgwgJVoxHS3PwvVonF7uaz">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="Math" />
+                    <Choice Kind="OperationCallFlag" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="Fp0vH7JDkSKLLUaHoQM631" Name="Input" Kind="InputPin" />
+                  <Pin Id="NMksRwNUy1zL24dAd6QEbp" Name="Input 2" Kind="InputPin" DefaultValue="-2" />
+                  <Pin Id="IDBhcvhAi19MB3z84STgMY" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="650,749,45,19" Id="VE4zX6hXzp8QLS2iEwkiwD">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Switch" />
+                  </p:NodeReference>
+                  <Pin Id="SUusRFfcqH8Pb0SSeb91PE" Name="Index" Kind="InputPin" />
+                  <Pin Id="UhVhU4MTgyKPnJbMo0snri" Name="Input" Kind="InputPin" />
+                  <Pin Id="E0sUfll1I3ULDOgK9SxCC0" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="OzaFpsV5uTmN6zPwY9gM3j" Name="Output" Kind="OutputPin" />
+                </Node>
+                <ControlPoint Id="T5253jcTE2WOyKEVyxJUt0" Bounds="700,709" />
+                <Node Bounds="1045,552,45,19" Id="Vp9tQuxgMmbNNTLaMgs3S5">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Switch" />
+                  </p:NodeReference>
+                  <Pin Id="CkrL7azxGnVM8ft39oYjUf" Name="Index" Kind="InputPin" />
+                  <Pin Id="Pg3P7EBO8pIQSbWaj28WWT" Name="Input" Kind="InputPin" />
+                  <Pin Id="Qn0oRZwAJtXLRyVOUgOvQG" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="OJmHnqpRTxTPMWOFBlvwON" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="1016,652,93,19" Id="VIWf0SlBj2hNWpsOvWoxCz">
+                  <p:NodeReference LastCategoryFullName="Animation.FrameBased" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="ProcessAppFlag" Name="Integrator" />
+                  </p:NodeReference>
+                  <Pin Id="BkOcLM8zW31LoZyeXuNXiS" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                  <Pin Id="HAuHI22NZI2PFovoqSu7JR" Name="Initial Value" Kind="InputPin" DefaultValue="0.1" />
+                  <Pin Id="TdywiaZTfneLPLkWJTk4R6" Name="Offset" Kind="InputPin" />
+                  <Pin Id="MV8Havkvr8mOBADPeTJT7n" Name="Reset Value" Kind="InputPin" />
+                  <Pin Id="KQRf3hZtDtQLCumOb2g0zM" Name="Value" Kind="OutputPin" />
+                  <Pin Id="Jf2GOfgcS60MaKK32w8pQv" Name="Reset" Kind="InputPin" />
+                </Node>
+                <Node Bounds="1085,522,25,19" Id="BPC8QDIGf9bOHnJq8VUZr0">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <FullNameCategoryReference ID="Math" />
+                    <Choice Kind="OperationCallFlag" Name="* (Scale)" />
+                  </p:NodeReference>
+                  <Pin Id="M9Onf33PwAvMn4pWjZLoYJ" Name="Input" Kind="InputPin" />
+                  <Pin Id="DHS2iuLCqVpNSdILHsRexD" Name="Scalar" Kind="InputPin" DefaultValue="0.01" />
+                  <Pin Id="VdmPuSRrR77MYGJ5xPXTQf" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Pad Id="F4Op1o52BnwLahzRlYmbXF" Comment="" Bounds="1018,790,43,17" ShowValueBox="true" isIOBox="true" />
+                <Node Bounds="1075,622,25,19" Id="AHeaeEOzkrAMG4FQO9LUQc">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="UVIRmpOZN2FLp5RY9LHK20" Name="Input" Kind="InputPin" />
+                  <Pin Id="FMhDvcX8iKIMBQZ3MKxLQi" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Qm7dFD6GA3kPDjA8IhD30x" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="650,716,30,19" Id="CoKuEjfVQdgLJqUU2PRNEl">
+                  <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="OR" />
+                  </p:NodeReference>
+                  <Pin Id="Tkh19H1ALH2NKyaRvW9dvX" Name="Input" Kind="StateInputPin" />
+                  <Pin Id="Gzaya5Piw2uQZkWVN7TCF3" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="KEL5pOLgilVNUptOtTm80C" Name="Output" Kind="StateOutputPin" />
+                </Node>
+                <Pad Id="NmiIaJZtbeLQMdmNPqUlpZ" Comment="Mouse Button" Bounds="854,181,78,15" ShowValueBox="true" isIOBox="true" Value="Left">
+                  <p:TypeAnnotation LastCategoryFullName="Stride.Input" LastDependency="VL.Stride.Rendering.vl">
+                    <Choice Kind="TypeFlag" Name="MouseButton" />
+                  </p:TypeAnnotation>
+                </Pad>
+                <ControlPoint Id="RqMnxT7CaP9Ncptb14UatB" Bounds="834,410" />
+                <!--
+
+    ************************ ConfineResultWithin ************************
+
+-->
+                <Node Name="ConfineResultWithin" Bounds="1762,323,240,284" Id="HcuABidUyy4Lmk9Tnrja1H">
+                  <p:NodeReference>
+                    <Choice Kind="OperationDefinition" />
+                  </p:NodeReference>
+                  <Patch Id="LFVdRaDVFdmO0zQQaAQATB">
+                    <Node Bounds="1774,420,25,19" Id="E8lViVecKsQMnL08Ej29Uc">
+                      <p:NodeReference LastCategoryFullName="Primitive.Float32" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="Float32Type" Name="Float32" NeedsToBeDirectParent="true" />
+                        <Choice Kind="OperationCallFlag" Name="&lt;" />
+                      </p:NodeReference>
+                      <Pin Id="R5fvzHHQjvGM9mVGv5Lc2p" Name="Input" Kind="InputPin" />
+                      <Pin Id="EEI0AtlkdJYMiayznCgzo4" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="OPyNQG5LOx8P6KBZhcARiV" Name="Result" Kind="OutputPin" />
+                    </Node>
+                    <Node Bounds="1938,420,25,19" Id="Viuqn6JZ2hiNa7ZsD7vB7L">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <Choice Kind="OperationCallFlag" Name="&gt;" />
+                      </p:NodeReference>
+                      <Pin Id="G4FynaAc98yPrMROFqlizb" Name="Input" Kind="InputPin" />
+                      <Pin Id="GWf1DtQZtf8LtFdWyIHYn5" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="VeAIAKvWn4XOMwXrXuzP94" Name="Result" Kind="OutputPin" />
+                    </Node>
+                    <Pin Id="UIWfTIBfXfOQXqIOjTVnaM" Name="Input" Kind="InputPin">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="TypeFlag" Name="Float32" />
+                      </p:TypeAnnotation>
+                    </Pin>
+                    <ControlPoint Id="LnUx8PO7hlgOk2ZSdRSHCZ" Bounds="1776,341" />
+                    <Link Id="Thw0LlmQ7u0N5TXMWNFw7D" Ids="UIWfTIBfXfOQXqIOjTVnaM,LnUx8PO7hlgOk2ZSdRSHCZ" IsHidden="true" />
+                    <ControlPoint Id="OoHlbR2IGk2MrgYoIsTjto" Bounds="1921,341" />
+                    <ControlPoint Id="PO7k4cz1OACNwGx00wMzQo" Bounds="1960,341" />
+                    <Pin Id="HBgTCtWBC35MLwDoGddwfD" Name="Last Value" Kind="InputPin" />
+                    <Link Id="SQtv2OvAzmTLGv4BtUgzTS" Ids="HBgTCtWBC35MLwDoGddwfD,RwDrluIQfoYL6k4V3E8WLI" IsHidden="true" />
+                    <Pin Id="FRmjAsBhIlnOvT2FueBm8N" Name="Min" Kind="InputPin">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="TypeFlag" Name="Float32" />
+                      </p:TypeAnnotation>
+                    </Pin>
+                    <Link Id="QegEpyrr2QxQdUXONTYXXk" Ids="FRmjAsBhIlnOvT2FueBm8N,OoHlbR2IGk2MrgYoIsTjto" IsHidden="true" />
+                    <Pin Id="OdflsKxmOgxMAHKJzyzitY" Name="Max" Kind="InputPin">
+                      <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="TypeFlag" Name="Float32" />
+                      </p:TypeAnnotation>
+                    </Pin>
+                    <Link Id="H2f0lsnVb3JQWJyGMqgTeh" Ids="OdflsKxmOgxMAHKJzyzitY,PO7k4cz1OACNwGx00wMzQo" IsHidden="true" />
+                    <Link Id="OR0o3OnYal6Pazw1AOBFlc" Ids="OoHlbR2IGk2MrgYoIsTjto,EEI0AtlkdJYMiayznCgzo4" />
+                    <Link Id="A5RlFxoOHCBQRdDdU5mXAk" Ids="LnUx8PO7hlgOk2ZSdRSHCZ,KUO94OjOW3XLZmr6i6SW7W" />
+                    <Link Id="GtNoa42SZ8HO63Ib8IJpHp" Ids="PO7k4cz1OACNwGx00wMzQo,GWf1DtQZtf8LtFdWyIHYn5" />
+                    <Node Bounds="1834,470,45,19" Id="Pf1mnTtspwuLzskiWVLGKP">
+                      <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
+                        <Choice Kind="OperationCallFlag" Name="Switch" />
+                      </p:NodeReference>
+                      <Pin Id="PLh1nL6QREQMp3tKc4dyig" Name="Index" Kind="InputPin" />
+                      <Pin Id="GiCxBBlHxwzM4eJB9dkRh6" Name="Input" Kind="InputPin" />
+                      <Pin Id="FNjcUFLFQQ4NK5eVCsfO3k" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="KQ8AQeX5twHNaPZzV6kFNg" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Link Id="KCI8i2jT5pXQCRBYYMrO9R" Ids="OPyNQG5LOx8P6KBZhcARiV,PLh1nL6QREQMp3tKc4dyig" />
+                    <Node Bounds="1861,540,45,19" Id="JVP9avQUWq8OFp0TpenVla">
+                      <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
+                        <Choice Kind="OperationCallFlag" Name="Switch" />
+                      </p:NodeReference>
+                      <Pin Id="HHY3ubBHeqnPHxrg6jZDv4" Name="Index" Kind="InputPin" />
+                      <Pin Id="StWRR1YkOKdPsEvNLOF0nI" Name="Input" Kind="InputPin" />
+                      <Pin Id="NYORDuosttMOn9LUzMKGtM" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="MSsFrBCjPDnPSzO6hX9t4u" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Link Id="RD1oOjfkdDtL6QM1sreG3h" Ids="VeAIAKvWn4XOMwXrXuzP94,HHY3ubBHeqnPHxrg6jZDv4" />
+                    <Node Bounds="1774,370,25,19" Id="OeWYrpBBF31NFhzjSRYSIg">
+                      <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                        <FullNameCategoryReference ID="Math" />
+                        <Choice Kind="OperationCallFlag" Name="+" />
+                      </p:NodeReference>
+                      <Pin Id="KUO94OjOW3XLZmr6i6SW7W" Name="Input" Kind="InputPin" />
+                      <Pin Id="LFeKKp2ewC3L0SD7BHeQdN" Name="Input 2" Kind="InputPin" />
+                      <Pin Id="D7tZmQMU1mkPtWuyiCZl1v" Name="Output" Kind="OutputPin" />
+                    </Node>
+                    <Link Id="S4Y9UuwRQ1APxiB1x5YvbA" Ids="D7tZmQMU1mkPtWuyiCZl1v,G4FynaAc98yPrMROFqlizb" />
+                    <ControlPoint Id="RwDrluIQfoYL6k4V3E8WLI" Bounds="1821,341" />
+                    <Link Id="BxFKVIrbvKNPEdS196BHsF" Ids="RwDrluIQfoYL6k4V3E8WLI,LFeKKp2ewC3L0SD7BHeQdN" />
+                    <Link Id="SBPgUjxy7FDQNbcAtb2nV2" Ids="D7tZmQMU1mkPtWuyiCZl1v,R5fvzHHQjvGM9mVGv5Lc2p" />
+                    <Link Id="QHWZeb44PLGQO7E36XLx6N" Ids="LnUx8PO7hlgOk2ZSdRSHCZ,GiCxBBlHxwzM4eJB9dkRh6" />
+                    <Link Id="JbQHHugxDiGO29tR0m3Kqd" Ids="KQ8AQeX5twHNaPZzV6kFNg,StWRR1YkOKdPsEvNLOF0nI" />
+                    <ControlPoint Id="T21NMXHRPCCOlFjCcHBQ9z" Bounds="1863,590" />
+                    <Link Id="KarcwduO7GaNzL8LYyvFYQ" Ids="MSsFrBCjPDnPSzO6hX9t4u,T21NMXHRPCCOlFjCcHBQ9z" />
+                    <Pin Id="UQ5QRNu71cLMmBIsPuNeVw" Name="Output" Kind="OutputPin" />
+                    <Link Id="KOpFHwysoG2O4cCOTovBF6" Ids="T21NMXHRPCCOlFjCcHBQ9z,UQ5QRNu71cLMmBIsPuNeVw" IsHidden="true" />
+                  </Patch>
+                </Node>
+                <Pad Id="OfXbWxgxtA7LnoXjGUJjnU" SlotId="Rvdz9D3P8EHQON6GFDVSGM" Bounds="1018,770" />
+                <Pad Id="OYiicZmDSwzNG5RM6GUCeo" SlotId="Rvdz9D3P8EHQON6GFDVSGM" Bounds="1028,564" />
+                <Node Bounds="1045,580,108,19" Id="Hm0SVUkUqJZMhzexR0p02W">
+                  <p:NodeReference LastCategoryFullName="Stride.Cameras.WASDCameraControls" LastDependency="VL.Stride.Engine.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="ConfineResultWithin" />
+                  </p:NodeReference>
+                  <Pin Id="CLTkbQdmyVMLnWGjaZd5Oc" Name="Input" Kind="InputPin" />
+                  <Pin Id="T3tQtaJZCi1OTPV1uPOFH7" Name="Last Value" Kind="InputPin" />
+                  <Pin Id="GR3hvwqXtixM70NCgb3sgy" Name="Min" Kind="InputPin" />
+                  <Pin Id="HKIMV9LkKQROT7N8FUkE50" Name="Max" Kind="InputPin" DefaultValue="1" />
+                  <Pin Id="Gx4RSOnw5RYOtOKmK93zZP" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="918,800,25,19" Id="DvR4sZF3t6MPFOCNkgb3w2">
+                  <p:NodeReference LastCategoryFullName="Math" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <Choice Kind="OperationCallFlag" Name="*" />
+                  </p:NodeReference>
+                  <Pin Id="Tb1X8puQ2PQL2KdGBQET9E" Name="Input" Kind="InputPin" />
+                  <Pin Id="PHBmVNpQjY8OR9XvZZX86k" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="GsxrCMZoeYxPwFUsnhSqcU" Name="Output" Kind="OutputPin" />
+                </Node>
+                <Node Bounds="918,735,45,19" Id="FFuXPtNh0IaNf1w2TgQq17">
+                  <p:NodeReference LastCategoryFullName="Control" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="Category" Name="Control" NeedsToBeDirectParent="true" />
+                    <Choice Kind="OperationCallFlag" Name="Switch" />
+                  </p:NodeReference>
+                  <Pin Id="SFeNyLiSI5iLDWdZUIvYbC" Name="Index" Kind="InputPin" />
+                  <Pin Id="IJVCM7ovPaVMck06U1JS4I" Name="Input" Kind="InputPin" DefaultValue="1" />
+                  <Pin Id="P6lU1nEFWvTQbxXstQTXz9" Name="Input 2" Kind="InputPin" />
+                  <Pin Id="Kfgw0DylLrVPFoRwZS7QaU" Name="Output" Kind="OutputPin" />
+                </Node>
               </Canvas>
               <ProcessDefinition Id="JfVa4ztlLUCQMNBMEG8DKv">
                 <Fragment Id="Ran8gJX74QRQWUS7qa4ohX" Patch="LQPKm5PtWAGOjOsQCTd6Yj" Enabled="true" />
                 <Fragment Id="IWAiiGKBZ4AN1KhSU8jnBk" Patch="JGRy32Nq5tCQAXAmj6ngTA" Enabled="true" />
                 <Fragment Id="OjYt3FUWHD9OVNx7YwoC0Y" Patch="Hb9a6I24BZSQZgyKJkT967" />
+                <Fragment Id="JufjI2u7XZPMf3fC0PPAKw" Patch="HcuABidUyy4Lmk9Tnrja1H" />
               </ProcessDefinition>
               <Patch Id="LQPKm5PtWAGOjOsQCTd6Yj" Name="Create" IsGeneric="true" />
-              <Patch Id="JGRy32Nq5tCQAXAmj6ngTA" Name="Update">
+              <Patch Id="JGRy32Nq5tCQAXAmj6ngTA" Name="Update" ParticipatingElements="QY2AJoGdBWzPybIC43iSi3">
                 <Pin Id="PlnIF3o77eONdnoomz4lTj" Name="Camera Controls" Kind="InputPin" />
                 <Pin Id="Tra4UUQKcK0LJSRmNkDBid" Name="Filter Time" Kind="InputPin" DefaultValue="0.3">
                   <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
@@ -2858,8 +3118,8 @@
                 </Pin>
                 <Pin Id="Szb343uB0YzLJUR3pImZyl" Name="Window Input Source" Kind="InputPin" />
                 <Pin Id="KbbMLEhIH6IQMxmU9imIKf" Name="Camera Controls" Kind="OutputPin" />
-                <Pin Id="EGeZKq7i414P4PnXEffc8C" Name="Speed" Kind="InputPin" />
-                <Pin Id="HsH0s03ESE6OScOdCc0E5O" Name="High Speed" Kind="InputPin" />
+                <Pin Id="EGeZKq7i414P4PnXEffc8C" Name="Speed" Kind="InputPin" DefaultValue="0.1" />
+                <Pin Id="VASKob0VkKQM5L48Jo3Tkh" Name="Speed Multiplier" Kind="InputPin" DefaultValue="3" />
                 <Pin Id="LjBDa6v8t86OYSE23cmEOV" Name="Enable Controls" Kind="InputPin" />
               </Patch>
               <Link Id="AlNaVgfzCffLzOCUKkeUhC" Ids="PlnIF3o77eONdnoomz4lTj,DcvMjjEmhqnMpMZj3ZpWYj" IsHidden="true" />
@@ -2956,10 +3216,6 @@
               <Link Id="HyykkDEsnNHPjzTfnImqQQ" Ids="HXLrIfFyNXmLeVM9jaZum9,Vu4pPlf8WmOOt1uEZMjIPb" />
               <Link Id="BKsjSkF3HMvP6ZrnvP4hf6" Ids="E7no0wh9WoSOdYN4vtRqYL,C8pbPahQsEIOhklz5K21p6" />
               <Link Id="Cr6jw0lKWpCNZUDlFA6t4H" Ids="DrDToRwO6B1OWaf92unxRB,EqoFTzBMlRBN0canPPkHy2" />
-              <Link Id="VxMFQYCYlTyO3OBkOgAj1T" Ids="NtB7XjhiD3MOyUxzY7NSMZ,LVwovCphonpLn4R9w7AE8U" />
-              <Link Id="FjemHcUQjHRMzLoX0fXXR3" Ids="PsM4OXst2CAMJ34Pylw6Eb,F0Tt1E1q5VMLJ3VPRfU9a2" />
-              <Link Id="Aq9iPjYF6jzNxh79TjOCmt" Ids="SGUsY7fQjTRL3ira7TE47F,OGenmaOqCD0LOCFu3ClkdX" />
-              <Link Id="RGFJjtgVeDfQY16bsdg9zk" Ids="MGhGfKf5L3hN6FYBNKS1OE,QVFoQ2wJERbLdUCkVKYZFz" />
               <Link Id="O6Hbf3dTFXOMyW0gsroQwV" Ids="OVTSBXIsAwtMGH3L8I2Ohk,N8ty1m8XG8eQAwqRgNYi1M" />
               <Link Id="BRJTzStTgz0QOFWQzq4blm" Ids="MrcEFUU7kKlNVBvE1Q9iJA,QZWthVpFVOMOqhf6PRe0NQ" />
               <Link Id="TbPpSn2OHZJLehsQwYzeTS" Ids="KZI2ZZ73p8KP2NE1ESGczQ,JqFaObWwNx1MGdcnsXcb9g" />
@@ -2969,13 +3225,10 @@
               <Link Id="MWMvb95sv4uO3CQtj9LRjG" Ids="PXg0Sb02cNJP1fKyHQ9NR5,Ed35c0TF7icNoooIz8i3BO" />
               <Link Id="AG2xMGhPJ06L2wE4CH70PT" Ids="FMpRe2Oj3q1PaeIVvxu4Pm,PsM4OXst2CAMJ34Pylw6Eb" />
               <Link Id="RZQEWhclQxwMLwPEkk8muY" Ids="EGeZKq7i414P4PnXEffc8C,FMpRe2Oj3q1PaeIVvxu4Pm" IsHidden="true" />
-              <Link Id="H9KxGCiOOPDQJLENkGiJI7" Ids="HuPgBTh7vm5QUryYd1vN78,MGhGfKf5L3hN6FYBNKS1OE" />
-              <Link Id="L2cAPMXJJwYQNqAvsp59Hi" Ids="HsH0s03ESE6OScOdCc0E5O,HuPgBTh7vm5QUryYd1vN78" IsHidden="true" />
               <Link Id="F8MJMdK2q9HOhWJh5sPpMG" Ids="KzBUYCHShp3OGtCtc3liUm,SLg4fTvz24vLPctcZj9BDZ" />
-              <Link Id="BmaTgQmqIneN9HHQlktF5l" Ids="BsC4v49fXeUPjWG958GSKI,KNS10uoc61xNrT0KgJkctU" />
+              <Link Id="BmaTgQmqIneN9HHQlktF5l" Ids="BsC4v49fXeUPjWG958GSKI,RqMnxT7CaP9Ncptb14UatB,KNS10uoc61xNrT0KgJkctU" />
               <Link Id="UHnPUmSV0ujLdCAsX4QaqH" Ids="U6gg6KMLJzfLLHw2laFkPt,KPPvMa795JnNfHvK4i8kEo" />
               <Link Id="JlDdPmgCPv1MSKmuVim7WN" Ids="Q4MSsBlffv0ODC7AMjch14,Cy4hUeJCozKNUxHl8tF4Ya" />
-              <Link Id="AW8wcx4eudTPT89suKLJUL" Ids="SvUfW4jjnvsNrg1CLnOZBP,GHBQ6x0y966LXcqqQZRApS,VLxNkcekASsL2U8oRJrdOk" />
               <Link Id="RALuN4AzjMxPhbE5qqDNtv" Ids="D8WSVrxe0WdL583mZgSv0b,DOf74aF95LKNssbHMJbohq" />
               <Link Id="VgC3buQFJwnNxn3C7Tc1iu" Ids="QqTwSThVzYhMiPzLul4e6v,RjWDpcqhdxiQZ9USJB0jLX" />
               <Link Id="CH1kT7n1fryMTU0AFXc6No" Ids="D8WSVrxe0WdL583mZgSv0b,ADyyY57LY4bNylbHVFAJ4O" />
@@ -2990,6 +3243,42 @@
               <Link Id="J1kv8ejdxOVMBde3GjVziW" Ids="LCjkgRLyKRBML18CJUaR0a,FDCCVRhdzNIMUEkTtfu0UN" />
               <Link Id="GizuWAkZCuqLBuCFJW0O4H" Ids="UqMQtEY4ADQPlqgx4hVAqp,JoNDRTBds59LKm9kN42tHn" />
               <Link Id="FHt0CPXMhtxPzebY8GPnQ9" Ids="S9HOIa7KgXaO0o4encKFQx,S8s7Ci6tBZ6NlRLQUevfnQ" />
+              <Link Id="LMtj25cXZ5pPjG3A7B3wzO" Ids="FZ8bXg7f87RQECCNDr1GzH,TpYeGsuEx43MTXgzVM48Oj" />
+              <Link Id="OaZ8P4OYnPiO4gX8sl6KiT" Ids="NxI4JyDi3Z5L7fm67mEHDY,RL08WOQZyKaNXzqVzsfNEg" />
+              <Link Id="R0IhxbmBk5zO74CbWxjZ0N" Ids="JBAMEICkj0qPlnD6WbeIx2,M8HciEBn1fbNDKMBE6HjUH" />
+              <Link Id="EZS9emmvk4FOWXDvTe5Q2N" Ids="OmBs5waGyPuNsYK7SB1EH1,RIdY8KKTv0vLusxSOcBVSz" />
+              <Link Id="TZ7XYiqund2Np2G4ttLzCx" Ids="PZsgRtyexPMMQuBofhnuep,I7mpz6U6VWyLFbHwSouD2J" />
+              <Link Id="PbFAvmFYox8MJ0lzSx7yO6" Ids="PBHFd0Wh2UFOpIB5dSfJLr,MToEi6b09dBNLtNpED99ip" />
+              <Link Id="Ggf4rF5U1iuNJ9Hl4grppU" Ids="RncbTmMADMPMaKxD9kOgFZ,T5253jcTE2WOyKEVyxJUt0,PT9mxvYgLNYLXClbIGqwC1" />
+              <Link Id="KaBgzDDSL2ANGPAUcus36q" Ids="S9HOIa7KgXaO0o4encKFQx,Fp0vH7JDkSKLLUaHoQM631" />
+              <Link Id="GIjtEG9AphbM8L5shOBWzh" Ids="SvUfW4jjnvsNrg1CLnOZBP,A9f8OODxMbnLU6a05LmFmY" />
+              <Link Id="S2rAbBRmJ0MMOspqFSr3G0" Ids="Ip77gfcEizmOOCoKSHp8KJ,VLxNkcekASsL2U8oRJrdOk" />
+              <Link Id="JrBQoy1BjPRLSBJDopqBK7" Ids="IDBhcvhAi19MB3z84STgMY,E3trQRKdwiwN8vIaDB5JXb" />
+              <Link Id="Uznuwf9N2s9MJcaPcUBHif" Ids="LMqsVcauNyMQWjPpLnV8hD,UhVhU4MTgyKPnJbMo0snri" />
+              <Link Id="Cky5ChEmS59My6qj7ejzD4" Ids="OzaFpsV5uTmN6zPwY9gM3j,N7wM42J8YUZLp3drj8hZgh" />
+              <Link Id="EVE1YrbPKDGNZaLf5Bw13A" Ids="Fu70tiuvgFvOb3Bd9lnxxs,CkrL7azxGnVM8ft39oYjUf" />
+              <Link Id="H18MYxGmAiCMe2YW28N6Vm" Ids="S9HOIa7KgXaO0o4encKFQx,M9Onf33PwAvMn4pWjZLoYJ" />
+              <Link Id="PRWNXkiZCuJN6wdu56e2tZ" Ids="FbcZQiNdNtMMJnOalTbYD0,FMhDvcX8iKIMBQZ3MKxLQi" />
+              <Link Id="McYFAgBt9NAO7En4BNa6bN" Ids="Qm7dFD6GA3kPDjA8IhD30x,MV8Havkvr8mOBADPeTJT7n" />
+              <Link Id="RrWX7hLQaOtNJDlHiGjmy0" Ids="FbcZQiNdNtMMJnOalTbYD0,Jf2GOfgcS60MaKK32w8pQv" />
+              <Link Id="SxRCRkmjibqLbCibwmBBtO" Ids="RncbTmMADMPMaKxD9kOgFZ,Gzaya5Piw2uQZkWVN7TCF3" />
+              <Link Id="SwxcjnqFbjMQcBvDxoBjZl" Ids="KEL5pOLgilVNUptOtTm80C,SUusRFfcqH8Pb0SSeb91PE" />
+              <Link Id="MNhO72YhamwPp039sCLxcH" Ids="Fu70tiuvgFvOb3Bd9lnxxs,Tkh19H1ALH2NKyaRvW9dvX" />
+              <Link Id="VnyHKQshpo7PKk24epv1My" Ids="VdmPuSRrR77MYGJ5xPXTQf,Qn0oRZwAJtXLRyVOUgOvQG" />
+              <Link Id="BkcZBZBSte3Pc5PXL8kR4U" Ids="NmiIaJZtbeLQMdmNPqUlpZ,KZv3Mjb2VokNG9lhH24MUa" />
+              <Link Id="KcxnoSb09hHPxkVJhKiNHa" Ids="KQRf3hZtDtQLCumOb2g0zM,OfXbWxgxtA7LnoXjGUJjnU" />
+              <Link Id="TMSD5W0V8PYP6bnYgAjFoB" Ids="OYiicZmDSwzNG5RM6GUCeo,T3tQtaJZCi1OTPV1uPOFH7" />
+              <Link Id="PYsSjGJMMpAOoddRjm5PZ4" Ids="OJmHnqpRTxTPMWOFBlvwON,CLTkbQdmyVMLnWGjaZd5Oc" />
+              <Link Id="M1RNKk5FBN7P4bLZ8C10Ts" Ids="Gx4RSOnw5RYOtOKmK93zZP,TdywiaZTfneLPLkWJTk4R6" />
+              <Slot Id="Rvdz9D3P8EHQON6GFDVSGM" Name="Current Speed" />
+              <Link Id="QY2AJoGdBWzPybIC43iSi3" Ids="OfXbWxgxtA7LnoXjGUJjnU,F4Op1o52BnwLahzRlYmbXF" />
+              <Link Id="R2GITjkKsaBNHAdz22YtUv" Ids="OfXbWxgxtA7LnoXjGUJjnU,PHBmVNpQjY8OR9XvZZX86k" />
+              <Link Id="IrqDpC2ZV5IPLlQ9B759T5" Ids="GsxrCMZoeYxPwFUsnhSqcU,OGenmaOqCD0LOCFu3ClkdX" />
+              <Link Id="GXTz5CmQzt5MAhoyb5BoGU" Ids="VASKob0VkKQM5L48Jo3Tkh,HuPgBTh7vm5QUryYd1vN78" IsHidden="true" />
+              <Link Id="OgBpeXFA1thNbIN0ft9G2H" Ids="NtB7XjhiD3MOyUxzY7NSMZ,SFeNyLiSI5iLDWdZUIvYbC" />
+              <Link Id="D4gotSdSB11O1gaqUqrk0w" Ids="HuPgBTh7vm5QUryYd1vN78,P6lU1nEFWvTQbxXstQTXz9" />
+              <Link Id="Gq8nzAZ8ZctNLCQu9SLsqV" Ids="PsM4OXst2CAMJ34Pylw6Eb,UVIRmpOZN2FLp5RY9LHK20" />
+              <Link Id="QKgrxMk2WAmNAnOu7YCCdp" Ids="Kfgw0DylLrVPFoRwZS7QaU,Tb1X8puQ2PQL2KdGBQET9E" />
             </Patch>
           </Node>
           <!--
@@ -3040,7 +3329,7 @@
                   <Pin Id="JahQwuyMGVbOVGK7aNm1tm" Name="Simulate" Kind="InputPin" />
                   <Pin Id="Rf03553zmyVQSpjGuZOcUT" Name="Output" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="808,300,124,19" Id="M9XPGommpF7NAisqAXO2oB">
+                <Node Bounds="808,300,125,19" Id="M9XPGommpF7NAisqAXO2oB">
                   <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.Engine.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="Category" Name="Cameras" NeedsToBeDirectParent="true" />
@@ -3052,8 +3341,9 @@
                   <Pin Id="OqSxOw51wTNNhVV6S7d4mv" Name="Window Input Source" Kind="InputPin" />
                   <Pin Id="Tc7GJUyxEkvMNatTMMF4d4" Name="Camera Controls" Kind="OutputPin" />
                   <Pin Id="DjjndRj4xWmOBk1Co0475C" Name="Speed" Kind="InputPin" />
-                  <Pin Id="L8XJZCagnGbNAV5IvtULUd" Name="High Speed" Kind="InputPin" />
+                  <Pin Id="URV34vCN9MYQLXGtJGZFPL" Name="Speed Multiplier" Kind="InputPin" />
                   <Pin Id="I2pz6cRj9kdNo1M9JSbMLz" Name="Enable Controls" Kind="InputPin" DefaultValue="True" />
+                  <Pin Id="L8XJZCagnGbNAV5IvtULUd" Name="High Speed" Kind="InputPin" />
                 </Node>
                 <Node Bounds="808,220,74,26" Id="KEKppRUvCgbMNYDwjs0I3N">
                   <p:NodeReference LastCategoryFullName="Editors.3D.CameraControls" LastDependency="VL.EditingFramework.vl">

--- a/VL.Stride/help/Cameras/Explanation WASD Camera.vl
+++ b/VL.Stride/help/Cameras/Explanation WASD Camera.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" xmlns:r="reflection" Id="MbxxMvhsY4GL0IKpduvTst" LanguageVersion="2025.7.1-0025-g457c9ac45e" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="MbxxMvhsY4GL0IKpduvTst" LanguageVersion="2025.7.0" Version="0.128">
   <NugetDependency Id="Rq1hxtGm4prLgcbPnzpr1q" Location="VL.CoreLib" Version="2025.7.0" />
   <Patch Id="EflKC5Ddi2BN1mZWLv60qK">
     <Canvas Id="NBB3K3ClmntMsyQxzUGU5L" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
@@ -98,7 +98,7 @@
             <Pin Id="BgTSBCMSA2EOENPtU1CojS" Name="Enabled" Kind="InputPin" />
             <Pin Id="TEC2boM0rLXNDfs5MvFVPB" Name="Output" Kind="OutputPin" />
           </Node>
-          <Node Bounds="544,512,325,19" Id="HNMQXZ6ZlA7N69T6YIX9tD">
+          <Node Bounds="544,512,345,19" Id="HNMQXZ6ZlA7N69T6YIX9tD">
             <p:NodeReference LastCategoryFullName="Stride.Cameras" LastDependency="VL.Stride.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="WASDCamera" />
@@ -130,7 +130,8 @@
             <Pin Id="AhbIFGUmB8vL6LKV8kSk3s" Name="Camera Component" Kind="OutputPin" />
             <Pin Id="S2i7irGAp4aMOJe54SQ6gc" Name="Interest" Kind="OutputPin" />
             <Pin Id="TsfavvToTdjOgZpXn4BjBT" Name="Speed" Kind="InputPin" />
-            <Pin Id="ECVlzaEfh3nL216yHO2vbZ" Name="High Speed" Kind="InputPin" />
+            <Pin Id="FaAB6ZQOgu5PkBrxmd0b1F" Name="Speed Multiplier" Kind="InputPin" />
+            <Pin Id="AnTg91uBAkYN8aZrTU1rnR" Name="Speed" Kind="OutputPin" />
           </Node>
           <Node Bounds="366,439,165,19" Id="HVZLeyR1AVQOVHzjURWhnM">
             <p:NodeReference LastCategoryFullName="Stride.Models" LastDependency="VL.Stride.Engine.vl">
@@ -185,7 +186,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="So4ec8pMghWNMs24Qx43vd" Bounds="574,56,518,323" ShowValueBox="true" isIOBox="true" Value="Orbit: Drag with Right Mouse Button&#xD;&#xA;Move: Press to move&#xD;&#xA;  W - forward&#xD;&#xA;  S - backward&#xD;&#xA;  A - Left&#xD;&#xA;  D - Right&#xD;&#xA;  E - Up&#xD;&#xA;  Q - Down&#xD;&#xA;(Hold down SHIFT key for high movement speed)&#xD;&#xA;&#xD;&#xA;Track: Drag with Middle Mouse Button&#xD;&#xA;Zoom: Use Mouse Wheel&#xD;&#xA;&#xD;&#xA;Reset: Press &amp; Hold [R] on the Keyboard">
+          <Pad Id="So4ec8pMghWNMs24Qx43vd" Bounds="579,33,527,370" ShowValueBox="true" isIOBox="true" Value="Orbit: Drag with Right Mouse Button&#xD;&#xA;Move: Press to move&#xD;&#xA;  W - forward&#xD;&#xA;  S - backward&#xD;&#xA;  A - Left&#xD;&#xA;  D - Right&#xD;&#xA;  E - Up&#xD;&#xA;  Q - Down&#xD;&#xA;(Hold down SHIFT key for multiplying movement speed)&#xD;&#xA;(Adjust Movement Speed: Hold Right Mouse Button + Mouse Wheel)&#xD;&#xA;&#xD;&#xA;Track: Drag with Middle Mouse Button&#xD;&#xA;Dolly forward/backward: Use Mouse Wheel&#xD;&#xA;Adjust FoV: CTRL + Mouse Wheel&#xD;&#xA;&#xD;&#xA;Reset: Press &amp; Hold [R] on the Keyboard">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
@@ -209,17 +210,12 @@
             <Pin Id="Ripl8xHDY6pPtDjZJM2jaK" Name="Enabled" Kind="InputPin" />
             <Pin Id="DMTNEiuamu8MJk7QRwQCO2" Name="Output" Kind="OutputPin" />
           </Node>
-          <Pad Id="N4YhZKHYEMlMdcOF0Wjvn0" Comment="Initial Interest" Bounds="586,415,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1, 3">
+          <Pad Id="N4YhZKHYEMlMdcOF0Wjvn0" Comment="Initial Interest" Bounds="588,415,35,43" ShowValueBox="true" isIOBox="true" Value="0, 1, 3">
             <p:TypeAnnotation LastCategoryFullName="3D" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Vector3" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="LIt2cgHE3VLNNCG7XTwOJi" Comment="Speed" Bounds="846,466,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
-              <Choice Kind="TypeFlag" Name="Float32" />
-            </p:TypeAnnotation>
-          </Pad>
-          <Pad Id="ITEEHK6f5A8LALQOwM5fOe" Comment="High Speed" Bounds="866,486,35,15" ShowValueBox="true" isIOBox="true" Value="0.4">
+          <Pad Id="LIt2cgHE3VLNNCG7XTwOJi" Comment="Speed" Bounds="865,461,35,15" ShowValueBox="true" isIOBox="true" Value="0.1">
             <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="Float32" />
             </p:TypeAnnotation>
@@ -276,6 +272,12 @@
             <Pin Id="Kvovley2Kf1NQM434pj7pH" Name="Back Buffer" Kind="OutputPin" IsHidden="true" />
             <Pin Id="QbzJ7VZGySiPB3bkazwm8X" Name="Depth Buffer" Kind="OutputPin" IsHidden="true" />
           </Node>
+          <Pad Id="Oc0nIF9Zn4yNhuZWJ5Ld7Z" Comment="Speed Multiplier" Bounds="886,490,35,15" ShowValueBox="true" isIOBox="true" Value="3">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Float32" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="FBPlmfyptGuMriK0BkPrJg" Comment="Speed" Bounds="886,550,35,15" ShowValueBox="true" isIOBox="true" />
         </Canvas>
         <Patch Id="MlJDEAkmWSCNFrBbC1wcnK" Name="Create" />
         <Patch Id="FH0PMPoKAjCPHHW3NlP1Bj" Name="Update" />
@@ -293,9 +295,10 @@
         <Link Id="AnpMe1f3sjEOYfUq8Lq2dl" Ids="DMTNEiuamu8MJk7QRwQCO2,HigQ7qCGgu3N7fGXM84AS7" />
         <Link Id="Q3Itdatq57SPDRgOHlkYW5" Ids="N4YhZKHYEMlMdcOF0Wjvn0,KTvdaR3kAQ4NKXs3YieIkY" />
         <Link Id="RYOi7Hxgd9ZOS276mLiiZH" Ids="LIt2cgHE3VLNNCG7XTwOJi,TsfavvToTdjOgZpXn4BjBT" />
-        <Link Id="U5CMOQQrBVAPXeI4xa1F0d" Ids="ITEEHK6f5A8LALQOwM5fOe,ECVlzaEfh3nL216yHO2vbZ" />
         <Link Id="PbQ5NmoSUAPNLt7R634nQn" Ids="OrhiFun7LMjMlUx7Qm76yX,IR5VtjjH9pHMZOkXt6JSAi" />
         <Link Id="NupBvWBIGUMMlXF1OxwmXG" Ids="UBNKKtaEU0ALHrm7moEeq4,GxKY4nCXx99MKixjpC0RRf" />
+        <Link Id="NLnvxYXAUT1NPmCcnXAQb1" Ids="Oc0nIF9Zn4yNhuZWJ5Ld7Z,FaAB6ZQOgu5PkBrxmd0b1F" />
+        <Link Id="Uhp44GfPKSPNXvapffofZz" Ids="AnTg91uBAkYN8aZrTU1rnR,FBPlmfyptGuMriK0BkPrJg" />
       </Patch>
     </Node>
   </Patch>


### PR DESCRIPTION
Following [some discussion here](https://github.com/vvvv/VL.StandardLibs/issues/347) with @jhnnslmk, some proposals to change camera behaviour wrt the mousewheel:

*  mousewheel dollies in/out (instead of changing FoV)
    * this is in line with the behaviour of Unity's and Unreal's camera
    * movement should have a priority over changing FoV
    * changing FoV should have a modifier key, therefore ...
* CTRL+mousewheel changes FoV
    * this is also the behaviour of the OrbitCamera
* rightclick/hold + mousewheel changes movement speed
    * same behaviour as in Unity and Unreal and makes sense
    * note: i left the Shift modifier also in and it acts as a multiplier now (i.e. holding Shift while moving multiplies current speed by a factor). this is similar to Unity's behaviour

to me this feels quite alright, as muscle memory from unity/unreal still applies.
opinions? 

one thing still bothers me:
* dollying forward by turning mouse wheel forward feels totally natural
* adding the CTRL key +  mouse wheel changes FoV *in the opposite visual direction* (ie. FoV widens, but it should zoom in). this is however the same as for the OrbitCam. we therefore have the dilemma that, CTRL+mousewheel should be inversed, but then it would not behave like the OrbitCam. i feel tempted to ask if we could therefore change the behaviour of the OrbitCam?

opinions?
