### PR TITLE
Fix: tag SkiaWindow surface with sRGB colorspace

### DIFF
--- a/VL.Core.Skia.Windows/EglSkiaRenderer.cs
+++ b/VL.Core.Skia.Windows/EglSkiaRenderer.cs
@@ -160,6 +160,9 @@ internal sealed class EglSkiaRenderer : ISkiaRenderer
             stencilBits: stencilBits,
             glInfo: glInfo);
 
-        return SKSurface.Create(renderContext.SkiaContext, renderTarget, GRSurfaceOrigin.BottomLeft, colorType);
+        // Window framebuffer is presented directly to the monitor → always sRGB.
+        // Without this tag, Skia treats the surface as unmanaged and sRGB-tagged
+        // images (e.g. from TextureToSkImage) composite with a gamma offset.
+        return SKSurface.Create(renderContext.SkiaContext, renderTarget, GRSurfaceOrigin.BottomLeft, colorType, SKColorSpace.CreateSrgb());
     }
 }


### PR DESCRIPTION
## Problem

`EglSkiaRenderer.CreateSkSurface` creates the backing `SKSurface` without a colorspace argument, which defaults to `null`. With a `null`-colorspace surface, Skia performs no color management on `DrawImage` operations from sRGB-tagged `SKImage`s — instead the bytes are interpreted as linear and an unwanted gamma conversion is applied to the destination, making sRGB-encoded content appear noticeably darker on the window than it does anywhere else.

Concrete reproduction: take a Stride render-target texture (a typical preview/render output, format `R8G8B8A8_UNORM_SRGB`), convert it to an `SKImage` via `Stride.Textures.TextureToSkImage` (which correctly tags the result with `SKColorSpace.CreateSrgb()` in `D3D11Utils.TextureToSKImage`), and `DrawImage` it into a `SkiaRenderer` window. Compare side-by-side with the same texture composited via a Stride `SkiaTexture` (which uses `SKColorSpace.CreateSrgb()` explicitly at `SkiaTexture.cs:172`) — the SkiaWindow version is visibly darker in the midtones.

## Fix

Pass `SKColorSpace.CreateSrgb()` as the 5th argument to `SKSurface.Create`. The window framebuffer is presented directly to the monitor, which is an sRGB display — so the surface's pixels must be interpreted as sRGB-encoded. This matches the existing pattern in `SkiaTexture.cs:171–172` for Stride-side Skia surfaces.

## Notes

- Considered also adding the `SKColorSpace.CreateSrgbLinear()` branch keyed off `renderContext.UseLinearColorspace`, mirroring `SkiaTexture`. Decided against it: a SkiaWindow surface is presented as-is to the monitor and there is no downstream linear → sRGB conversion step, so it must always be sRGB regardless of the surrounding compositing pipeline's color mode.

## Test plan

- [ ] Existing SkiaWindow content renders identically (no regression for pure Avalonia/Skia drawing — Skia's `SKPaint.Color` values are byte-for-byte sRGB).
- [ ] `TextureToSkImage` → `DrawImage` into SkiaWindow now matches midtone brightness of the same texture rendered via Stride's swapchain.

---

_Note: this PR supersedes #719 (which was opened from a branch based on our internal fork; this one is based on `vvvv/main` so the diff is just the 4-line fix)._